### PR TITLE
add deployment cell sidebar

### DIFF
--- a/mkdocs/mkdocs.yml
+++ b/mkdocs/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
       - login: "omnistrate-ctl_login.md"
       - logout: "omnistrate-ctl_logout.md"
       - account: "omnistrate-ctl_account.md"
+      - deployment-cell: "omnistrate-ctl_deployment-cell.md"
       - build: "omnistrate-ctl_build.md"
       - build-from-repo: "omnistrate-ctl_build-from-repo.md"
       - custom-network: "omnistrate-ctl_custom-network.md"


### PR DESCRIPTION
This pull request makes a small update to the documentation navigation by adding a new entry for deployment cell commands.

* Added `deployment-cell` documentation to the navigation in `mkdocs/mkdocs.yml` to improve discoverability of deployment cell features.