### PR TITLE
expose sync target and fix logs

### DIFF
--- a/cmd/deploymentcell/update_template.go
+++ b/cmd/deploymentcell/update_template.go
@@ -221,8 +221,15 @@ func syncDeploymentCellWithTemplate(ctx context.Context, token string, deploymen
 	fmt.Printf("Current configuration: %d amenities (%d managed, %d custom)\n",
 		currentManagedCount+currentCustomCount, currentManagedCount, currentCustomCount)
 
+	envType := currentHc.GetEnvironmentType()
+	if envType == "" {
+		utils.PrintError(fmt.Errorf("deployment cell %s does not have an environment type set",
+			deploymentCellID))
+		return fmt.Errorf("missing environment type for deployment cell %s", deploymentCellID)
+	}
+
 	// Perform sync with organization template
-	fmt.Printf("Syncing with organization template...\n")
+	fmt.Printf("Syncing deployment cell with organization template for environment '%s'...\n", envType)
 	err = dataaccess.UpdateHostCluster(ctx, token, deploymentCellID, nil, utils.ToPtr(true))
 	if err != nil {
 		utils.PrintError(fmt.Errorf("failed to sync deployment cell with organization template: %w", err))
@@ -254,10 +261,10 @@ func syncDeploymentCellWithTemplate(ctx context.Context, token string, deploymen
 	totalBefore := currentManagedCount + currentCustomCount
 	totalAfter := updatedManagedCount + updatedCustomCount
 
-	if totalBefore == totalAfter && currentManagedCount == updatedManagedCount && currentCustomCount == updatedCustomCount {
+	if totalAfter == 0 && updatedManagedCount == 0 && updatedCustomCount == 0 {
 		fmt.Printf("Deployment cell is already synchronized with organization template\n")
 		fmt.Printf("Configuration remains: %d amenities (%d managed, %d custom)\n",
-			totalAfter, updatedManagedCount, updatedCustomCount)
+			totalBefore, currentManagedCount, currentCustomCount)
 	} else {
 		fmt.Printf("Successfully synchronized deployment cell with organization template\n")
 		fmt.Printf("Configuration updated: %d → %d amenities\n", totalBefore, totalAfter)

--- a/cmd/deploymentcell/update_template.go
+++ b/cmd/deploymentcell/update_template.go
@@ -261,7 +261,7 @@ func syncDeploymentCellWithTemplate(ctx context.Context, token string, deploymen
 	totalBefore := currentManagedCount + currentCustomCount
 	totalAfter := updatedManagedCount + updatedCustomCount
 
-	if totalAfter == 0 && updatedManagedCount == 0 && updatedCustomCount == 0 {
+	if totalAfter == 0 {
 		fmt.Printf("Deployment cell is already synchronized with organization template\n")
 		fmt.Printf("Configuration remains: %d amenities (%d managed, %d custom)\n",
 			totalBefore, currentManagedCount, currentCustomCount)

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.6.8
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-wordwrap v1.0.1
-	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.65
+	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.66
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/rivo/tview v0.0.0-20250625164341-a4a78f1e05cb

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.65 h1:lDnscKWP4QkoJNH+0UaAKoJoX7S6xK5vM+ufR9ZywcE=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.65/go.mod h1:13Nya7BhDXIOJlImVh4QP/GWgk0hc/3PeSd6cQoRJvU=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.66 h1:i7HabAwrIwykip3hxtUq0wDkKZvrYSIc4cssItwHP/w=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.66/go.mod h1:13Nya7BhDXIOJlImVh4QP/GWgk0hc/3PeSd6cQoRJvU=
 github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM=
 github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=


### PR DESCRIPTION
This pull request introduces improvements to the deployment cell synchronization process, including enhanced error handling and messaging, as well as a dependency update. The most important changes are grouped below.

Deployment cell sync logic and messaging:

* Added a check to ensure the deployment cell has an environment type set before syncing; if missing, an error is printed and the operation is aborted.
* Improved sync messaging to include the environment type in the output, making it clearer which environment is being synchronized.
* Adjusted the logic for reporting synchronization status: now, if the updated amenities count is zero, the tool reports that the deployment cell is already synchronized and displays the original configuration.

Dependency update:

* Updated the `omnistrate-sdk-go` dependency from version `v0.0.65` to `v0.0.66` in `go.mod`.