### PR TITLE
Improve upgrade cmd output

### DIFF
--- a/cmd/get/get.go
+++ b/cmd/get/get.go
@@ -13,7 +13,7 @@ var (
 
 var GetCmd = &cobra.Command{
 	Use:          "get [type] [name] [flags]",
-	Short:        "Display one or many objects with a table, only the most important information will be displayed.",
+	Short:        "Display one or many objects with a text, only the most important information will be displayed.",
 	Long:         getLong,
 	Run:          runGet,
 	SilenceUsage: true,

--- a/cmd/upgrade/status/detail/detail.go
+++ b/cmd/upgrade/status/detail/detail.go
@@ -30,7 +30,7 @@ var Cmd = &cobra.Command{
 func init() {
 	Cmd.Args = cobra.ExactArgs(1)
 
-	Cmd.Flags().StringVarP(&output, "output", "o", "table", "Output format. One of: table, json")
+	Cmd.Flags().StringVarP(&output, "output", "o", "text", "Output format. One of: text, json")
 }
 
 type Res struct {
@@ -106,7 +106,7 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	switch output {
-	case "table":
+	case "text":
 		printTable(res)
 	case "json":
 		utils.PrintJSON(res)

--- a/cmd/upgrade/status/status.go
+++ b/cmd/upgrade/status/status.go
@@ -34,7 +34,7 @@ func init() {
 
 	Cmd.Args = cobra.MinimumNArgs(1)
 
-	Cmd.Flags().StringVarP(&output, "output", "o", "table", "Output format. One of: table, json")
+	Cmd.Flags().StringVarP(&output, "output", "o", "text", "Output format. One of: text, json")
 }
 
 func getExample() (example string) {
@@ -112,19 +112,20 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	switch output {
-	case "table":
+	case "text":
 		printTable(res)
+
+		println("\nTo get more details, run the following command(s):")
+		for _, r := range res {
+			println(fmt.Sprintf("  omnistrate-ctl upgrade status detail %s", r.UpgradeID))
+		}
+
 	case "json":
 		utils.PrintJSON(res)
 	default:
 		err = fmt.Errorf("invalid output format: %s", output)
 		utils.PrintError(err)
 		return err
-	}
-
-	println("\nTo get more details, run the following command(s):")
-	for _, r := range res {
-		println(fmt.Sprintf("  omnistrate-ctl upgrade status detail %s", r.UpgradeID))
 	}
 
 	return nil


### PR DESCRIPTION
- No extra print if the output option is json
- Name the other output option "text" instead of "table" to keep consistent with AWS CLI https://docs.aws.amazon.com/cli/v1/userguide/cli-usage-output-format.html