### PR TITLE
print preview before applying

### DIFF
--- a/cmd/deploymentcell/apply_pending_changes.go
+++ b/cmd/deploymentcell/apply_pending_changes.go
@@ -124,7 +124,7 @@ func runApplyPendingChanges(cmd *cobra.Command, args []string) error {
 			}
 
 			// Display properties if available
-			if amenity.Properties != nil && len(amenity.Properties) > 0 {
+			if amenity.Properties != nil {
 				fmt.Printf("     Properties:\n")
 				for key, value := range amenity.Properties {
 					fmt.Printf("       %s: %v\n", key, value)

--- a/cmd/deploymentcell/apply_pending_changes.go
+++ b/cmd/deploymentcell/apply_pending_changes.go
@@ -85,17 +85,53 @@ func runApplyPendingChanges(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Total pending changes: %d amenities\n\n", len(pendingChanges))
 
 	// Display pending changes in a readable format
-	fmt.Printf("Pending Amenities:\n")
-	for i, amenity := range pendingChanges {
-		fmt.Printf("  %d. Name: %s\n", i+1, amenity.GetName())
-		if amenity.GetDescription() != "" {
-			fmt.Printf("     Description: %s\n", amenity.GetDescription())
+	// Separate amenities into managed and custom categories
+	var managedAmenities []openapiclientfleet.Amenity
+	var customAmenities []openapiclientfleet.Amenity
+
+	for _, amenity := range pendingChanges {
+		if amenity.GetIsManaged() {
+			managedAmenities = append(managedAmenities, amenity)
+		} else {
+			customAmenities = append(customAmenities, amenity)
 		}
-		if amenity.GetType() != "" {
-			fmt.Printf("     Type: %s\n", amenity.GetType())
+	}
+
+	// Display managed amenities section
+	if len(managedAmenities) > 0 {
+		fmt.Printf("Managed Amenities (%d):\n", len(managedAmenities))
+		for i, amenity := range managedAmenities {
+			fmt.Printf("  %d. Name: %s\n", i+1, amenity.GetName())
+			if amenity.GetDescription() != "" {
+				fmt.Printf("     Description: %s\n", amenity.GetDescription())
+			}
+			if amenity.GetType() != "" {
+				fmt.Printf("     Type: %s\n", amenity.GetType())
+			}
 		}
-		fmt.Printf("     Managed: %t\n", amenity.GetIsManaged())
-		fmt.Println()
+	}
+
+	// Display custom amenities section
+	if len(customAmenities) > 0 {
+		fmt.Printf("Custom Amenities (%d):\n", len(customAmenities))
+		for i, amenity := range customAmenities {
+			fmt.Printf("  %d. Name: %s\n", i+1, amenity.GetName())
+			if amenity.GetDescription() != "" {
+				fmt.Printf("     Description: %s\n", amenity.GetDescription())
+			}
+			if amenity.GetType() != "" {
+				fmt.Printf("     Type: %s\n", amenity.GetType())
+			}
+
+			// Display properties if available
+			if amenity.Properties != nil && len(amenity.Properties) > 0 {
+				fmt.Printf("     Properties:\n")
+				for key, value := range amenity.Properties {
+					fmt.Printf("       %s: %v\n", key, value)
+				}
+			}
+			fmt.Println()
+		}
 	}
 
 	// Confirm if not forced or if there are significant changes

--- a/cmd/deploymentcell/apply_pending_changes.go
+++ b/cmd/deploymentcell/apply_pending_changes.go
@@ -75,13 +75,13 @@ func runApplyPendingChanges(cmd *cobra.Command, args []string) error {
 	// Display pending changes
 	fmt.Printf("Pending Changes for Deployment Cell: %s\n", deploymentCellID)
 
-	pendingChanges := hc.GetPendingAmenities()
-	if len(pendingChanges) == 0 {
+	if !utils.FromPtr(hc.HasPendingChanges) {
 		utils.PrintSuccess("No pending changes found.")
 		utils.PrintInfo("Deployment cell is already up to date")
 		return nil
 	}
 
+	pendingChanges := hc.GetPendingAmenities()
 	fmt.Printf("Total pending changes: %d amenities\n\n", len(pendingChanges))
 
 	// Display pending changes in a readable format


### PR DESCRIPTION
```
yuhuiyuan@Yuhuis-MacBook-Pro dist % ./omnistrate-ctl-darwin-arm64 deployment-cell apply-pending-changes --id hc-zu04sn2qq
Pending Changes for Deployment Cell: hc-zu04sn2qq
Total pending changes: 11 amenities

Managed Amenities (10):
  1. Name: EBS CSI Driver
     Description: EBS CSI Driver
     Type: Helm
  2. Name: EFS CSI Driver
     Description: EFS CSI Driver
     Type: Helm
  3. Name: AWS Load Balancer Controller
     Description: AWS Load Balancer Controller
     Type: Helm
  4. Name: Cluster Autoscaler
     Description: Cluster Autoscaler
     Type: Helm
  5. Name: Observability Prometheus
     Description: Observability Prometheus
     Type: Helm
  6. Name: Kubernetes Dashboard
     Description: Kubernetes Dashboard
     Type: Helm
  7. Name: External DNS
     Description: External DNS
     Type: Helm
  8. Name: Cert Manager
     Description: Cert Manager
     Type: Helm
  9. Name: Nginx Ingress Controller
     Description: Nginx Ingress Controller
     Type: Helm
  10. Name: Cost Insight Prometheus
     Description: Cost Insight Prometheus
     Type: Helm
Custom Amenities (1):
  1. Name: Redis
     Description: Redis in-memory data store
     Type: Helm
     Properties:
       ChartRepoName: bitnami
       ChartRepoURL: https://charts.bitnami.com/bitnami
       ChartValues: map[architecture:standalone auth:map[enabled:true password:myredispassword] master:map[tolerations:[map[effect:NoSchedule key:CriticalAddonsOnly operator:Equal value:true]]]]
       ChartVersion: 18.19.4
       CredentialsProvider: map[Type:none]
       DefaultNamespace: redis-system
       ChartName: redis

You are about to apply the above pending changes to deployment cell hc-zu04sn2qq
This will modify the live configuration of the deployment cell.
? Do you want to proceed with applying these changes? ›
❯ Yes
  No
  ```