### PR TITLE
Apply release/releaseAsPreferred/releaseName args for service plan spec in build cmd

### DIFF
--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -577,13 +577,16 @@ func buildService(ctx context.Context, fileData []byte, token, name, specType st
 	switch specType {
 	case ServicePlanSpecType:
 		request := serviceapi.BuildServiceFromServicePlanSpecRequest{
-			Token:           token,
-			Name:            name,
-			Description:     description,
-			ServiceLogoURL:  serviceLogoURL,
-			Environment:     environment,
-			EnvironmentType: (*serviceapi.EnvironmentType)(environmentType),
-			FileContent:     base64.StdEncoding.EncodeToString(fileData),
+			Token:              token,
+			Name:               name,
+			Description:        description,
+			ServiceLogoURL:     serviceLogoURL,
+			Environment:        environment,
+			EnvironmentType:    (*serviceapi.EnvironmentType)(environmentType),
+			FileContent:        base64.StdEncoding.EncodeToString(fileData),
+			Release:            utils.ToPtr(release),
+			ReleaseAsPreferred: utils.ToPtr(releaseAsPreferred),
+			ReleaseVersionName: releaseName,
 		}
 
 		var buildRes *serviceapi.BuildServiceFromServicePlanSpecResult

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.33
-	github.com/omnistrate/api-design v0.7.152
-	github.com/omnistrate/api-design/pkg/httpclientwrapper v0.0.0-20250116042147-302937b36cd0
+	github.com/omnistrate/api-design v0.7.153
+	github.com/omnistrate/api-design/pkg/httpclientwrapper v0.0.0-20250116233445-a5074b602f2e
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,12 @@ github.com/omnistrate-oss/omnistrate-sdk-go v0.0.33 h1:tKI+LZ8v9q01z4tqG1IvP3trG
 github.com/omnistrate-oss/omnistrate-sdk-go v0.0.33/go.mod h1:tDZC+n915VJTaSepBd2tGV7mBepAlBrE5kdxsSveh5E=
 github.com/omnistrate/api-design v0.7.152 h1:r9vO9fazhvaFd4tLnCftHJ8Gv+DFpbIAV2fxh+El4Ic=
 github.com/omnistrate/api-design v0.7.152/go.mod h1:QJaVyPRU2pSL6CCHmg8BKsxlUu+VkoxAbAMq6g270ik=
+github.com/omnistrate/api-design v0.7.153 h1:+7V9yHCxY7HskPtHZtOU3f7Ru/sndHff/bstpuK5KZ8=
+github.com/omnistrate/api-design v0.7.153/go.mod h1:QJaVyPRU2pSL6CCHmg8BKsxlUu+VkoxAbAMq6g270ik=
 github.com/omnistrate/api-design/pkg/httpclientwrapper v0.0.0-20250116042147-302937b36cd0 h1:iWa0PsQNvoTRLx+upc5Mm2OwZV9pcAA+pIoCugPmnvc=
 github.com/omnistrate/api-design/pkg/httpclientwrapper v0.0.0-20250116042147-302937b36cd0/go.mod h1:xEjXHuSwyK79a4kRRC1DjZuykubPi6vfq+65NdxXyZY=
+github.com/omnistrate/api-design/pkg/httpclientwrapper v0.0.0-20250116233445-a5074b602f2e h1:OvgmLv57c+O1hPnO3yW1K+OKdiusr4334J2/uoJbNlo=
+github.com/omnistrate/api-design/pkg/httpclientwrapper v0.0.0-20250116233445-a5074b602f2e/go.mod h1:xEjXHuSwyK79a4kRRC1DjZuykubPi6vfq+65NdxXyZY=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=


### PR DESCRIPTION
This pull request includes several changes to the `cmd/build/build.go` file and updates to dependencies in the `go.mod` file. The most important changes are summarized below:

Enhancements to build service:

* [`cmd/build/build.go`](diffhunk://#diff-0d2f61dadb3ebe76a6fecb5dbe9af9a6aaf20b129bcea45a683af82e4be4b163R587-R589): Added new fields `Release`, `ReleaseAsPreferred`, and `ReleaseVersionName` to the `serviceapi.EnvironmentType` structure to include additional release information.

Dependency updates:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L18-R19): Updated the `github.com/omnistrate/api-design` dependency from version `v0.7.152` to `v0.7.153` and updated the `github.com/omnistrate/api-design/pkg/httpclientwrapper` dependency to a new commit version.