### PR TITLE
Add support for an instance list-endpoints command

### DIFF
--- a/cmd/instance/instance.go
+++ b/cmd/instance/instance.go
@@ -17,6 +17,7 @@ func init() {
 	Cmd.AddCommand(describeCmd)
 	Cmd.AddCommand(deleteCmd)
 	Cmd.AddCommand(listCmd)
+	Cmd.AddCommand(listEndpointsCmd)
 	Cmd.AddCommand(startCmd)
 	Cmd.AddCommand(stopCmd)
 	Cmd.AddCommand(restartCmd)

--- a/cmd/instance/list_endpoints.go
+++ b/cmd/instance/list_endpoints.go
@@ -1,0 +1,294 @@
+package instance
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/chelnak/ysmrr"
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
+	"github.com/spf13/cobra"
+)
+
+const (
+	listEndpointsExample = `# List endpoints for a specific instance
+omctl instance list-endpoints instance-abcd1234`
+)
+
+// ResourceEndpoints represents the endpoints for a resource
+type ResourceEndpoints struct {
+	ClusterEndpoint     string         `json:"cluster_endpoint"`
+	AdditionalEndpoints map[string]any `json:"additional_endpoints"`
+}
+
+// EndpointTableRow represents a single row in the table output
+type EndpointTableRow struct {
+	ResourceName string `json:"resource_name"`
+	EndpointType string `json:"endpoint_type"`
+	EndpointName string `json:"endpoint_name"`
+	URL          string `json:"url"`
+	Status       string `json:"status,omitempty"`
+	NetworkType  string `json:"network_type,omitempty"`
+	Ports        string `json:"ports,omitempty"`
+}
+
+var listEndpointsCmd = &cobra.Command{
+	Use:          "list-endpoints [instance-id]",
+	Short:        "List endpoints for a specific instance",
+	Long:         `This command lists all additional endpoints and cluster endpoint for a specific instance by instance ID.`,
+	Example:      listEndpointsExample,
+	RunE:         runListEndpoints,
+	SilenceUsage: true,
+}
+
+func init() {
+	listEndpointsCmd.Args = cobra.ExactArgs(1) // Require exactly one argument (instance ID)
+}
+
+func runListEndpoints(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	// Retrieve args
+	instanceID := args[0]
+
+	// Retrieve flags
+	output, err := cmd.Flags().GetString("output")
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	// Validate user is currently logged in
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	// Initialize spinner if output is not JSON
+	var sm ysmrr.SpinnerManager
+	var spinner *ysmrr.Spinner
+	if output != common.OutputTypeJson {
+		sm = ysmrr.NewSpinnerManager()
+		spinner = sm.AddSpinner("Fetching endpoint information...")
+		sm.Start()
+	}
+
+	// Check if instance exists and get details
+	serviceID, environmentID, _, err := getInstanceWithResourceName(cmd.Context(), token, instanceID)
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+
+	// Get detailed instance information
+	detailedInstance, err := dataaccess.DescribeResourceInstance(cmd.Context(), token, serviceID, environmentID, instanceID)
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+
+	// Extract endpoint information
+	resourceEndpoints := extractEndpoints(detailedInstance)
+
+	if len(resourceEndpoints) == 0 {
+		utils.HandleSpinnerSuccess(spinner, sm, "No endpoint information found for this instance.")
+		// Print empty result for consistency
+		if output == common.OutputTypeJson {
+			err = utils.PrintTextTableJsonOutput(output, resourceEndpoints)
+		} else {
+			err = utils.PrintTextTableJsonArrayOutput(output, []EndpointTableRow{})
+		}
+		if err != nil {
+			utils.PrintError(err)
+			return err
+		}
+		return nil
+	}
+
+	utils.HandleSpinnerSuccess(spinner, sm, "Successfully retrieved endpoint information")
+
+	// Print output
+	if output == common.OutputTypeJson {
+		err = utils.PrintTextTableJsonOutput(output, resourceEndpoints)
+	} else {
+		// Convert to table format for better readability
+		tableRows := convertToTableRows(resourceEndpoints)
+		err = utils.PrintTextTableJsonArrayOutput(output, tableRows)
+	}
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	return nil
+}
+
+// getInstanceWithResourceName gets instance details including resource name
+func getInstanceWithResourceName(ctx context.Context, token, instanceID string) (serviceID, environmentID, productTierID string, err error) {
+	searchRes, err := dataaccess.SearchInventory(ctx, token, fmt.Sprintf("resourceinstance:%s", instanceID))
+	if err != nil {
+		return
+	}
+
+	var found bool
+	for _, instance := range searchRes.ResourceInstanceResults {
+		if instance.Id == instanceID {
+			serviceID = instance.ServiceId
+			environmentID = instance.ServiceEnvironmentId
+			productTierID = instance.ProductTierId
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		err = fmt.Errorf("%s not found. Please check the instance ID and try again", instanceID)
+		return
+	}
+
+	return
+}
+
+// extractEndpoints extracts endpoint information from the instance
+func extractEndpoints(instance *openapiclientfleet.ResourceInstance) (resourceEndpoints map[string]ResourceEndpoints) {
+	resourceEndpoints = make(map[string]ResourceEndpoints)
+
+	if len(instance.ConsumptionResourceInstanceResult.DetailedNetworkTopology) == 0 {
+		return nil
+	}
+
+	for _, resourceIntfc := range instance.ConsumptionResourceInstanceResult.DetailedNetworkTopology {
+		resource, exists := resourceIntfc.(map[string]interface{})
+		if !exists {
+			continue // Skip if not a map
+		}
+
+		var data interface{}
+		if data, exists = resource["resourceName"]; !exists {
+			// If resourceName doesn't exist, skip this resource
+			continue
+		}
+
+		var resourceName string
+		if resourceName, exists = data.(string); !exists {
+			// If resourceName is not a string, skip this resource
+			continue
+		}
+
+		// Check for cluster endpoint
+		var endpoints ResourceEndpoints
+		if data, exists = resource["clusterEndpoint"]; exists {
+			if endpoints.ClusterEndpoint, exists = data.(string); !exists {
+				endpoints.ClusterEndpoint = "" // Default to empty string if not found
+			}
+		}
+
+		// Check for additional endpoints
+		if data, exists = resource["additionalEndpoints"]; exists {
+			if endpoints.AdditionalEndpoints, exists = data.(map[string]interface{}); !exists {
+				endpoints.AdditionalEndpoints = nil // Default to nil if not found
+			}
+		}
+
+		if endpoints.ClusterEndpoint == "" && len(endpoints.AdditionalEndpoints) == 0 {
+			// If both clusterEndpoint and additionalEndpoints are empty, skip this resource
+			continue
+		}
+
+		// Add to the map with resourceName as key
+		resourceEndpoints[resourceName] = endpoints
+	}
+
+	return
+}
+
+// convertToTableRows converts the nested endpoint structure to a flat table format
+func convertToTableRows(resourceEndpoints map[string]ResourceEndpoints) []EndpointTableRow {
+	var rows []EndpointTableRow
+
+	for resourceName, endpoints := range resourceEndpoints {
+		// Add cluster endpoint if present
+		if endpoints.ClusterEndpoint != "" {
+			rows = append(rows, EndpointTableRow{
+				ResourceName: resourceName,
+				EndpointType: "cluster",
+				EndpointName: "cluster_endpoint",
+				URL:          endpoints.ClusterEndpoint,
+			})
+		}
+
+		// Add additional endpoints if present
+		for endpointName, endpointData := range endpoints.AdditionalEndpoints {
+			// Handle different endpoint data structures
+			if endpointMap, ok := endpointData.(map[string]interface{}); ok {
+				url := ""
+				status := ""
+				networkType := ""
+				ports := ""
+
+				// Extract URL/endpoint
+				if endpointVal, exists := endpointMap["endpoint"]; exists {
+					if endpointStr, ok := endpointVal.(string); ok {
+						url = endpointStr
+					}
+				}
+
+				// Extract health status
+				if statusVal, exists := endpointMap["healthStatus"]; exists {
+					if statusStr, ok := statusVal.(string); ok {
+						status = statusStr
+					}
+				}
+
+				// Extract network type
+				if networkVal, exists := endpointMap["networkingType"]; exists {
+					if networkStr, ok := networkVal.(string); ok {
+						networkType = networkStr
+					}
+				}
+
+				// Extract ports
+				if portsVal, exists := endpointMap["openPorts"]; exists {
+					if portsSlice, ok := portsVal.([]interface{}); ok {
+						var portStrs []string
+						for _, port := range portsSlice {
+							if portNum, ok := port.(float64); ok {
+								portStrs = append(portStrs, fmt.Sprintf("%.0f", portNum))
+							} else if portStr, ok := port.(string); ok {
+								portStrs = append(portStrs, portStr)
+							}
+						}
+						ports = strings.Join(portStrs, ",")
+					}
+				}
+
+				rows = append(rows, EndpointTableRow{
+					ResourceName: resourceName,
+					EndpointType: "additional",
+					EndpointName: endpointName,
+					URL:          url,
+					Status:       status,
+					NetworkType:  networkType,
+					Ports:        ports,
+				})
+			} else {
+				// Handle simple string endpoints
+				if endpointStr, ok := endpointData.(string); ok {
+					rows = append(rows, EndpointTableRow{
+						ResourceName: resourceName,
+						EndpointType: "additional",
+						EndpointName: endpointName,
+						URL:          endpointStr,
+					})
+				}
+			}
+		}
+	}
+
+	return rows
+}

--- a/cmd/instance/list_endpoints_test.go
+++ b/cmd/instance/list_endpoints_test.go
@@ -1,0 +1,170 @@
+package instance
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
+)
+
+func TestListEndpointsCommand(t *testing.T) {
+	// Test that the command is properly registered
+	assert.NotNil(t, listEndpointsCmd)
+	assert.Equal(t, "list-endpoints [instance-id]", listEndpointsCmd.Use)
+	assert.Contains(t, listEndpointsCmd.Short, "endpoints")
+	assert.Contains(t, listEndpointsCmd.Short, "specific instance")
+}
+
+func TestResourceEndpointsStructure(t *testing.T) {
+	// Test the ResourceEndpoints structure
+	endpoints := ResourceEndpoints{
+		ClusterEndpoint:     "test-cluster-endpoint",
+		AdditionalEndpoints: map[string]interface{}{"test": "endpoint"},
+	}
+	
+	assert.Equal(t, "test-cluster-endpoint", endpoints.ClusterEndpoint)
+	assert.NotNil(t, endpoints.AdditionalEndpoints)
+}
+
+func TestExtractEndpoints(t *testing.T) {
+	// Test endpoint extraction with various scenarios
+	
+	// Test case 1: Instance with DetailedNetworkTopology containing endpoints
+	instance1 := &openapiclientfleet.ResourceInstance{
+		ConsumptionResourceInstanceResult: openapiclientfleet.DescribeResourceInstanceResult{
+			DetailedNetworkTopology: map[string]interface{}{
+				"test-resource": map[string]interface{}{
+					"resourceName": "test-resource",
+					"clusterEndpoint": "https://cluster.example.com",
+					"additionalEndpoints": map[string]interface{}{
+						"admin": "https://admin.example.com",
+						"api":   "https://api.example.com",
+					},
+				},
+			},
+		},
+	}
+	
+	endpoints1 := extractEndpoints(instance1)
+	assert.NotNil(t, endpoints1)
+	assert.Greater(t, len(endpoints1), 0)
+	
+	// Check the test-resource endpoints
+	testResource, exists := endpoints1["test-resource"]
+	assert.True(t, exists)
+	assert.Equal(t, "https://cluster.example.com", testResource.ClusterEndpoint)
+	assert.NotNil(t, testResource.AdditionalEndpoints)
+	
+	// Test case 2: Instance with no endpoint information
+	instance2 := &openapiclientfleet.ResourceInstance{
+		ConsumptionResourceInstanceResult: openapiclientfleet.DescribeResourceInstanceResult{
+			DetailedNetworkTopology: map[string]interface{}{},
+		},
+	}
+	
+	endpoints2 := extractEndpoints(instance2)
+	assert.Nil(t, endpoints2)
+	
+	// Test case 3: Instance with only additional endpoints
+	instance3 := &openapiclientfleet.ResourceInstance{
+		ConsumptionResourceInstanceResult: openapiclientfleet.DescribeResourceInstanceResult{
+			DetailedNetworkTopology: map[string]interface{}{
+				"api-resource": map[string]interface{}{
+					"resourceName": "api-resource",
+					"additionalEndpoints": map[string]interface{}{
+						"api": "https://api.example.com",
+						"health": "https://health.example.com",
+					},
+				},
+			},
+		},
+	}
+	
+	endpoints3 := extractEndpoints(instance3)
+	assert.NotNil(t, endpoints3)
+	assert.Greater(t, len(endpoints3), 0)
+	
+	// Check the api-resource endpoints
+	apiResource, exists := endpoints3["api-resource"]
+	assert.True(t, exists)
+	assert.Equal(t, "", apiResource.ClusterEndpoint) // Should be empty
+	assert.NotNil(t, apiResource.AdditionalEndpoints)
+	assert.Equal(t, 2, len(apiResource.AdditionalEndpoints))
+}
+
+func TestGetInstanceWithResourceName(t *testing.T) {
+	// This test would normally require mocking the dataaccess.SearchInventory function
+	// For now, we'll just test that the function signature is correct
+	
+	// Test that the function has the correct signature
+	ctx := context.Background()
+	token := "test-token"
+	instanceID := "test-instance-id"
+	
+	// This would fail with a real API call, but validates the function signature
+	_, _, _, err := getInstanceWithResourceName(ctx, token, instanceID)
+	assert.Error(t, err) // Should error since this is not a real token/instance
+}
+
+func TestConvertToTableRows(t *testing.T) {
+	// Test converting ResourceEndpoints to table rows
+	resourceEndpoints := map[string]ResourceEndpoints{
+		"test-resource": {
+			ClusterEndpoint: "https://cluster.example.com",
+			AdditionalEndpoints: map[string]any{
+				"App": map[string]interface{}{
+					"endpoint":        "https://app.example.com",
+					"healthStatus":    "HEALTHY",
+					"networkingType":  "PUBLIC",
+					"openPorts":       []interface{}{443.0, 80.0},
+					"primary":         true,
+				},
+				"API": "https://api.example.com",
+			},
+		},
+	}
+
+	rows := convertToTableRows(resourceEndpoints)
+
+	// Should have 3 rows: 1 cluster + 2 additional endpoints
+	assert.Len(t, rows, 3)
+
+	// Check cluster endpoint row
+	clusterRow := rows[0]
+	assert.Equal(t, "test-resource", clusterRow.ResourceName)
+	assert.Equal(t, "cluster", clusterRow.EndpointType)
+	assert.Equal(t, "cluster_endpoint", clusterRow.EndpointName)
+	assert.Equal(t, "https://cluster.example.com", clusterRow.URL)
+
+	// Check App endpoint row (complex structure)
+	var appRow *EndpointTableRow
+	for i := range rows {
+		if rows[i].EndpointName == "App" {
+			appRow = &rows[i]
+			break
+		}
+	}
+	assert.NotNil(t, appRow)
+	assert.Equal(t, "test-resource", appRow.ResourceName)
+	assert.Equal(t, "additional", appRow.EndpointType)
+	assert.Equal(t, "App", appRow.EndpointName)
+	assert.Equal(t, "https://app.example.com", appRow.URL)
+	assert.Equal(t, "HEALTHY", appRow.Status)
+	assert.Equal(t, "PUBLIC", appRow.NetworkType)
+	assert.Equal(t, "443,80", appRow.Ports)
+
+	// Check API endpoint row (simple string)
+	var apiRow *EndpointTableRow
+	for i := range rows {
+		if rows[i].EndpointName == "API" {
+			apiRow = &rows[i]
+			break
+		}
+	}
+	assert.NotNil(t, apiRow)
+	assert.Equal(t, "test-resource", apiRow.ResourceName)
+	assert.Equal(t, "additional", apiRow.EndpointType)
+	assert.Equal(t, "API", apiRow.EndpointName)
+	assert.Equal(t, "https://api.example.com", apiRow.URL)
+}

