### PR TITLE
Add support for expression evaluator commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ REPO_ROOT=$(shell git rev-parse --show-toplevel)
 # Build info
 BUILD_INFO_PKG=github.com/omnistrate-oss/omnistrate-ctl/internal/config
 BUILD_TIMESTAMP=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
-BUILD_FLAGS=-trimpath -ldflags "-X $(BUILD_INFO_PKG).CommitID=$(GIT_COMMIT) -X $(BUILD_INFO_PKG).Timestamp=$(BUILD_TIMESTAMP) -X $(BUILD_INFO_PKG).Version=$(GIT_VERSION)"
+BUILD_FLAGS=-trimpath -ldflags "-s -w -X $(BUILD_INFO_PKG).CommitID=$(GIT_COMMIT) -X $(BUILD_INFO_PKG).Timestamp=$(BUILD_TIMESTAMP) -X $(BUILD_INFO_PKG).Version=$(GIT_VERSION)"
 
 CGO_ENABLED=0
 GOPRIVATE=github.com/omnistrate
@@ -78,7 +78,7 @@ build:
 	if [ "$(GOOS)" = "windows" ]; then \
 		binary_name="$$binary_name.exe"; \
 	fi; \
-	CGO_ENABLED=0 go build -mod=mod ${BUILD_FLAGS} -o dist/$$binary_name github.com/omnistrate-oss/omnistrate-ctl
+	CGO_ENABLED=0 go build -mod=mod ${BUILD_FLAGS} -v -o dist/$$binary_name github.com/omnistrate-oss/omnistrate-ctl
 	@echo "Build complete: dist/$$binary_name"
 	@echo "Build integration test"
 	go test -c -o /dev/null ./test/integration_test/...

--- a/cmd/instance/evaluate.go
+++ b/cmd/instance/evaluate.go
@@ -1,0 +1,165 @@
+package instance
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+
+	"github.com/chelnak/ysmrr"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+)
+
+const (
+	evaluateExample = `# Evaluate an expression for an instance
+omctl instance evaluate instance-abcd1234 my-resource-key --expression "param1 + param2"
+
+# Evaluate expressions from a JSON file
+omctl instance evaluate instance-abcd1234 my-resource-key --expression-file expressions.json`
+)
+
+var evaluateCmd = &cobra.Command{
+	Use:          "evaluate [instance-id] [resource-key]",
+	Short:        "Evaluate an expression in the context of an instance",
+	Long:         `This command helps you evaluate expressions using instance parameters and system variables.`,
+	Example:      evaluateExample,
+	RunE:         runEvaluate,
+	SilenceUsage: true,
+}
+
+func init() {
+	evaluateCmd.Args = cobra.ExactArgs(2) // Require exactly two arguments
+	evaluateCmd.Flags().StringP("expression", "e", "", "Expression string to evaluate")
+	evaluateCmd.Flags().StringP("expression-file", "f", "", "Path to JSON file containing expressions mapped to expressionMap field")
+	evaluateCmd.MarkFlagsMutuallyExclusive("expression", "expression-file")
+}
+
+func runEvaluate(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	// Retrieve args
+	instanceID := args[0]
+	resourceKey := args[1]
+
+	// Retrieve flags
+	output, err := cmd.Flags().GetString("output")
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	expression, err := cmd.Flags().GetString("expression")
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	expressionFile, err := cmd.Flags().GetString("expression-file")
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	// Validate that either expression or expression-file is provided
+	if expression == "" && expressionFile == "" {
+		err = errors.New("either --expression or --expression-file must be provided")
+		utils.PrintError(err)
+		return err
+	}
+
+	// Validate user login
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	// Initialize spinner if output is not JSON
+	var sm ysmrr.SpinnerManager
+	var spinner *ysmrr.Spinner
+	if output != common.OutputTypeJson {
+		sm = ysmrr.NewSpinnerManager()
+		msg := "Evaluating expression..."
+		spinner = sm.AddSpinner(msg)
+		sm.Start()
+	}
+
+	// Get instance details to extract service ID and product tier ID
+	serviceID, _, productTierID, _, err := getInstance(cmd.Context(), token, instanceID)
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+
+	// Prepare the request
+	var expressionMap map[string]interface{}
+	if expressionFile != "" {
+		// Load expressions from file
+		expressionMap, err = loadExpressionsFromFile(expressionFile)
+		if err != nil {
+			utils.HandleSpinnerError(spinner, sm, err)
+			return err
+		}
+	}
+
+	// Call the evaluate API
+	result, err := dataaccess.EvaluateExpression(cmd.Context(), token, serviceID, productTierID, instanceID, resourceKey, expression, expressionMap)
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+
+	utils.HandleSpinnerSuccess(spinner, sm, "Successfully evaluated expression")
+
+	// Create a result structure for consistent JSON output
+	evaluationResult := struct {
+		Result interface{} `json:"result"`
+	}{
+		Result: result,
+	}
+
+	// Print output using standard utility function
+	err = utils.PrintTextTableJsonOutput(output, evaluationResult)
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	return nil
+}
+
+func loadExpressionsFromFile(filePath string) (map[string]interface{}, error) {
+	// Check if file exists
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("expression file not found: %s", filePath)
+	}
+
+	// Open and read the file
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open expression file: %w", err)
+	}
+	defer file.Close()
+
+	content, err := io.ReadAll(file)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read expression file: %w", err)
+	}
+
+	// Parse JSON content
+	var expressionMap map[string]interface{}
+	err = json.Unmarshal(content, &expressionMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse JSON expression file: %w", err)
+	}
+
+	return expressionMap, nil
+}
+
+

