### PR TITLE
Skip pre checks for compose spec without build context

### DIFF
--- a/internal/utils/regex.go
+++ b/internal/utils/regex.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-func ReplaceBuildSection(input string, dockerPathsToImageUrls map[string]string) string {
+func ReplaceBuildContext(input string, dockerPathsToImageUrls map[string]string) string {
 	// Define the pattern to match the build section in the YAML structure.
 	// This pattern captures the indentation of the build section as well.
 	pattern := `(?m)(^\s*)build:\s*\n\s*context:\s*(?P<context>.+)\n\s*dockerfile:\s*(?P<dockerfile>.+)`

--- a/internal/utils/regex_test.go
+++ b/internal/utils/regex_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-func TestReplaceBuildSection(t *testing.T) {
+func TestReplaceBuildContext(t *testing.T) {
 	cwd, _ := os.Getwd()
 
 	// Test cases with different scenarios.
@@ -110,7 +110,7 @@ some random content here without build section
 	// Iterate over each test case
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualOutput := ReplaceBuildSection(tt.input, tt.versionTaggedImageURIs)
+			actualOutput := ReplaceBuildContext(tt.input, tt.versionTaggedImageURIs)
 			if actualOutput != tt.expectedOutput {
 				t.Errorf("expected: %v, but got: %v", tt.expectedOutput, actualOutput)
 			}


### PR DESCRIPTION
This pull request includes significant changes to the `runBuildFromRepo` function in `cmd/build/build_from_repo.go` to streamline the build process and improve code readability. The changes involve reordering the steps, removing redundant checks, and renaming a utility function for clarity.

Reordering and streamlining steps:

* Removed redundant checks for Docker and `gh` CLI installation and moved the check for the Docker daemon to a later step. [[1]](diffhunk://#diff-35e2a1b3609cc3be1a818bd38f21285dd462730af0ff38c7f47ea6f412386745L161-R161) [[2]](diffhunk://#diff-35e2a1b3609cc3be1a818bd38f21285dd462730af0ff38c7f47ea6f412386745L208-R186)
* Moved the validation of the user's login status to the beginning of the process.
* Reordered the steps to retrieve the repository name and check for a compose spec earlier in the process. [[1]](diffhunk://#diff-35e2a1b3609cc3be1a818bd38f21285dd462730af0ff38c7f47ea6f412386745L294-R218) [[2]](diffhunk://#diff-35e2a1b3609cc3be1a818bd38f21285dd462730af0ff38c7f47ea6f412386745R239) [[3]](diffhunk://#diff-35e2a1b3609cc3be1a818bd38f21285dd462730af0ff38c7f47ea6f412386745R273-R274)
* Added a check for the existence of a build context in the compose spec.
* Deferred the check for Docker installation and daemon status until after other preliminary steps.

Renaming and refactoring:

* Renamed the utility function `ReplaceBuildSection` to `ReplaceBuildContext` for better clarity and updated its usage accordingly. [[1]](diffhunk://#diff-1c85b2693cac05e52bd740ba3ec9187d9287c665f936e527794cd84c4ff50aa6L10-R10) [[2]](diffhunk://#diff-951c2a5e4b67709a677ce4eba61d341a38263e441129bccaa36e4c10580cfff7L9-R9) [[3]](diffhunk://#diff-951c2a5e4b67709a677ce4eba61d341a38263e441129bccaa36e4c10580cfff7L113-R113)

Enhancements to user prompts and error handling:

* Improved the user prompt and error handling for missing GitHub Personal Access Tokens (PATs). [[1]](diffhunk://#diff-35e2a1b3609cc3be1a818bd38f21285dd462730af0ff38c7f47ea6f412386745L208-R186) [[2]](diffhunk://#diff-35e2a1b3609cc3be1a818bd38f21285dd462730af0ff38c7f47ea6f412386745L384-R403)
* Ensured the process stops and provides clear instructions if a required PAT is not found.

These changes aim to make the build process more efficient and user-friendly by reducing unnecessary checks and improving the flow of steps.

Test result:

Build compose spec without build context:
<img width="1063" alt="image" src="https://github.com/user-attachments/assets/87ca4f4f-891b-467a-b157-003f6290ad52">

Build compose spec with build context:
<img width="1063" alt="image" src="https://github.com/user-attachments/assets/ed4bef95-4127-4473-b264-ed8d7fddbb5e">

Build from repo without compose spec:
<img width="1063" alt="image" src="https://github.com/user-attachments/assets/5646c99d-af0a-4399-a549-41c040b85448">