--- a/mkdocs/docs/omnistrate-ctl_instance.md
+++ b/mkdocs/docs/omnistrate-ctl_instance.md
@@ -36,6 +36,7 @@ omnistrate-ctl instance [operation] [flags]
 * [omnistrate-ctl instance enable-debug-mode](omnistrate-ctl_instance_enable-debug-mode.md)	 - Enable debug mode for an instance deployment
 * [omnistrate-ctl instance get-deployment](omnistrate-ctl_instance_get-deployment.md)	 - Get the deployment entity metadata of the instance
 * [omnistrate-ctl instance list](omnistrate-ctl_instance_list.md)	 - List instance deployments for your service
+* [omnistrate-ctl instance list-endpoints](omnistrate-ctl_instance_list-endpoints.md)	 - List endpoints for a specific instance
 * [omnistrate-ctl instance list-snapshots](omnistrate-ctl_instance_list-snapshots.md)	 - List all snapshots for an instance
 * [omnistrate-ctl instance modify](omnistrate-ctl_instance_modify.md)	 - Modify an instance deployment for your service
 * [omnistrate-ctl instance patch-deployment](omnistrate-ctl_instance_patch-deployment.md)	 - Patch deployment for an instance deployment

--- a/mkdocs/docs/omnistrate-ctl_instance_list-endpoints.md
+++ b/mkdocs/docs/omnistrate-ctl_instance_list-endpoints.md
@@ -1,0 +1,36 @@
+## omnistrate-ctl instance list-endpoints
+
+List endpoints for a specific instance
+
+### Synopsis
+
+This command lists all additional endpoints and cluster endpoint for a specific instance by instance ID.
+
+```
+omnistrate-ctl instance list-endpoints [instance-id] [flags]
+```
+
+### Examples
+
+```
+# List endpoints for a specific instance
+omctl instance list-endpoints instance-abcd1234
+```
+
+### Options
+
+```
+  -h, --help   help for list-endpoints
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl instance](omnistrate-ctl_instance.md)	 - Manage Instance Deployments for your service
+

--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -116,7 +116,7 @@ plugins:
   - include_dir_to_nav
   - search:
       separator: '[\s\-,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
-      lang: 
+      lang:
         - en
   - minify:
       minify_html: true


### PR DESCRIPTION
```bash
➜ omctl instance list-endpoints instance-abcdefgh
✓ Successfully retrieved endpoint information
+---------------+---------------+--------------+-------+-----------------+---------+-------------------------------------------------------------------------------+
| ENDPOINT_NAME | ENDPOINT_TYPE | NETWORK_TYPE | PORTS | RESOURCE_NAME   | STATUS  | URL                                                                           |
+---------------+---------------+--------------+-------+-----------------+---------+-------------------------------------------------------------------------------+
| App           | additional    | PUBLIC       | 443   | examplepp-chart | HEALTHY | r-abcdefgh.instance-abcdefgh.hc-abcdefgh.us-west-2.aws.f2e0a955bb84.cloud     |
+---------------+---------------+--------------+-------+-----------------+---------+-------------------------------------------------------------------------------+

➜ omctl instance list-endpoints instance-abcdefgh -o json
{
    "datarobot-chart": {
        "cluster_endpoint": "",
        "additional_endpoints": {
            "App": {
                "endpoint": "r-abcdefgh.instance-abcdefgh.hc-abcdefgh.us-west-2.aws.f2e0a955bb84.cloud",
                "healthStatus": "HEALTHY",
                "networkingType": "PUBLIC",
                "openPorts": [
                    443
                ],
                "primary": true
            }
        }
    }
}
```