--- a/cmd/instance/instance.go
+++ b/cmd/instance/instance.go
@@ -34,6 +34,7 @@ func init() {
 	Cmd.AddCommand(adoptCmd)
 	Cmd.AddCommand(versionUpgradeCmd)
 	Cmd.AddCommand(debugCmd)
+	Cmd.AddCommand(evaluateCmd)
 }
 
 func run(cmd *cobra.Command, args []string) {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.6.8
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-wordwrap v1.0.1
-	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.69
+	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.70
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/rivo/tview v0.0.0-20250625164341-a4a78f1e05cb

--- a/go.sum
+++ b/go.sum
@@ -142,8 +142,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.69 h1:42qe9vHHyZwt6N7BXD1BD5+aEFofoqp9XWVTTWp7DjE=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.69/go.mod h1:13Nya7BhDXIOJlImVh4QP/GWgk0hc/3PeSd6cQoRJvU=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.70 h1:VmuD6A7RtSp8aiNUoZO47Y/XTlTL/56KxNDmm3dnGp0=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.70/go.mod h1:13Nya7BhDXIOJlImVh4QP/GWgk0hc/3PeSd6cQoRJvU=
 github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM=
 github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=

--- a/mkdocs/docs/omnistrate-ctl_instance.md
+++ b/mkdocs/docs/omnistrate-ctl_instance.md
@@ -34,6 +34,7 @@ omnistrate-ctl instance [operation] [flags]
 * [omnistrate-ctl instance describe](omnistrate-ctl_instance_describe.md)	 - Describe an instance deployment for your service
 * [omnistrate-ctl instance disable-debug-mode](omnistrate-ctl_instance_disable-debug-mode.md)	 - Disable debug mode for an instance deployment
 * [omnistrate-ctl instance enable-debug-mode](omnistrate-ctl_instance_enable-debug-mode.md)	 - Enable debug mode for an instance deployment
+* [omnistrate-ctl instance evaluate](omnistrate-ctl_instance_evaluate.md)	 - Evaluate an expression in the context of an instance
 * [omnistrate-ctl instance get-deployment](omnistrate-ctl_instance_get-deployment.md)	 - Get the deployment entity metadata of the instance
 * [omnistrate-ctl instance list](omnistrate-ctl_instance_list.md)	 - List instance deployments for your service
 * [omnistrate-ctl instance list-endpoints](omnistrate-ctl_instance_list-endpoints.md)	 - List endpoints for a specific instance

--- a/mkdocs/docs/omnistrate-ctl_instance_evaluate.md
+++ b/mkdocs/docs/omnistrate-ctl_instance_evaluate.md
@@ -1,0 +1,41 @@
+## omnistrate-ctl instance evaluate
+
+Evaluate an expression in the context of an instance
+
+### Synopsis
+
+This command helps you evaluate expressions using instance parameters and system variables.
+
+```
+omnistrate-ctl instance evaluate [instance-id] [resource-key] [flags]
+```
+
+### Examples
+
+```
+# Evaluate an expression for an instance
+omctl instance evaluate instance-abcd1234 my-resource-key --expression "param1 + param2"
+
+# Evaluate expressions from a JSON file
+omctl instance evaluate instance-abcd1234 my-resource-key --expression-file expressions.json
+```
+
+### Options
+
+```
+  -e, --expression string        Expression string to evaluate
+  -f, --expression-file string   Path to JSON file containing expressions mapped to expressionMap field
+  -h, --help                     help for evaluate
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl instance](omnistrate-ctl_instance.md)	 - Manage Instance Deployments for your service
+


### PR DESCRIPTION
This PR adds a new `evaluate` subcommand under `instance` that allows users to evaluate expressions in the context of an instance. The command supports both single expressions and multiple expressions from JSON files, with full output format support (table/text/json).

```bash
omctl instance evaluate [instance-id] [resource-key] --expression "param1 + param2"

omctl instance evaluate [instance-id] [resource-key] --expression-file expressions.json

omctl instance evaluate [instance-id] [resource-key] --expression "test" --output json

Key Features

- Single Expression Support: Evaluate individual expressions via --expression flag
- Expression File Support: Load multiple expressions from JSON files via --expression-file flag
- Mutual Exclusivity: Flags are mutually exclusive - use either expression or expression-file
- Full Output Format Support: Supports --output table|text|json like other CLI commands
- Smart Spinner Logic: Shows spinner for interactive formats (table/text) but not for JSON output
- Instance Context: Automatically extracts serviceID and productTierID from instance details

Implementation Details

Command Structure

- Arguments: [instance-id] [resource-key] (both required)
- Flags:
  - --expression, -e: Expression string to evaluate
  - --expression-file, -f: Path to JSON file with expression map
  - --output, -o: Output format (inherited from global flags)

API Integration

- Uses ExpressionEvaluatorApiExpressionEvaluator endpoint from v1 SDK
- Supports both Expression and ExpressionMap fields in requests

Output Formats

- Table/Text: Structured JSON wrapped in result object with spinner
- JSON: Clean programmatic output without spinner
{
    "result": "evaluated_value_here"
}

For expression maps:
{
    "result": {
        "sum": "10",
        "product": "20",
        "greeting": "Hello instance-xyz"
    }
}