### PR TITLE
Read volumes as configs

### DIFF
--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -623,7 +623,6 @@ func convertVolumesToConfigs(project *types.Project) (converted *types.Project, 
 }
 
 func listFiles(dir string) (files []string, err error) {
-	fmt.Printf("Listing files in %s\n", dir)
 	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
 		// Skip the directory itself
 		if path == dir {
@@ -631,7 +630,6 @@ func listFiles(dir string) (files []string, err error) {
 		}
 
 		if !info.IsDir() {
-			fmt.Printf("File: %s\n", path)
 			files = append(files, path)
 		}
 


### PR DESCRIPTION
- Many docker compose files are written with config files mounted as local volumes
- This is a UX improvement where the CLI will seamless convert them into configs without the user having to redefine them as configs in the spec