### PR TITLE
fix ctl

### DIFF
--- a/internal/dataaccess/fleetcustomnetwork.go
+++ b/internal/dataaccess/fleetcustomnetwork.go
@@ -43,7 +43,7 @@ func FleetListCustomNetworks(
 		req = req.CloudProviderRegion(*cloudProviderRegion)
 	}
 
-	req.CustomNetworksOnly(false)
+	req = req.CustomNetworksOnly(false)
 
 	var r *http.Response
 	defer func() {


### PR DESCRIPTION
This pull request includes a small change to the `internal/dataaccess/fleetcustomnetwork.go` file. The change ensures that the `CustomNetworksOnly` method is correctly chained by assigning its return value to `req`.

* [`internal/dataaccess/fleetcustomnetwork.go`](diffhunk://#diff-22ccafae23ecda48b19533652e2b4a05c7454cb09d700b97e567486d01769157L46-R46): Modified the `FleetListCustomNetworks` function to assign the return value of `CustomNetworksOnly` to `req` for proper method chaining.