### PR TITLE
Fix git repo owner name

### DIFF
--- a/cmd/build/build_from_repo.go
+++ b/cmd/build/build_from_repo.go
@@ -280,8 +280,9 @@ func runBuildFromRepo(cmd *cobra.Command, args []string) error {
 	}
 	repoURL := strings.TrimSpace(string(output))
 	repoName := filepath.Base(repoURL)
+	repoOwner := filepath.Base(filepath.Dir(repoURL))
 	repoName = strings.TrimSuffix(repoName, ".git") // Extract repo name
-	spinner.UpdateMessage(fmt.Sprintf("Retrieving repository name: %s", repoName))
+	spinner.UpdateMessage(fmt.Sprintf("Retrieving repository name: %s/%s", repoOwner, repoName))
 	spinner.Complete()
 
 	// Step 7: Retrieve the GitHub username
@@ -310,7 +311,7 @@ func runBuildFromRepo(cmd *cobra.Command, args []string) error {
 		spinner.UpdateMessage("Labeling Docker image with the repository name: Already labeled")
 	} else {
 		// Append the label to the Dockerfile
-		dockerfileData = append(dockerfileData, []byte(fmt.Sprintf("\nLABEL org.opencontainers.image.source=\"https://github.com/%s/%s\"\n", ghUsername, repoName))...)
+		dockerfileData = append(dockerfileData, []byte(fmt.Sprintf("\nLABEL org.opencontainers.image.source=\"https://github.com/%s/%s\"\n", repoOwner, repoName))...)
 
 		// Write the Dockerfile back
 		err = os.WriteFile(filepath.Join(cwd, "Dockerfile"), dockerfileData, 0600)
@@ -319,7 +320,7 @@ func runBuildFromRepo(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		spinner.UpdateMessage(fmt.Sprintf("Labeling Docker image with the repository name: %s", repoName))
+		spinner.UpdateMessage(fmt.Sprintf("Labeling Docker image with the repository name: %s/%s", repoOwner, repoName))
 	}
 
 	spinner.Complete()
@@ -345,7 +346,7 @@ func runBuildFromRepo(cmd *cobra.Command, args []string) error {
 	sm.Start()
 
 	// Step 10: Build docker image
-	imageUrl := fmt.Sprintf("ghcr.io/%s/%s", strings.ToLower(ghUsername), repoName)
+	imageUrl := fmt.Sprintf("ghcr.io/%s/%s", strings.ToLower(repoOwner), repoName)
 
 	spinner = sm.AddSpinner(fmt.Sprintf("Building Docker image: %s", imageUrl))
 	spinner.Complete()


### PR DESCRIPTION
This pull request includes several changes to the `runBuildFromRepo` function in the `cmd/build/build_from_repo.go` file to ensure that the repository owner's name is included in various messages and labels. The most important changes include updating the repository owner and name in spinner messages, Docker image labels, and the Docker image URL.

Updates to include repository owner:

* Updated spinner message to include both repository owner and name when retrieving the repository name. (`cmd/build/build_from_repo.go`, [cmd/build/build_from_repo.goR283-R285](diffhunk://#diff-35e2a1b3609cc3be1a818bd38f21285dd462730af0ff38c7f47ea6f412386745R283-R285))
* Updated Docker image label to include the repository owner in the label source URL. (`cmd/build/build_from_repo.go`, [cmd/build/build_from_repo.goL313-R314](diffhunk://#diff-35e2a1b3609cc3be1a818bd38f21285dd462730af0ff38c7f47ea6f412386745L313-R314))
* Updated spinner message to include both repository owner and name when labeling the Docker image. (`cmd/build/build_from_repo.go`, [cmd/build/build_from_repo.goL322-R323](diffhunk://#diff-35e2a1b3609cc3be1a818bd38f21285dd462730af0ff38c7f47ea6f412386745L322-R323))
* Updated Docker image URL to include the repository owner. (`cmd/build/build_from_repo.go`, [cmd/build/build_from_repo.goL348-R349](diffhunk://#diff-35e2a1b3609cc3be1a818bd38f21285dd462730af0ff38c7f47ea6f412386745L348-R349))