### PR TITLE
Fix compose render issue upon deploy cpus

### DIFF
--- a/cmd/build/build_from_repo.go
+++ b/cmd/build/build_from_repo.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -1327,6 +1328,11 @@ func RenderEnvFileAndInterpolateVariables(fileData []byte, rootDir string, file 
 
 	// Docker compose config command escapes the $ character by adding a $ in front of it, so we need to unescape it
 	newFileData = []byte(strings.ReplaceAll(string(newFileData), "$$", "$"))
+
+	// Quote numeric cpus values in deploy.resources
+	// Match: cpus: <number> where the number is NOT quoted
+	re := regexp.MustCompile(`(?m)(^\s*cpus:\s*)([0-9.]+)\s*$`)
+	newFileData = []byte(re.ReplaceAllString(string(newFileData), `$1"$2"`))
 
 	return
 }


### PR DESCRIPTION
This pull request introduces a small but important enhancement to the `RenderEnvFileAndInterpolateVariables` function in `cmd/build/build_from_repo.go`. It ensures that numeric CPU values in `deploy.resources` are properly quoted, addressing a potential issue with configuration parsing.

### Key Changes:

**Bug Fix and Enhancement:**
* [`cmd/build/build_from_repo.go`](diffhunk://#diff-35e2a1b3609cc3be1a818bd38f21285dd462730af0ff38c7f47ea6f412386745R1332-R1336): Added logic to quote numeric `cpus` values in `deploy.resources` by using a regular expression to match and replace unquoted values. This ensures compatibility with systems expecting quoted CPU values.

**Dependency Update:**
* [`cmd/build/build_from_repo.go`](diffhunk://#diff-35e2a1b3609cc3be1a818bd38f21285dd462730af0ff38c7f47ea6f412386745R11): Added the `regexp` package to the imports to support the new regular expression logic.