### PR TITLE
Fix flaky account test

### DIFF
--- a/test/smoke_test/account/account_test.go
+++ b/test/smoke_test/account/account_test.go
@@ -33,6 +33,7 @@ func Test_account_basic(t *testing.T) {
 	awsAccountName := "aws" + uuid.NewString()
 	gcpAccountName := "gcp" + uuid.NewString()
 	azureAccountName := "azure" + uuid.NewString()
+	// nolint:gosec
 	rand10DigitsNum := rand.New(rand.NewSource(time.Now().UnixNano())).Int63n(9000000000) + 1000000000
 
 	// PASS: create aws account


### PR DESCRIPTION
This pull request updates the `account_test.go` file to introduce randomized values for account IDs and project IDs in the smoke tests, improving test robustness and reducing the likelihood of hardcoded conflicts.

### Enhancements to test robustness:

* Added imports for `math/rand` and `time` to support generating random numbers for test data. (`test/smoke_test/account/account_test.go`)
* Introduced a new variable, `rand10DigitNum`, to generate a random 10-digit number seeded with the current timestamp. This value is used to dynamically create unique account IDs and project IDs in the test cases. (`test/smoke_test/account/account_test.go`)
* Updated the `cmd.RootCmd.SetArgs` calls for AWS, GCP, and Azure account creation commands to use `fmt.Sprintf` with `rand10DigitNum`, ensuring unique and randomized identifiers for each test run. (`test/smoke_test/account/account_test.go`)