### PR TITLE
Support repo cloned with SSH clone for build-from-repo cmd

### DIFF
--- a/cmd/build/build_from_repo.go
+++ b/cmd/build/build_from_repo.go
@@ -70,7 +70,6 @@ func init() {
 
 func runBuildFromRepo(cmd *cobra.Command, args []string) error {
 	defer config.CleanupArgsAndFlags(cmd, &args)
-
 	// Retrieve the flags
 	envVars, err := cmd.Flags().GetStringArray("env-var")
 	if err != nil {
@@ -204,7 +203,7 @@ func runBuildFromRepo(cmd *cobra.Command, args []string) error {
 	// Step 2: Retrieve the repository name
 	spinner = sm.AddSpinner("Retrieving repository name")
 	time.Sleep(1 * time.Second) // Add a delay to show the spinner
-	output, err := exec.Command("git", "config", "--get", "remote.origin.url").Output()
+	output, err := exec.Command("sh", "-c", `git config --get remote.origin.url | sed -E 's/:([^\/])/\/\1/g' | sed -e 's/ssh\/\/\///g' | sed -e 's/git@/https:\/\//g'`).Output()
 	if err != nil {
 		utils.HandleSpinnerError(spinner, sm, err)
 		return err


### PR DESCRIPTION
This pull request includes changes to the `cmd/build/build_from_repo.go` file to improve the retrieval of the repository URL and clean up the code.

Code improvements:

* [`cmd/build/build_from_repo.go`](diffhunk://#diff-35e2a1b3609cc3be1a818bd38f21285dd462730af0ff38c7f47ea6f412386745L207-R206): Modified the command to retrieve the repository URL to use a more robust shell command that converts the SSH URL to an HTTPS URL.

Code cleanup:

* [`cmd/build/build_from_repo.go`](diffhunk://#diff-35e2a1b3609cc3be1a818bd38f21285dd462730af0ff38c7f47ea6f412386745L73): Removed an unnecessary blank line in the `runBuildFromRepo` function.