### PR TITLE
Add more commands

### DIFF
--- a/cmd/audit/audit.go
+++ b/cmd/audit/audit.go
@@ -1,0 +1,15 @@
+package audit
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "audit",
+	Short: "Audit events and logging management",
+	Long:  "Access and manage audit events for services, instances, and operations.",
+}
+
+func init() {
+	Cmd.AddCommand(listCmd)
+}

--- a/cmd/audit/audit_test.go
+++ b/cmd/audit/audit_test.go
@@ -1,0 +1,53 @@
+package audit
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditCommands(t *testing.T) {
+	require.Equal(t, "audit", Cmd.Use)
+	require.Equal(t, "Audit events and logging management", Cmd.Short)
+
+	// Check that list subcommand is added
+	subCommands := []string{"list"}
+	for _, subCmd := range subCommands {
+		found := false
+		for _, cmd := range Cmd.Commands() {
+			if cmd.Use == subCmd {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "Expected subcommand %s not found", subCmd)
+	}
+}
+
+func TestListCommandFlags(t *testing.T) {
+	cmd := listCmd
+
+	require.Equal(t, "list", cmd.Use)
+	require.Equal(t, "List audit events", cmd.Short)
+
+	// Check flags
+	flags := []string{
+		"next-page-token", "page-size", "service-id", "environment-type",
+		"event-source-types", "instance-id", "product-tier-id",
+		"start-date", "end-date",
+	}
+	for _, flagName := range flags {
+		flag := cmd.Flags().Lookup(flagName)
+		require.NotNil(t, flag, "Expected flag %s not found", flagName)
+	}
+
+	// Check shorthand flags
+	serviceIDFlag := cmd.Flags().Lookup("service-id")
+	require.Equal(t, "s", serviceIDFlag.Shorthand)
+
+	environmentTypeFlag := cmd.Flags().Lookup("environment-type")
+	require.Equal(t, "e", environmentTypeFlag.Shorthand)
+
+	instanceIDFlag := cmd.Flags().Lookup("instance-id")
+	require.Equal(t, "i", instanceIDFlag.Shorthand)
+}

--- a/cmd/audit/list.go
+++ b/cmd/audit/list.go
@@ -1,0 +1,98 @@
+package audit
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List audit events",
+	Long:  "List audit events with detailed filtering options for services, instances, and time ranges.",
+	RunE:  runList,
+}
+
+func init() {
+	listCmd.Flags().String("next-page-token", "", "Token for next page of results")
+	listCmd.Flags().Int64("page-size", 0, "Number of results per page")
+	listCmd.Flags().StringP("service-id", "s", "", "Service ID to filter by")
+	listCmd.Flags().StringP("environment-type", "e", "", "Environment type to filter by")
+	listCmd.Flags().StringSlice("event-source-types", []string{}, "Event source types to filter by (comma-separated)")
+	listCmd.Flags().StringP("instance-id", "i", "", "Instance ID to filter by")
+	listCmd.Flags().String("product-tier-id", "", "Product tier ID to filter by")
+	listCmd.Flags().String("start-date", "", "Start date for events (RFC3339 format)")
+	listCmd.Flags().String("end-date", "", "End date for events (RFC3339 format)")
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	nextPageToken, _ := cmd.Flags().GetString("next-page-token")
+	pageSize, _ := cmd.Flags().GetInt64("page-size")
+	serviceID, _ := cmd.Flags().GetString("service-id")
+	environmentType, _ := cmd.Flags().GetString("environment-type")
+	eventSourceTypes, _ := cmd.Flags().GetStringSlice("event-source-types")
+	instanceID, _ := cmd.Flags().GetString("instance-id")
+	productTierID, _ := cmd.Flags().GetString("product-tier-id")
+	startDateStr, _ := cmd.Flags().GetString("start-date")
+	endDateStr, _ := cmd.Flags().GetString("end-date")
+
+	// Parse dates
+	var startDate, endDate *time.Time
+	if startDateStr != "" {
+		parsed, err := time.Parse(time.RFC3339, startDateStr)
+		if err != nil {
+			return err
+		}
+		startDate = &parsed
+	}
+	if endDateStr != "" {
+		parsed, err := time.Parse(time.RFC3339, endDateStr)
+		if err != nil {
+			return err
+		}
+		endDate = &parsed
+	}
+
+	// Clean up event source types
+	var cleanEventSourceTypes []string
+	for _, eventType := range eventSourceTypes {
+		if strings.TrimSpace(eventType) != "" {
+			cleanEventSourceTypes = append(cleanEventSourceTypes, strings.TrimSpace(eventType))
+		}
+	}
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		return err
+	}
+
+	opts := &dataaccess.ListAuditEventsOptions{
+		NextPageToken:    nextPageToken,
+		ServiceID:        serviceID,
+		EnvironmentType:  environmentType,
+		EventSourceTypes: cleanEventSourceTypes,
+		InstanceID:       instanceID,
+		ProductTierID:    productTierID,
+		StartDate:        startDate,
+		EndDate:          endDate,
+	}
+
+	if pageSize > 0 {
+		opts.PageSize = &pageSize
+	}
+
+	result, err := dataaccess.ListAuditEvents(ctx, token, opts)
+	if err != nil {
+		return err
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	return utils.PrintTextTableJsonArrayOutput(output, []interface{}{result})
+}

--- a/cmd/instance/describe_snapshot.go
+++ b/cmd/instance/describe_snapshot.go
@@ -1,0 +1,91 @@
+package instance
+
+import (
+	"errors"
+
+	"github.com/chelnak/ysmrr"
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+const (
+	describeSnapshotExample = `# Describe a specific snapshot
+omctl instance describe-snapshot instance-abcd1234 snapshot-xyz789`
+)
+
+var describeSnapshotCmd = &cobra.Command{
+	Use:          "describe-snapshot [instance-id] [snapshot-id]",
+	Short:        "Describe a specific instance snapshot",
+	Long:         `This command helps you get detailed information about a specific snapshot for your instance.`,
+	Example:      describeSnapshotExample,
+	RunE:         runDescribeSnapshot,
+	SilenceUsage: true,
+}
+
+func init() {
+	describeSnapshotCmd.Args = cobra.ExactArgs(2) // Require exactly two arguments
+}
+
+func runDescribeSnapshot(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	if len(args) < 2 {
+		err := errors.New("both instance id and snapshot id are required")
+		utils.PrintError(err)
+		return err
+	}
+
+	// Retrieve args
+	instanceID := args[0]
+	snapshotID := args[1]
+
+	// Retrieve flags
+	output, err := cmd.Flags().GetString("output")
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	// Validate user login
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	// Initialize spinner if output is not JSON
+	var sm ysmrr.SpinnerManager
+	var spinner *ysmrr.Spinner
+	if output != "json" {
+		sm = ysmrr.NewSpinnerManager()
+		msg := "Describing snapshot..."
+		spinner = sm.AddSpinner(msg)
+		sm.Start()
+	}
+
+	// Check if instance exists and get its details
+	serviceID, environmentID, _, _, err := getInstance(cmd.Context(), token, instanceID)
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+
+	// Describe snapshot
+	result, err := dataaccess.DescribeInstanceSnapshot(cmd.Context(), token, serviceID, environmentID, instanceID, snapshotID)
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+
+	utils.HandleSpinnerSuccess(spinner, sm, "Successfully described snapshot")
+
+	// Print output
+	if err = utils.PrintTextTableJsonOutput(output, result); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/instance/instance.go
+++ b/cmd/instance/instance.go
@@ -30,6 +30,7 @@ func init() {
 	Cmd.AddCommand(patchDeploymentCmd)
 	Cmd.AddCommand(triggerBackupCmd)
 	Cmd.AddCommand(listSnapshotsCmd)
+	Cmd.AddCommand(describeSnapshotCmd)
 	Cmd.AddCommand(restoreCmd)
 	Cmd.AddCommand(adoptCmd)
 	Cmd.AddCommand(versionUpgradeCmd)

--- a/cmd/operations/deployment_cell_health.go
+++ b/cmd/operations/deployment_cell_health.go
@@ -1,0 +1,50 @@
+package operations
+
+import (
+	"context"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+var deploymentCellHealthCmd = &cobra.Command{
+	Use:   "deployment-cell-health",
+	Short: "Get deployment cell health details",
+	Long:  "Get detailed health information for deployment cells, including host clusters and services.",
+	RunE:  runDeploymentCellHealth,
+}
+
+func init() {
+	deploymentCellHealthCmd.Flags().String("host-cluster-id", "", "Host cluster ID to get health for")
+	deploymentCellHealthCmd.Flags().StringP("service-id", "s", "", "Service ID to get health for")
+	deploymentCellHealthCmd.Flags().StringP("environment-id", "e", "", "Service environment ID to get health for")
+}
+
+func runDeploymentCellHealth(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	hostClusterID, _ := cmd.Flags().GetString("host-cluster-id")
+	serviceID, _ := cmd.Flags().GetString("service-id")
+	environmentID, _ := cmd.Flags().GetString("environment-id")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		return err
+	}
+
+	opts := &dataaccess.DeploymentCellHealthOptions{
+		HostClusterID:        hostClusterID,
+		ServiceID:            serviceID,
+		ServiceEnvironmentID: environmentID,
+	}
+
+	result, err := dataaccess.GetDeploymentCellHealth(ctx, token, opts)
+	if err != nil {
+		return err
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	return utils.PrintTextTableJsonArrayOutput(output, []interface{}{result})
+}

--- a/cmd/operations/events.go
+++ b/cmd/operations/events.go
@@ -1,0 +1,101 @@
+package operations
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+var eventsCmd = &cobra.Command{
+	Use:   "events",
+	Short: "List operational events",
+	Long:  "List operational events for services, environments, and instances with filtering options.",
+	RunE:  runEvents,
+}
+
+func init() {
+	eventsCmd.Flags().String("next-page-token", "", "Token for next page of results")
+	eventsCmd.Flags().Int64("page-size", 0, "Number of results per page")
+	eventsCmd.Flags().StringP("environment-type", "e", "", "Environment type to filter by")
+	eventsCmd.Flags().StringSlice("event-types", []string{}, "Event types to filter by (comma-separated)")
+	eventsCmd.Flags().StringP("service-id", "s", "", "Service ID to list events for")
+	eventsCmd.Flags().String("service-environment-id", "", "Service environment ID to list events for")
+	eventsCmd.Flags().StringP("instance-id", "i", "", "Instance ID to list events for")
+	eventsCmd.Flags().String("start-date", "", "Start date of events (RFC3339 format)")
+	eventsCmd.Flags().String("end-date", "", "End date of events (RFC3339 format)")
+	eventsCmd.Flags().String("product-tier-id", "", "Product tier ID to filter by")
+}
+
+func runEvents(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	nextPageToken, _ := cmd.Flags().GetString("next-page-token")
+	pageSize, _ := cmd.Flags().GetInt64("page-size")
+	environmentType, _ := cmd.Flags().GetString("environment-type")
+	eventTypes, _ := cmd.Flags().GetStringSlice("event-types")
+	serviceID, _ := cmd.Flags().GetString("service-id")
+	serviceEnvironmentID, _ := cmd.Flags().GetString("service-environment-id")
+	instanceID, _ := cmd.Flags().GetString("instance-id")
+	startDateStr, _ := cmd.Flags().GetString("start-date")
+	endDateStr, _ := cmd.Flags().GetString("end-date")
+	productTierID, _ := cmd.Flags().GetString("product-tier-id")
+
+	// Parse dates
+	var startDate, endDate *time.Time
+	if startDateStr != "" {
+		parsed, err := time.Parse(time.RFC3339, startDateStr)
+		if err != nil {
+			return err
+		}
+		startDate = &parsed
+	}
+	if endDateStr != "" {
+		parsed, err := time.Parse(time.RFC3339, endDateStr)
+		if err != nil {
+			return err
+		}
+		endDate = &parsed
+	}
+
+	// Clean up event types
+	var cleanEventTypes []string
+	for _, eventType := range eventTypes {
+		if strings.TrimSpace(eventType) != "" {
+			cleanEventTypes = append(cleanEventTypes, strings.TrimSpace(eventType))
+		}
+	}
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		return err
+	}
+
+	opts := &dataaccess.ListEventsOptions{
+		NextPageToken:        nextPageToken,
+		EnvironmentType:      environmentType,
+		EventTypes:           cleanEventTypes,
+		ServiceID:            serviceID,
+		ServiceEnvironmentID: serviceEnvironmentID,
+		InstanceID:           instanceID,
+		StartDate:            startDate,
+		EndDate:              endDate,
+		ProductTierID:        productTierID,
+	}
+
+	if pageSize > 0 {
+		opts.PageSize = &pageSize
+	}
+
+	result, err := dataaccess.ListOperationsEvents(ctx, token, opts)
+	if err != nil {
+		return err
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	return utils.PrintTextTableJsonArrayOutput(output, []interface{}{result})
+}

--- a/cmd/operations/health.go
+++ b/cmd/operations/health.go
@@ -1,0 +1,45 @@
+package operations
+
+import (
+	"context"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+var healthCmd = &cobra.Command{
+	Use:   "health",
+	Short: "Get service health summary",
+	Long:  "Get the overall health status of a service and its environment.",
+	RunE:  runHealth,
+}
+
+func init() {
+	healthCmd.Flags().StringP("service-id", "s", "", "Service ID (required)")
+	healthCmd.Flags().StringP("environment-id", "e", "", "Service environment ID (required)")
+
+	_ = healthCmd.MarkFlagRequired("service-id")
+	_ = healthCmd.MarkFlagRequired("environment-id")
+}
+
+func runHealth(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	serviceID, _ := cmd.Flags().GetString("service-id")
+	environmentID, _ := cmd.Flags().GetString("environment-id")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		return err
+	}
+
+	result, err := dataaccess.GetServiceHealth(ctx, token, serviceID, environmentID)
+	if err != nil {
+		return err
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	return utils.PrintTextTableJsonArrayOutput(output, []interface{}{result})
+}

--- a/cmd/operations/operations.go
+++ b/cmd/operations/operations.go
@@ -1,0 +1,17 @@
+package operations
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:   "operations",
+	Short: "Operations and health monitoring commands",
+	Long:  "Manage and monitor operational health of your services, deployment cells, and infrastructure.",
+}
+
+func init() {
+	Cmd.AddCommand(healthCmd)
+	Cmd.AddCommand(deploymentCellHealthCmd)
+	Cmd.AddCommand(eventsCmd)
+}

--- a/cmd/operations/operations_test.go
+++ b/cmd/operations/operations_test.go
@@ -1,0 +1,84 @@
+package operations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOperationsCommands(t *testing.T) {
+	require.Equal(t, "operations", Cmd.Use)
+	require.Equal(t, "Operations and health monitoring commands", Cmd.Short)
+	require.Contains(t, Cmd.Long, "Manage and monitor operational health")
+
+	// Check that all subcommands are added
+	subCommands := []string{"health", "deployment-cell-health", "events"}
+	for _, subCmd := range subCommands {
+		found := false
+		for _, cmd := range Cmd.Commands() {
+			if cmd.Use == subCmd {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "Expected subcommand %s not found", subCmd)
+	}
+}
+
+func TestHealthCommandFlags(t *testing.T) {
+	cmd := healthCmd
+
+	require.Equal(t, "health", cmd.Use)
+	require.Equal(t, "Get service health summary", cmd.Short)
+
+	// Check required flags
+	serviceIDFlag := cmd.Flags().Lookup("service-id")
+	require.NotNil(t, serviceIDFlag)
+	require.Equal(t, "s", serviceIDFlag.Shorthand)
+
+	environmentIDFlag := cmd.Flags().Lookup("environment-id")
+	require.NotNil(t, environmentIDFlag)
+	require.Equal(t, "e", environmentIDFlag.Shorthand)
+}
+
+func TestDeploymentCellHealthCommandFlags(t *testing.T) {
+	cmd := deploymentCellHealthCmd
+
+	require.Equal(t, "deployment-cell-health", cmd.Use)
+	require.Equal(t, "Get deployment cell health details", cmd.Short)
+
+	// Check optional flags
+	flags := []string{"host-cluster-id", "service-id", "environment-id"}
+	for _, flagName := range flags {
+		flag := cmd.Flags().Lookup(flagName)
+		require.NotNil(t, flag, "Expected flag %s not found", flagName)
+	}
+}
+
+func TestEventsCommandFlags(t *testing.T) {
+	cmd := eventsCmd
+
+	require.Equal(t, "events", cmd.Use)
+	require.Equal(t, "List operational events", cmd.Short)
+
+	// Check flags
+	flags := []string{
+		"next-page-token", "page-size", "environment-type", "event-types",
+		"service-id", "service-environment-id", "instance-id",
+		"start-date", "end-date", "product-tier-id",
+	}
+	for _, flagName := range flags {
+		flag := cmd.Flags().Lookup(flagName)
+		require.NotNil(t, flag, "Expected flag %s not found", flagName)
+	}
+
+	// Check shorthand flags
+	serviceIDFlag := cmd.Flags().Lookup("service-id")
+	require.Equal(t, "s", serviceIDFlag.Shorthand)
+
+	environmentTypeFlag := cmd.Flags().Lookup("environment-type")
+	require.Equal(t, "e", environmentTypeFlag.Shorthand)
+
+	instanceIDFlag := cmd.Flags().Lookup("instance-id")
+	require.Equal(t, "i", instanceIDFlag.Shorthand)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,8 @@ import (
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/upgrade"
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/workflow"
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/cost"
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/operations"
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/audit"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
 	"github.com/spf13/cobra"
@@ -131,6 +133,8 @@ func init() {
 	RootCmd.AddCommand(secret.Cmd)
 	RootCmd.AddCommand(workflow.Cmd)
 	RootCmd.AddCommand(cost.Cmd)
+	RootCmd.AddCommand(operations.Cmd)
+	RootCmd.AddCommand(audit.Cmd)
 
 	// Hide the default completion command
 	RootCmd.Root().CompletionOptions.DisableDefaultCmd = true

--- a/cmd/subscription/approve_request.go
+++ b/cmd/subscription/approve_request.go
@@ -1,0 +1,47 @@
+package subscription
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/spf13/cobra"
+)
+
+var approveRequestCmd = &cobra.Command{
+	Use:   "approve-request <request-id>",
+	Short: "Approve a subscription request",
+	Long:  "Approve a pending subscription request for a service environment.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runApproveRequest,
+}
+
+func init() {
+	approveRequestCmd.Flags().StringP("service-id", "s", "", "Service ID (required)")
+	approveRequestCmd.Flags().StringP("environment-id", "e", "", "Environment ID (required)")
+
+	_ = approveRequestCmd.MarkFlagRequired("service-id")
+	_ = approveRequestCmd.MarkFlagRequired("environment-id")
+}
+
+func runApproveRequest(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	requestID := args[0]
+	serviceID, _ := cmd.Flags().GetString("service-id")
+	environmentID, _ := cmd.Flags().GetString("environment-id")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		return err
+	}
+
+	err = dataaccess.ApproveSubscriptionRequest(ctx, token, serviceID, environmentID, requestID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Successfully approved subscription request %s\n", requestID)
+	return nil
+}

--- a/cmd/subscription/create_on_behalf.go
+++ b/cmd/subscription/create_on_behalf.go
@@ -1,0 +1,93 @@
+package subscription
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+var createOnBehalfCmd = &cobra.Command{
+	Use:   "create-on-behalf",
+	Short: "Create subscription on behalf of customer",
+	Long:  "Create a subscription on behalf of a customer for a service environment.",
+	RunE:  runCreateOnBehalf,
+}
+
+func init() {
+	createOnBehalfCmd.Flags().StringP("service-id", "s", "", "Service ID (required)")
+	createOnBehalfCmd.Flags().StringP("environment-id", "e", "", "Environment ID (required)")
+	createOnBehalfCmd.Flags().String("product-tier-id", "", "Product tier ID (required)")
+	createOnBehalfCmd.Flags().String("customer-user-id", "", "Customer user ID (required)")
+	createOnBehalfCmd.Flags().Bool("allow-creates-without-payment", false, "Allow creation without payment configured")
+	createOnBehalfCmd.Flags().String("billing-provider", "", "Billing provider")
+	createOnBehalfCmd.Flags().Bool("custom-price", false, "Whether to use custom price")
+	createOnBehalfCmd.Flags().String("custom-price-per-unit", "", "Custom price per unit (JSON object)")
+	createOnBehalfCmd.Flags().String("external-payer-id", "", "External payer ID")
+	createOnBehalfCmd.Flags().Int64("max-instances", 0, "Maximum number of instances")
+	createOnBehalfCmd.Flags().String("price-effective-date", "", "Price effective date")
+
+	_ = createOnBehalfCmd.MarkFlagRequired("service-id")
+	_ = createOnBehalfCmd.MarkFlagRequired("environment-id")
+	_ = createOnBehalfCmd.MarkFlagRequired("product-tier-id")
+	_ = createOnBehalfCmd.MarkFlagRequired("customer-user-id")
+}
+
+func runCreateOnBehalf(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	serviceID, _ := cmd.Flags().GetString("service-id")
+	environmentID, _ := cmd.Flags().GetString("environment-id")
+	productTierID, _ := cmd.Flags().GetString("product-tier-id")
+	customerUserID, _ := cmd.Flags().GetString("customer-user-id")
+	allowWithoutPayment, _ := cmd.Flags().GetBool("allow-creates-without-payment")
+	billingProvider, _ := cmd.Flags().GetString("billing-provider")
+	customPrice, _ := cmd.Flags().GetBool("custom-price")
+	customPricePerUnitStr, _ := cmd.Flags().GetString("custom-price-per-unit")
+	externalPayerID, _ := cmd.Flags().GetString("external-payer-id")
+	maxInstances, _ := cmd.Flags().GetInt64("max-instances")
+	priceEffectiveDate, _ := cmd.Flags().GetString("price-effective-date")
+
+	// Parse custom price per unit if provided
+	var customPricePerUnit map[string]interface{}
+	if customPricePerUnitStr != "" {
+		if err := json.Unmarshal([]byte(customPricePerUnitStr), &customPricePerUnit); err != nil {
+			return err
+		}
+	}
+
+	opts := &dataaccess.CreateSubscriptionOnBehalfOptions{
+		ProductTierID:            productTierID,
+		OnBehalfOfCustomerUserID: customerUserID,
+		BillingProvider:          billingProvider,
+		ExternalPayerID:          externalPayerID,
+		PriceEffectiveDate:       priceEffectiveDate,
+		CustomPricePerUnit:       customPricePerUnit,
+	}
+
+	if cmd.Flags().Changed("allow-creates-without-payment") {
+		opts.AllowCreatesWhenPaymentNotConfigured = &allowWithoutPayment
+	}
+	if cmd.Flags().Changed("custom-price") {
+		opts.CustomPrice = &customPrice
+	}
+	if cmd.Flags().Changed("max-instances") {
+		opts.MaxNumberOfInstances = &maxInstances
+	}
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		return err
+	}
+
+	result, err := dataaccess.CreateSubscriptionOnBehalf(ctx, token, serviceID, environmentID, opts)
+	if err != nil {
+		return err
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	return utils.PrintTextTableJsonArrayOutput(output, []interface{}{result})
+}

--- a/cmd/subscription/deny_request.go
+++ b/cmd/subscription/deny_request.go
@@ -1,0 +1,47 @@
+package subscription
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/spf13/cobra"
+)
+
+var denyRequestCmd = &cobra.Command{
+	Use:   "deny-request <request-id>",
+	Short: "Deny a subscription request",
+	Long:  "Deny a pending subscription request for a service environment.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runDenyRequest,
+}
+
+func init() {
+	denyRequestCmd.Flags().StringP("service-id", "s", "", "Service ID (required)")
+	denyRequestCmd.Flags().StringP("environment-id", "e", "", "Environment ID (required)")
+
+	_ = denyRequestCmd.MarkFlagRequired("service-id")
+	_ = denyRequestCmd.MarkFlagRequired("environment-id")
+}
+
+func runDenyRequest(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	requestID := args[0]
+	serviceID, _ := cmd.Flags().GetString("service-id")
+	environmentID, _ := cmd.Flags().GetString("environment-id")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		return err
+	}
+
+	err = dataaccess.DenySubscriptionRequest(ctx, token, serviceID, environmentID, requestID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Successfully denied subscription request %s\n", requestID)
+	return nil
+}

--- a/cmd/subscription/list_for_service.go
+++ b/cmd/subscription/list_for_service.go
@@ -1,0 +1,45 @@
+package subscription
+
+import (
+	"context"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+var listForServiceCmd = &cobra.Command{
+	Use:   "list-for-service",
+	Short: "List subscriptions for a specific service environment",
+	Long:  "List all subscriptions for a specific service and environment using fleet API.",
+	RunE:  runListForService,
+}
+
+func init() {
+	listForServiceCmd.Flags().StringP("service-id", "s", "", "Service ID (required)")
+	listForServiceCmd.Flags().StringP("environment-id", "e", "", "Environment ID (required)")
+
+	_ = listForServiceCmd.MarkFlagRequired("service-id")
+	_ = listForServiceCmd.MarkFlagRequired("environment-id")
+}
+
+func runListForService(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	serviceID, _ := cmd.Flags().GetString("service-id")
+	environmentID, _ := cmd.Flags().GetString("environment-id")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		return err
+	}
+
+	result, err := dataaccess.ListSubscriptions(ctx, token, serviceID, environmentID)
+	if err != nil {
+		return err
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	return utils.PrintTextTableJsonArrayOutput(output, []interface{}{result})
+}

--- a/cmd/subscription/list_requests.go
+++ b/cmd/subscription/list_requests.go
@@ -1,0 +1,45 @@
+package subscription
+
+import (
+	"context"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+var listRequestsCmd = &cobra.Command{
+	Use:   "list-requests",
+	Short: "List subscription requests",
+	Long:  "List all pending and processed subscription requests for a service environment.",
+	RunE:  runListRequests,
+}
+
+func init() {
+	listRequestsCmd.Flags().StringP("service-id", "s", "", "Service ID (required)")
+	listRequestsCmd.Flags().StringP("environment-id", "e", "", "Environment ID (required)")
+
+	_ = listRequestsCmd.MarkFlagRequired("service-id")
+	_ = listRequestsCmd.MarkFlagRequired("environment-id")
+}
+
+func runListRequests(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	serviceID, _ := cmd.Flags().GetString("service-id")
+	environmentID, _ := cmd.Flags().GetString("environment-id")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		return err
+	}
+
+	result, err := dataaccess.ListSubscriptionRequests(ctx, token, serviceID, environmentID)
+	if err != nil {
+		return err
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	return utils.PrintTextTableJsonArrayOutput(output, []interface{}{result})
+}

--- a/cmd/subscription/resume.go
+++ b/cmd/subscription/resume.go
@@ -1,0 +1,47 @@
+package subscription
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/spf13/cobra"
+)
+
+var resumeCmd = &cobra.Command{
+	Use:   "resume <subscription-id>",
+	Short: "Resume a suspended subscription",
+	Long:  "Resume a previously suspended subscription for a service environment.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runResume,
+}
+
+func init() {
+	resumeCmd.Flags().StringP("service-id", "s", "", "Service ID (required)")
+	resumeCmd.Flags().StringP("environment-id", "e", "", "Environment ID (required)")
+
+	_ = resumeCmd.MarkFlagRequired("service-id")
+	_ = resumeCmd.MarkFlagRequired("environment-id")
+}
+
+func runResume(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	subscriptionID := args[0]
+	serviceID, _ := cmd.Flags().GetString("service-id")
+	environmentID, _ := cmd.Flags().GetString("environment-id")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		return err
+	}
+
+	err = dataaccess.ResumeSubscription(ctx, token, serviceID, environmentID, subscriptionID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Successfully resumed subscription %s\n", subscriptionID)
+	return nil
+}

--- a/cmd/subscription/subscription.go
+++ b/cmd/subscription/subscription.go
@@ -14,8 +14,15 @@ var Cmd = &cobra.Command{
 
 func init() {
 	Cmd.AddCommand(listCmd)
+	Cmd.AddCommand(listForServiceCmd)
 	Cmd.AddCommand(describeCmd)
-
+	Cmd.AddCommand(listRequestsCmd)
+	Cmd.AddCommand(approveRequestCmd)
+	Cmd.AddCommand(denyRequestCmd)
+	Cmd.AddCommand(createOnBehalfCmd)
+	Cmd.AddCommand(suspendCmd)
+	Cmd.AddCommand(resumeCmd)
+	Cmd.AddCommand(terminateCmd)
 }
 
 func run(cmd *cobra.Command, args []string) {

--- a/cmd/subscription/subscription_test.go
+++ b/cmd/subscription/subscription_test.go
@@ -1,0 +1,91 @@
+package subscription
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSubscriptionCommands(t *testing.T) {
+	require.Equal(t, "subscription [operation] [flags]", Cmd.Use)
+	require.Equal(t, "Manage Customer Subscriptions for your service", Cmd.Short)
+
+	// Check that all subcommands are added
+	expectedCommands := []string{
+		"list", "list-for-service", "describe", "list-requests",
+		"approve-request", "deny-request", "create-on-behalf",
+		"suspend", "resume", "terminate",
+	}
+	
+	for _, expectedCmd := range expectedCommands {
+		found := false
+		for _, cmd := range Cmd.Commands() {
+			cmdName := cmd.Use
+			if space := strings.Index(cmdName, " "); space != -1 {
+				cmdName = cmdName[:space]
+			}
+			if cmdName == expectedCmd {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "Expected subcommand %s not found", expectedCmd)
+	}
+}
+
+func TestListRequestsCommandFlags(t *testing.T) {
+	cmd := listRequestsCmd
+
+	require.Equal(t, "list-requests", cmd.Use)
+	require.Equal(t, "List subscription requests", cmd.Short)
+
+	// Check required flags
+	serviceIDFlag := cmd.Flags().Lookup("service-id")
+	require.NotNil(t, serviceIDFlag)
+	require.Equal(t, "s", serviceIDFlag.Shorthand)
+
+	environmentIDFlag := cmd.Flags().Lookup("environment-id")
+	require.NotNil(t, environmentIDFlag)
+	require.Equal(t, "e", environmentIDFlag.Shorthand)
+}
+
+func TestApproveRequestCommandFlags(t *testing.T) {
+	cmd := approveRequestCmd
+
+	require.Equal(t, "approve-request <request-id>", cmd.Use)
+	require.Equal(t, "Approve a subscription request", cmd.Short)
+
+	// Check required flags
+	serviceIDFlag := cmd.Flags().Lookup("service-id")
+	require.NotNil(t, serviceIDFlag)
+	require.Equal(t, "s", serviceIDFlag.Shorthand)
+
+	environmentIDFlag := cmd.Flags().Lookup("environment-id")
+	require.NotNil(t, environmentIDFlag)
+	require.Equal(t, "e", environmentIDFlag.Shorthand)
+}
+
+func TestCreateOnBehalfCommandFlags(t *testing.T) {
+	cmd := createOnBehalfCmd
+
+	require.Equal(t, "create-on-behalf", cmd.Use)
+	require.Equal(t, "Create subscription on behalf of customer", cmd.Short)
+
+	// Check required flags
+	requiredFlags := []string{"service-id", "environment-id", "product-tier-id", "customer-user-id"}
+	for _, flagName := range requiredFlags {
+		flag := cmd.Flags().Lookup(flagName)
+		require.NotNil(t, flag, "Expected required flag %s not found", flagName)
+	}
+
+	// Check optional flags
+	optionalFlags := []string{
+		"allow-creates-without-payment", "billing-provider", "custom-price",
+		"custom-price-per-unit", "external-payer-id", "max-instances", "price-effective-date",
+	}
+	for _, flagName := range optionalFlags {
+		flag := cmd.Flags().Lookup(flagName)
+		require.NotNil(t, flag, "Expected optional flag %s not found", flagName)
+	}
+}

--- a/cmd/subscription/suspend.go
+++ b/cmd/subscription/suspend.go
@@ -1,0 +1,47 @@
+package subscription
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/spf13/cobra"
+)
+
+var suspendCmd = &cobra.Command{
+	Use:   "suspend <subscription-id>",
+	Short: "Suspend a subscription",
+	Long:  "Temporarily suspend a subscription for a service environment.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runSuspend,
+}
+
+func init() {
+	suspendCmd.Flags().StringP("service-id", "s", "", "Service ID (required)")
+	suspendCmd.Flags().StringP("environment-id", "e", "", "Environment ID (required)")
+
+	_ = suspendCmd.MarkFlagRequired("service-id")
+	_ = suspendCmd.MarkFlagRequired("environment-id")
+}
+
+func runSuspend(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	subscriptionID := args[0]
+	serviceID, _ := cmd.Flags().GetString("service-id")
+	environmentID, _ := cmd.Flags().GetString("environment-id")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		return err
+	}
+
+	err = dataaccess.SuspendSubscription(ctx, token, serviceID, environmentID, subscriptionID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Successfully suspended subscription %s\n", subscriptionID)
+	return nil
+}

--- a/cmd/subscription/terminate.go
+++ b/cmd/subscription/terminate.go
@@ -1,0 +1,47 @@
+package subscription
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/spf13/cobra"
+)
+
+var terminateCmd = &cobra.Command{
+	Use:   "terminate <subscription-id>",
+	Short: "Terminate a subscription",
+	Long:  "Permanently terminate a subscription for a service environment.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runTerminate,
+}
+
+func init() {
+	terminateCmd.Flags().StringP("service-id", "s", "", "Service ID (required)")
+	terminateCmd.Flags().StringP("environment-id", "e", "", "Environment ID (required)")
+
+	_ = terminateCmd.MarkFlagRequired("service-id")
+	_ = terminateCmd.MarkFlagRequired("environment-id")
+}
+
+func runTerminate(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	subscriptionID := args[0]
+	serviceID, _ := cmd.Flags().GetString("service-id")
+	environmentID, _ := cmd.Flags().GetString("environment-id")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		return err
+	}
+
+	err = dataaccess.TerminateSubscription(ctx, token, serviceID, environmentID, subscriptionID)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Successfully terminated subscription %s\n", subscriptionID)
+	return nil
+}

--- a/cmd/upgrade/describe.go
+++ b/cmd/upgrade/describe.go
@@ -1,0 +1,47 @@
+package upgrade
+
+import (
+	"context"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+var describeCmd = &cobra.Command{
+	Use:   "describe <upgrade-path-id>",
+	Short: "Describe an upgrade path",
+	Long:  "Get detailed information about a specific upgrade path.",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runDescribe,
+}
+
+func init() {
+	describeCmd.Flags().StringP("service-id", "s", "", "Service ID (required)")
+	describeCmd.Flags().StringP("product-tier-id", "p", "", "Product tier ID (required)")
+
+	_ = describeCmd.MarkFlagRequired("service-id")
+	_ = describeCmd.MarkFlagRequired("product-tier-id")
+}
+
+func runDescribe(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	upgradePathID := args[0]
+	serviceID, _ := cmd.Flags().GetString("service-id")
+	productTierID, _ := cmd.Flags().GetString("product-tier-id")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		return err
+	}
+
+	result, err := dataaccess.DescribeUpgradePath(ctx, token, serviceID, productTierID, upgradePathID)
+	if err != nil {
+		return err
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	return utils.PrintTextTableJsonArrayOutput(output, []interface{}{result})
+}

--- a/cmd/upgrade/list.go
+++ b/cmd/upgrade/list.go
@@ -1,0 +1,69 @@
+package upgrade
+
+import (
+	"context"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+var listCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List upgrade paths",
+	Long:  "List upgrade paths for a service and product tier with filtering options.",
+	RunE:  runList,
+}
+
+func init() {
+	listCmd.Flags().StringP("service-id", "s", "", "Service ID (required)")
+	listCmd.Flags().StringP("product-tier-id", "p", "", "Product tier ID (required)")
+	listCmd.Flags().String("source-version", "", "Source product tier version to filter by")
+	listCmd.Flags().String("target-version", "", "Target product tier version to filter by")
+	listCmd.Flags().String("status", "", "Status of upgrade path to filter by")
+	listCmd.Flags().String("type", "", "Type of upgrade path to filter by")
+	listCmd.Flags().String("next-page-token", "", "Token for next page of results")
+	listCmd.Flags().Int64("page-size", 0, "Number of results per page")
+
+	_ = listCmd.MarkFlagRequired("service-id")
+	_ = listCmd.MarkFlagRequired("product-tier-id")
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	serviceID, _ := cmd.Flags().GetString("service-id")
+	productTierID, _ := cmd.Flags().GetString("product-tier-id")
+	sourceVersion, _ := cmd.Flags().GetString("source-version")
+	targetVersion, _ := cmd.Flags().GetString("target-version")
+	status, _ := cmd.Flags().GetString("status")
+	upgradeType, _ := cmd.Flags().GetString("type")
+	nextPageToken, _ := cmd.Flags().GetString("next-page-token")
+	pageSize, _ := cmd.Flags().GetInt64("page-size")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		return err
+	}
+
+	opts := &dataaccess.ListUpgradePathsOptions{
+		SourceProductTierVersion: sourceVersion,
+		TargetProductTierVersion: targetVersion,
+		Status:                   status,
+		Type:                     upgradeType,
+		NextPageToken:            nextPageToken,
+	}
+
+	if pageSize > 0 {
+		opts.PageSize = &pageSize
+	}
+
+	result, err := dataaccess.ListUpgradePaths(ctx, token, serviceID, productTierID, opts)
+	if err != nil {
+		return err
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	return utils.PrintTextTableJsonArrayOutput(output, []interface{}{result})
+}

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -47,6 +47,8 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
+	Cmd.AddCommand(listCmd)
+	Cmd.AddCommand(describeCmd)
 	Cmd.AddCommand(status.Cmd)
 	Cmd.AddCommand(manageupgradelifecycle.CancelCmd)
 	Cmd.AddCommand(manageupgradelifecycle.ResumeCmd)

--- a/cmd/upgrade/upgrade_test.go
+++ b/cmd/upgrade/upgrade_test.go
@@ -1,0 +1,64 @@
+package upgrade
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpgradeCommands(t *testing.T) {
+	require.Equal(t, "upgrade --version=[version]", Cmd.Use)
+	require.Equal(t, "Upgrade Instance Deployments to a newer or older version", Cmd.Short)
+
+	// Check that new subcommands are added
+	subCommands := []string{"list", "describe"}
+	for _, subCmd := range subCommands {
+		found := false
+		for _, cmd := range Cmd.Commands() {
+			if cmd.Use == subCmd || cmd.Use == subCmd+" <upgrade-path-id>" {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "Expected subcommand %s not found", subCmd)
+	}
+}
+
+func TestListCommandFlags(t *testing.T) {
+	cmd := listCmd
+
+	require.Equal(t, "list", cmd.Use)
+	require.Equal(t, "List upgrade paths", cmd.Short)
+
+	// Check required flags
+	serviceIDFlag := cmd.Flags().Lookup("service-id")
+	require.NotNil(t, serviceIDFlag)
+	require.Equal(t, "s", serviceIDFlag.Shorthand)
+
+	productTierIDFlag := cmd.Flags().Lookup("product-tier-id")
+	require.NotNil(t, productTierIDFlag)
+	require.Equal(t, "p", productTierIDFlag.Shorthand)
+
+	// Check optional flags
+	flags := []string{"source-version", "target-version", "status", "type", "next-page-token", "page-size"}
+	for _, flagName := range flags {
+		flag := cmd.Flags().Lookup(flagName)
+		require.NotNil(t, flag, "Expected flag %s not found", flagName)
+	}
+}
+
+func TestDescribeCommandFlags(t *testing.T) {
+	cmd := describeCmd
+
+	require.Equal(t, "describe <upgrade-path-id>", cmd.Use)
+	require.Equal(t, "Describe an upgrade path", cmd.Short)
+
+	// Check required flags
+	serviceIDFlag := cmd.Flags().Lookup("service-id")
+	require.NotNil(t, serviceIDFlag)
+	require.Equal(t, "s", serviceIDFlag.Shorthand)
+
+	productTierIDFlag := cmd.Flags().Lookup("product-tier-id")
+	require.NotNil(t, productTierIDFlag)
+	require.Equal(t, "p", productTierIDFlag.Shorthand)
+}

--- a/internal/dataaccess/audit.go
+++ b/internal/dataaccess/audit.go
@@ -1,0 +1,71 @@
+package dataaccess
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
+)
+
+type ListAuditEventsOptions struct {
+	NextPageToken    string
+	PageSize         *int64
+	ServiceID        string
+	EnvironmentType  string
+	EventSourceTypes []string
+	InstanceID       string
+	ProductTierID    string
+	StartDate        *time.Time
+	EndDate          *time.Time
+}
+
+func ListAuditEvents(ctx context.Context, token string, opts *ListAuditEventsOptions) (resp *openapiclientfleet.FleetAuditEventsResult, err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.AuditEventsApiAPI.AuditEventsApiAuditEvents(ctxWithToken)
+
+	if opts != nil {
+		if opts.NextPageToken != "" {
+			req = req.NextPageToken(opts.NextPageToken)
+		}
+		if opts.PageSize != nil {
+			req = req.PageSize(*opts.PageSize)
+		}
+		if opts.ServiceID != "" {
+			req = req.ServiceID(opts.ServiceID)
+		}
+		if opts.EnvironmentType != "" {
+			req = req.EnvironmentType(opts.EnvironmentType)
+		}
+		if len(opts.EventSourceTypes) > 0 {
+			req = req.EventSourceTypes(opts.EventSourceTypes)
+		}
+		if opts.InstanceID != "" {
+			req = req.InstanceID(opts.InstanceID)
+		}
+		if opts.ProductTierID != "" {
+			req = req.ProductTierID(opts.ProductTierID)
+		}
+		if opts.StartDate != nil {
+			req = req.StartDate(*opts.StartDate)
+		}
+		if opts.EndDate != nil {
+			req = req.EndDate(*opts.EndDate)
+		}
+	}
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	resp, r, err = req.Execute()
+	if err != nil {
+		return nil, handleFleetError(err)
+	}
+	return
+}

--- a/internal/dataaccess/inventory.go
+++ b/internal/dataaccess/inventory.go
@@ -2,6 +2,7 @@ package dataaccess
 
 import (
 	"context"
+	"net/http"
 
 	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
 )
@@ -26,4 +27,80 @@ func SearchInventory(ctx context.Context, token, query string) (*openapiclientfl
 
 	r.Body.Close()
 	return res, nil
+}
+
+func ListInstanceSnapshots(ctx context.Context, token, serviceID, environmentID, instanceID string) (resp *openapiclientfleet.FleetListInstanceSnapshotResult, err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.InventoryApiAPI.InventoryApiListResourceInstanceSnapshots(
+		ctxWithToken,
+		serviceID,
+		environmentID,
+		instanceID,
+	)
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	resp, r, err = req.Execute()
+	if err != nil {
+		return nil, handleFleetError(err)
+	}
+	return
+}
+
+func DescribeInstanceSnapshot(ctx context.Context, token, serviceID, environmentID, instanceID, snapshotID string) (resp *openapiclientfleet.FleetDescribeInstanceSnapshotResult, err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.InventoryApiAPI.InventoryApiDescribeResourceInstanceSnapshot(
+		ctxWithToken,
+		serviceID,
+		environmentID,
+		instanceID,
+		snapshotID,
+	)
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	resp, r, err = req.Execute()
+	if err != nil {
+		return nil, handleFleetError(err)
+	}
+	return
+}
+
+func CreateInstanceSnapshot(ctx context.Context, token, serviceID, environmentID, instanceID string) (resp *openapiclientfleet.FleetCreateInstanceSnapshotResult, err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.InventoryApiAPI.InventoryApiCreateResourceInstanceSnapshot(
+		ctxWithToken,
+		serviceID,
+		environmentID,
+		instanceID,
+	)
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	resp, r, err = req.Execute()
+	if err != nil {
+		return nil, handleFleetError(err)
+	}
+	return
 }

--- a/internal/dataaccess/operations.go
+++ b/internal/dataaccess/operations.go
@@ -1,0 +1,135 @@
+package dataaccess
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
+)
+
+type DeploymentCellHealthOptions struct {
+	HostClusterID        string
+	ServiceID            string
+	ServiceEnvironmentID string
+}
+
+func GetDeploymentCellHealth(ctx context.Context, token string, opts *DeploymentCellHealthOptions) (res *openapiclientfleet.DeploymentCellHealthDetail, err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.OperationsApiAPI.OperationsApiDeploymentCellHealth(ctxWithToken)
+
+	if opts != nil {
+		if opts.HostClusterID != "" {
+			req = req.HostClusterID(opts.HostClusterID)
+		}
+		if opts.ServiceID != "" {
+			req = req.ServiceID(opts.ServiceID)
+		}
+		if opts.ServiceEnvironmentID != "" {
+			req = req.ServiceEnvironmentID(opts.ServiceEnvironmentID)
+		}
+	}
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	res, r, err = req.Execute()
+	if err != nil {
+		return nil, handleFleetError(err)
+	}
+	return
+}
+
+func GetServiceHealth(ctx context.Context, token string, serviceID, serviceEnvironmentID string) (res *openapiclientfleet.ServiceHealthSummary, err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.OperationsApiAPI.OperationsApiServiceHealth(ctxWithToken).
+		ServiceID(serviceID).
+		ServiceEnvironmentID(serviceEnvironmentID)
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	res, r, err = req.Execute()
+	if err != nil {
+		return nil, handleFleetError(err)
+	}
+	return
+}
+
+type ListEventsOptions struct {
+	NextPageToken        string
+	PageSize             *int64
+	EnvironmentType      string
+	EventTypes           []string
+	ServiceID            string
+	ServiceEnvironmentID string
+	InstanceID           string
+	StartDate            *time.Time
+	EndDate              *time.Time
+	ProductTierID        string
+}
+
+func ListOperationsEvents(ctx context.Context, token string, opts *ListEventsOptions) (res *openapiclientfleet.ListServiceProviderEventsResult, err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.OperationsApiAPI.OperationsApiListEvents(ctxWithToken)
+
+	if opts != nil {
+		if opts.NextPageToken != "" {
+			req = req.NextPageToken(opts.NextPageToken)
+		}
+		if opts.PageSize != nil {
+			req = req.PageSize(*opts.PageSize)
+		}
+		if opts.EnvironmentType != "" {
+			req = req.EnvironmentType(opts.EnvironmentType)
+		}
+		if len(opts.EventTypes) > 0 {
+			req = req.EventTypes(opts.EventTypes)
+		}
+		if opts.ServiceID != "" {
+			req = req.ServiceID(opts.ServiceID)
+		}
+		if opts.ServiceEnvironmentID != "" {
+			req = req.ServiceEnvironmentID(opts.ServiceEnvironmentID)
+		}
+		if opts.InstanceID != "" {
+			req = req.InstanceID(opts.InstanceID)
+		}
+		if opts.StartDate != nil {
+			req = req.StartDate(*opts.StartDate)
+		}
+		if opts.EndDate != nil {
+			req = req.EndDate(*opts.EndDate)
+		}
+		if opts.ProductTierID != "" {
+			req = req.ProductTierID(opts.ProductTierID)
+		}
+	}
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	res, r, err = req.Execute()
+	if err != nil {
+		return nil, handleFleetError(err)
+	}
+	return
+}

--- a/internal/dataaccess/subscription.go
+++ b/internal/dataaccess/subscription.go
@@ -119,3 +119,264 @@ func GetSubscriptionByCustomerEmail(ctx context.Context, token string, serviceID
 	err = errors.New("no subscription found for the given customer email or the plan does not exist")
 	return
 }
+
+func ListSubscriptions(ctx context.Context, token string, serviceID, environmentID string) (resp *openapiclientfleet.FleetListSubscriptionsResult, err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.InventoryApiAPI.InventoryApiListSubscription(
+		ctxWithToken,
+		serviceID,
+		environmentID,
+	)
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	resp, r, err = req.Execute()
+	if err != nil {
+		return nil, handleFleetError(err)
+	}
+	return
+}
+
+func ListSubscriptionRequests(ctx context.Context, token string, serviceID, environmentID string) (resp *openapiclientfleet.ListSubscriptionRequestsResult, err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.InventoryApiAPI.InventoryApiListSubscriptionRequests(
+		ctxWithToken,
+		serviceID,
+		environmentID,
+	)
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	resp, r, err = req.Execute()
+	if err != nil {
+		return nil, handleFleetError(err)
+	}
+	return
+}
+
+func DescribeSubscriptionRequest(ctx context.Context, token string, serviceID, environmentID, requestID string) (resp *openapiclientfleet.DescribeSubscriptionRequestResult, err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.InventoryApiAPI.InventoryApiDescribeSubscriptionRequest(
+		ctxWithToken,
+		serviceID,
+		environmentID,
+		requestID,
+	)
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	resp, r, err = req.Execute()
+	if err != nil {
+		return nil, handleFleetError(err)
+	}
+	return
+}
+
+func ApproveSubscriptionRequest(ctx context.Context, token string, serviceID, environmentID, requestID string) (err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.InventoryApiAPI.InventoryApiApproveSubscriptionRequest(
+		ctxWithToken,
+		serviceID,
+		environmentID,
+		requestID,
+	)
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	r, err = req.Execute()
+	if err != nil {
+		return handleFleetError(err)
+	}
+	return
+}
+
+func DenySubscriptionRequest(ctx context.Context, token string, serviceID, environmentID, requestID string) (err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.InventoryApiAPI.InventoryApiDenySubscriptionRequest(
+		ctxWithToken,
+		serviceID,
+		environmentID,
+		requestID,
+	)
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	r, err = req.Execute()
+	if err != nil {
+		return handleFleetError(err)
+	}
+	return
+}
+
+type CreateSubscriptionOnBehalfOptions struct {
+	ProductTierID                          string
+	OnBehalfOfCustomerUserID               string
+	AllowCreatesWhenPaymentNotConfigured   *bool
+	BillingProvider                        string
+	CustomPrice                            *bool
+	CustomPricePerUnit                     map[string]interface{}
+	ExternalPayerID                        string
+	MaxNumberOfInstances                   *int64
+	PriceEffectiveDate                     string
+}
+
+func CreateSubscriptionOnBehalf(ctx context.Context, token string, serviceID, environmentID string, opts *CreateSubscriptionOnBehalfOptions) (resp *openapiclientfleet.FleetCreateSubscriptionOnBehalfOfCustomerResult, err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	requestBody := openapiclientfleet.FleetCreateSubscriptionOnBehalfOfCustomerRequest2{
+		ProductTierId:            opts.ProductTierID,
+		OnBehalfOfCustomerUserId: opts.OnBehalfOfCustomerUserID,
+	}
+
+	if opts.AllowCreatesWhenPaymentNotConfigured != nil {
+		requestBody.AllowCreatesWhenPaymentNotConfigured = opts.AllowCreatesWhenPaymentNotConfigured
+	}
+	if opts.BillingProvider != "" {
+		requestBody.BillingProvider = &opts.BillingProvider
+	}
+	if opts.CustomPrice != nil {
+		requestBody.CustomPrice = opts.CustomPrice
+	}
+	if opts.CustomPricePerUnit != nil {
+		requestBody.CustomPricePerUnit = opts.CustomPricePerUnit
+	}
+	if opts.ExternalPayerID != "" {
+		requestBody.ExternalPayerId = &opts.ExternalPayerID
+	}
+	if opts.MaxNumberOfInstances != nil {
+		requestBody.MaxNumberOfInstances = opts.MaxNumberOfInstances
+	}
+	if opts.PriceEffectiveDate != "" {
+		requestBody.PriceEffectiveDate = &opts.PriceEffectiveDate
+	}
+
+	req := apiClient.InventoryApiAPI.InventoryApiCreateSubscriptionOnBehalfOfCustomer(
+		ctxWithToken,
+		serviceID,
+		environmentID,
+	).FleetCreateSubscriptionOnBehalfOfCustomerRequest2(requestBody)
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	resp, r, err = req.Execute()
+	if err != nil {
+		return nil, handleFleetError(err)
+	}
+	return
+}
+
+func SuspendSubscription(ctx context.Context, token string, serviceID, environmentID, subscriptionID string) (err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.InventoryApiAPI.InventoryApiSuspendSubscription(
+		ctxWithToken,
+		serviceID,
+		environmentID,
+		subscriptionID,
+	)
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	r, err = req.Execute()
+	if err != nil {
+		return handleFleetError(err)
+	}
+	return
+}
+
+func ResumeSubscription(ctx context.Context, token string, serviceID, environmentID, subscriptionID string) (err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.InventoryApiAPI.InventoryApiResumeSubscription(
+		ctxWithToken,
+		serviceID,
+		environmentID,
+		subscriptionID,
+	)
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	r, err = req.Execute()
+	if err != nil {
+		return handleFleetError(err)
+	}
+	return
+}
+
+func TerminateSubscription(ctx context.Context, token string, serviceID, environmentID, subscriptionID string) (err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.InventoryApiAPI.InventoryApiTerminateSubscription(
+		ctxWithToken,
+		serviceID,
+		environmentID,
+		subscriptionID,
+	)
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	r, err = req.Execute()
+	if err != nil {
+		return handleFleetError(err)
+	}
+	return
+}

--- a/mkdocs/docs/omnistrate-ctl.md
+++ b/mkdocs/docs/omnistrate-ctl.md
@@ -37,6 +37,7 @@ omnistrate-ctl [flags]
 
 * [omnistrate-ctl account](omnistrate-ctl_account.md)	 - Manage your Cloud Provider Accounts
 * [omnistrate-ctl alarms](omnistrate-ctl_alarms.md)	 - Manage alarms and notification channels
+* [omnistrate-ctl audit](omnistrate-ctl_audit.md)	 - Audit events and logging management
 * [omnistrate-ctl build](omnistrate-ctl_build.md)	 - Build Services from image, compose spec or service plan spec
 * [omnistrate-ctl build-from-repo](omnistrate-ctl_build-from-repo.md)	 - Build Service from Git Repository
 * [omnistrate-ctl cost](omnistrate-ctl_cost.md)	 - Manage cost analytics for your services
@@ -50,6 +51,7 @@ omnistrate-ctl [flags]
 * [omnistrate-ctl login](omnistrate-ctl_login.md)	 - Log in to the Omnistrate platform
 * [omnistrate-ctl logout](omnistrate-ctl_logout.md)	 - Logout
 * [omnistrate-ctl mcp](omnistrate-ctl_mcp.md)	 - MCP server management
+* [omnistrate-ctl operations](omnistrate-ctl_operations.md)	 - Operations and health monitoring commands
 * [omnistrate-ctl secret](omnistrate-ctl_secret.md)	 - Manage secrets
 * [omnistrate-ctl service](omnistrate-ctl_service.md)	 - Manage Services for your account
 * [omnistrate-ctl service-plan](omnistrate-ctl_service-plan.md)	 - Manage Service Plans for your service

--- a/mkdocs/docs/omnistrate-ctl_audit.md
+++ b/mkdocs/docs/omnistrate-ctl_audit.md
@@ -1,0 +1,26 @@
+## omnistrate-ctl audit
+
+Audit events and logging management
+
+### Synopsis
+
+Access and manage audit events for services, instances, and operations.
+
+### Options
+
+```
+  -h, --help   help for audit
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl](omnistrate-ctl.md)	 - Manage your Omnistrate SaaS from the command line
+* [omnistrate-ctl audit list](omnistrate-ctl_audit_list.md)	 - List audit events
+

--- a/mkdocs/docs/omnistrate-ctl_audit_list.md
+++ b/mkdocs/docs/omnistrate-ctl_audit_list.md
@@ -1,0 +1,38 @@
+## omnistrate-ctl audit list
+
+List audit events
+
+### Synopsis
+
+List audit events with detailed filtering options for services, instances, and time ranges.
+
+```
+omnistrate-ctl audit list [flags]
+```
+
+### Options
+
+```
+      --end-date string              End date for events (RFC3339 format)
+  -e, --environment-type string      Environment type to filter by
+      --event-source-types strings   Event source types to filter by (comma-separated)
+  -h, --help                         help for list
+  -i, --instance-id string           Instance ID to filter by
+      --next-page-token string       Token for next page of results
+      --page-size int                Number of results per page
+      --product-tier-id string       Product tier ID to filter by
+  -s, --service-id string            Service ID to filter by
+      --start-date string            Start date for events (RFC3339 format)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl audit](omnistrate-ctl_audit.md)	 - Audit events and logging management
+

--- a/mkdocs/docs/omnistrate-ctl_instance.md
+++ b/mkdocs/docs/omnistrate-ctl_instance.md
@@ -32,6 +32,7 @@ omnistrate-ctl instance [operation] [flags]
 * [omnistrate-ctl instance debug](omnistrate-ctl_instance_debug.md)	 - Debug instance resources
 * [omnistrate-ctl instance delete](omnistrate-ctl_instance_delete.md)	 - Delete an instance deployment
 * [omnistrate-ctl instance describe](omnistrate-ctl_instance_describe.md)	 - Describe an instance deployment for your service
+* [omnistrate-ctl instance describe-snapshot](omnistrate-ctl_instance_describe-snapshot.md)	 - Describe a specific instance snapshot
 * [omnistrate-ctl instance disable-debug-mode](omnistrate-ctl_instance_disable-debug-mode.md)	 - Disable debug mode for an instance deployment
 * [omnistrate-ctl instance enable-debug-mode](omnistrate-ctl_instance_enable-debug-mode.md)	 - Enable debug mode for an instance deployment
 * [omnistrate-ctl instance evaluate](omnistrate-ctl_instance_evaluate.md)	 - Evaluate an expression in the context of an instance

--- a/mkdocs/docs/omnistrate-ctl_instance_describe-snapshot.md
+++ b/mkdocs/docs/omnistrate-ctl_instance_describe-snapshot.md
@@ -1,0 +1,36 @@
+## omnistrate-ctl instance describe-snapshot
+
+Describe a specific instance snapshot
+
+### Synopsis
+
+This command helps you get detailed information about a specific snapshot for your instance.
+
+```
+omnistrate-ctl instance describe-snapshot [instance-id] [snapshot-id] [flags]
+```
+
+### Examples
+
+```
+# Describe a specific snapshot
+omctl instance describe-snapshot instance-abcd1234 snapshot-xyz789
+```
+
+### Options
+
+```
+  -h, --help   help for describe-snapshot
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl instance](omnistrate-ctl_instance.md)	 - Manage Instance Deployments for your service
+

--- a/mkdocs/docs/omnistrate-ctl_operations.md
+++ b/mkdocs/docs/omnistrate-ctl_operations.md
@@ -1,0 +1,28 @@
+## omnistrate-ctl operations
+
+Operations and health monitoring commands
+
+### Synopsis
+
+Manage and monitor operational health of your services, deployment cells, and infrastructure.
+
+### Options
+
+```
+  -h, --help   help for operations
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl](omnistrate-ctl.md)	 - Manage your Omnistrate SaaS from the command line
+* [omnistrate-ctl operations deployment-cell-health](omnistrate-ctl_operations_deployment-cell-health.md)	 - Get deployment cell health details
+* [omnistrate-ctl operations events](omnistrate-ctl_operations_events.md)	 - List operational events
+* [omnistrate-ctl operations health](omnistrate-ctl_operations_health.md)	 - Get service health summary
+

--- a/mkdocs/docs/omnistrate-ctl_operations_deployment-cell-health.md
+++ b/mkdocs/docs/omnistrate-ctl_operations_deployment-cell-health.md
@@ -1,0 +1,32 @@
+## omnistrate-ctl operations deployment-cell-health
+
+Get deployment cell health details
+
+### Synopsis
+
+Get detailed health information for deployment cells, including host clusters and services.
+
+```
+omnistrate-ctl operations deployment-cell-health [flags]
+```
+
+### Options
+
+```
+  -e, --environment-id string    Service environment ID to get health for
+  -h, --help                     help for deployment-cell-health
+      --host-cluster-id string   Host cluster ID to get health for
+  -s, --service-id string        Service ID to get health for
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl operations](omnistrate-ctl_operations.md)	 - Operations and health monitoring commands
+

--- a/mkdocs/docs/omnistrate-ctl_operations_events.md
+++ b/mkdocs/docs/omnistrate-ctl_operations_events.md
@@ -1,0 +1,39 @@
+## omnistrate-ctl operations events
+
+List operational events
+
+### Synopsis
+
+List operational events for services, environments, and instances with filtering options.
+
+```
+omnistrate-ctl operations events [flags]
+```
+
+### Options
+
+```
+      --end-date string                 End date of events (RFC3339 format)
+  -e, --environment-type string         Environment type to filter by
+      --event-types strings             Event types to filter by (comma-separated)
+  -h, --help                            help for events
+  -i, --instance-id string              Instance ID to list events for
+      --next-page-token string          Token for next page of results
+      --page-size int                   Number of results per page
+      --product-tier-id string          Product tier ID to filter by
+      --service-environment-id string   Service environment ID to list events for
+  -s, --service-id string               Service ID to list events for
+      --start-date string               Start date of events (RFC3339 format)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl operations](omnistrate-ctl_operations.md)	 - Operations and health monitoring commands
+

--- a/mkdocs/docs/omnistrate-ctl_operations_health.md
+++ b/mkdocs/docs/omnistrate-ctl_operations_health.md
@@ -1,0 +1,31 @@
+## omnistrate-ctl operations health
+
+Get service health summary
+
+### Synopsis
+
+Get the overall health status of a service and its environment.
+
+```
+omnistrate-ctl operations health [flags]
+```
+
+### Options
+
+```
+  -e, --environment-id string   Service environment ID (required)
+  -h, --help                    help for health
+  -s, --service-id string       Service ID (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl operations](omnistrate-ctl_operations.md)	 - Operations and health monitoring commands
+

--- a/mkdocs/docs/omnistrate-ctl_subscription.md
+++ b/mkdocs/docs/omnistrate-ctl_subscription.md
@@ -26,6 +26,14 @@ omnistrate-ctl subscription [operation] [flags]
 ### SEE ALSO
 
 * [omnistrate-ctl](omnistrate-ctl.md)	 - Manage your Omnistrate SaaS from the command line
+* [omnistrate-ctl subscription approve-request](omnistrate-ctl_subscription_approve-request.md)	 - Approve a subscription request
+* [omnistrate-ctl subscription create-on-behalf](omnistrate-ctl_subscription_create-on-behalf.md)	 - Create subscription on behalf of customer
+* [omnistrate-ctl subscription deny-request](omnistrate-ctl_subscription_deny-request.md)	 - Deny a subscription request
 * [omnistrate-ctl subscription describe](omnistrate-ctl_subscription_describe.md)	 - Describe a Customer Subscription to your service
 * [omnistrate-ctl subscription list](omnistrate-ctl_subscription_list.md)	 - List Customer Subscriptions to your services
+* [omnistrate-ctl subscription list-for-service](omnistrate-ctl_subscription_list-for-service.md)	 - List subscriptions for a specific service environment
+* [omnistrate-ctl subscription list-requests](omnistrate-ctl_subscription_list-requests.md)	 - List subscription requests
+* [omnistrate-ctl subscription resume](omnistrate-ctl_subscription_resume.md)	 - Resume a suspended subscription
+* [omnistrate-ctl subscription suspend](omnistrate-ctl_subscription_suspend.md)	 - Suspend a subscription
+* [omnistrate-ctl subscription terminate](omnistrate-ctl_subscription_terminate.md)	 - Terminate a subscription
 

--- a/mkdocs/docs/omnistrate-ctl_subscription_approve-request.md
+++ b/mkdocs/docs/omnistrate-ctl_subscription_approve-request.md
@@ -1,0 +1,31 @@
+## omnistrate-ctl subscription approve-request
+
+Approve a subscription request
+
+### Synopsis
+
+Approve a pending subscription request for a service environment.
+
+```
+omnistrate-ctl subscription approve-request <request-id> [flags]
+```
+
+### Options
+
+```
+  -e, --environment-id string   Environment ID (required)
+  -h, --help                    help for approve-request
+  -s, --service-id string       Service ID (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl subscription](omnistrate-ctl_subscription.md)	 - Manage Customer Subscriptions for your service
+

--- a/mkdocs/docs/omnistrate-ctl_subscription_create-on-behalf.md
+++ b/mkdocs/docs/omnistrate-ctl_subscription_create-on-behalf.md
@@ -1,0 +1,40 @@
+## omnistrate-ctl subscription create-on-behalf
+
+Create subscription on behalf of customer
+
+### Synopsis
+
+Create a subscription on behalf of a customer for a service environment.
+
+```
+omnistrate-ctl subscription create-on-behalf [flags]
+```
+
+### Options
+
+```
+      --allow-creates-without-payment   Allow creation without payment configured
+      --billing-provider string         Billing provider
+      --custom-price                    Whether to use custom price
+      --custom-price-per-unit string    Custom price per unit (JSON object)
+      --customer-user-id string         Customer user ID (required)
+  -e, --environment-id string           Environment ID (required)
+      --external-payer-id string        External payer ID
+  -h, --help                            help for create-on-behalf
+      --max-instances int               Maximum number of instances
+      --price-effective-date string     Price effective date
+      --product-tier-id string          Product tier ID (required)
+  -s, --service-id string               Service ID (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl subscription](omnistrate-ctl_subscription.md)	 - Manage Customer Subscriptions for your service
+

--- a/mkdocs/docs/omnistrate-ctl_subscription_deny-request.md
+++ b/mkdocs/docs/omnistrate-ctl_subscription_deny-request.md
@@ -1,0 +1,31 @@
+## omnistrate-ctl subscription deny-request
+
+Deny a subscription request
+
+### Synopsis
+
+Deny a pending subscription request for a service environment.
+
+```
+omnistrate-ctl subscription deny-request <request-id> [flags]
+```
+
+### Options
+
+```
+  -e, --environment-id string   Environment ID (required)
+  -h, --help                    help for deny-request
+  -s, --service-id string       Service ID (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl subscription](omnistrate-ctl_subscription.md)	 - Manage Customer Subscriptions for your service
+

--- a/mkdocs/docs/omnistrate-ctl_subscription_list-for-service.md
+++ b/mkdocs/docs/omnistrate-ctl_subscription_list-for-service.md
@@ -1,0 +1,31 @@
+## omnistrate-ctl subscription list-for-service
+
+List subscriptions for a specific service environment
+
+### Synopsis
+
+List all subscriptions for a specific service and environment using fleet API.
+
+```
+omnistrate-ctl subscription list-for-service [flags]
+```
+
+### Options
+
+```
+  -e, --environment-id string   Environment ID (required)
+  -h, --help                    help for list-for-service
+  -s, --service-id string       Service ID (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl subscription](omnistrate-ctl_subscription.md)	 - Manage Customer Subscriptions for your service
+

--- a/mkdocs/docs/omnistrate-ctl_subscription_list-requests.md
+++ b/mkdocs/docs/omnistrate-ctl_subscription_list-requests.md
@@ -1,0 +1,31 @@
+## omnistrate-ctl subscription list-requests
+
+List subscription requests
+
+### Synopsis
+
+List all pending and processed subscription requests for a service environment.
+
+```
+omnistrate-ctl subscription list-requests [flags]
+```
+
+### Options
+
+```
+  -e, --environment-id string   Environment ID (required)
+  -h, --help                    help for list-requests
+  -s, --service-id string       Service ID (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl subscription](omnistrate-ctl_subscription.md)	 - Manage Customer Subscriptions for your service
+

--- a/mkdocs/docs/omnistrate-ctl_subscription_resume.md
+++ b/mkdocs/docs/omnistrate-ctl_subscription_resume.md
@@ -1,0 +1,31 @@
+## omnistrate-ctl subscription resume
+
+Resume a suspended subscription
+
+### Synopsis
+
+Resume a previously suspended subscription for a service environment.
+
+```
+omnistrate-ctl subscription resume <subscription-id> [flags]
+```
+
+### Options
+
+```
+  -e, --environment-id string   Environment ID (required)
+  -h, --help                    help for resume
+  -s, --service-id string       Service ID (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl subscription](omnistrate-ctl_subscription.md)	 - Manage Customer Subscriptions for your service
+

--- a/mkdocs/docs/omnistrate-ctl_subscription_suspend.md
+++ b/mkdocs/docs/omnistrate-ctl_subscription_suspend.md
@@ -1,0 +1,31 @@
+## omnistrate-ctl subscription suspend
+
+Suspend a subscription
+
+### Synopsis
+
+Temporarily suspend a subscription for a service environment.
+
+```
+omnistrate-ctl subscription suspend <subscription-id> [flags]
+```
+
+### Options
+
+```
+  -e, --environment-id string   Environment ID (required)
+  -h, --help                    help for suspend
+  -s, --service-id string       Service ID (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl subscription](omnistrate-ctl_subscription.md)	 - Manage Customer Subscriptions for your service
+

--- a/mkdocs/docs/omnistrate-ctl_subscription_terminate.md
+++ b/mkdocs/docs/omnistrate-ctl_subscription_terminate.md
@@ -1,0 +1,31 @@
+## omnistrate-ctl subscription terminate
+
+Terminate a subscription
+
+### Synopsis
+
+Permanently terminate a subscription for a service environment.
+
+```
+omnistrate-ctl subscription terminate <subscription-id> [flags]
+```
+
+### Options
+
+```
+  -e, --environment-id string   Environment ID (required)
+  -h, --help                    help for terminate
+  -s, --service-id string       Service ID (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl subscription](omnistrate-ctl_subscription.md)	 - Manage Customer Subscriptions for your service
+

--- a/mkdocs/docs/omnistrate-ctl_upgrade.md
+++ b/mkdocs/docs/omnistrate-ctl_upgrade.md
@@ -53,6 +53,8 @@ omctl upgrade [instance-id] --version=2.0 --max-concurrent-upgrades=5
 
 * [omnistrate-ctl](omnistrate-ctl.md)	 - Manage your Omnistrate SaaS from the command line
 * [omnistrate-ctl upgrade cancel](omnistrate-ctl_upgrade_cancel.md)	 - Cancel an uncompleted upgrade
+* [omnistrate-ctl upgrade describe](omnistrate-ctl_upgrade_describe.md)	 - Describe an upgrade path
+* [omnistrate-ctl upgrade list](omnistrate-ctl_upgrade_list.md)	 - List upgrade paths
 * [omnistrate-ctl upgrade notify-customer](omnistrate-ctl_upgrade_notify-customer.md)	 - Enable customer notifications for a scheduled upgrade
 * [omnistrate-ctl upgrade pause](omnistrate-ctl_upgrade_pause.md)	 - Pause an ongoing upgrade
 * [omnistrate-ctl upgrade resume](omnistrate-ctl_upgrade_resume.md)	 - Resume a paused upgrade

--- a/mkdocs/docs/omnistrate-ctl_upgrade_describe.md
+++ b/mkdocs/docs/omnistrate-ctl_upgrade_describe.md
@@ -1,0 +1,31 @@
+## omnistrate-ctl upgrade describe
+
+Describe an upgrade path
+
+### Synopsis
+
+Get detailed information about a specific upgrade path.
+
+```
+omnistrate-ctl upgrade describe <upgrade-path-id> [flags]
+```
+
+### Options
+
+```
+  -h, --help                     help for describe
+  -p, --product-tier-id string   Product tier ID (required)
+  -s, --service-id string        Service ID (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl upgrade](omnistrate-ctl_upgrade.md)	 - Upgrade Instance Deployments to a newer or older version
+

--- a/mkdocs/docs/omnistrate-ctl_upgrade_list.md
+++ b/mkdocs/docs/omnistrate-ctl_upgrade_list.md
@@ -1,0 +1,37 @@
+## omnistrate-ctl upgrade list
+
+List upgrade paths
+
+### Synopsis
+
+List upgrade paths for a service and product tier with filtering options.
+
+```
+omnistrate-ctl upgrade list [flags]
+```
+
+### Options
+
+```
+  -h, --help                     help for list
+      --next-page-token string   Token for next page of results
+      --page-size int            Number of results per page
+  -p, --product-tier-id string   Product tier ID (required)
+  -s, --service-id string        Service ID (required)
+      --source-version string    Source product tier version to filter by
+      --status string            Status of upgrade path to filter by
+      --target-version string    Target product tier version to filter by
+      --type string              Type of upgrade path to filter by
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl upgrade](omnistrate-ctl_upgrade.md)	 - Upgrade Instance Deployments to a newer or older version
+


### PR DESCRIPTION
✅ Operations command - Health monitoring with subcommands for service health, deployment cell health, and events 
✅ Extended subscription command - Added 8 new operations including list-requests, approve/deny, create-on-behalf, suspend/resume/terminate 
✅ Audit command - Event listing with comprehensive filtering options 
✅ Instance snapshot functionality - Added describe-snapshot subcommand (list-snapshots already existed) 
✅ Extended upgrade command - Added list and describe subcommands for upgrade path management 
✅ Data access functions - Created comprehensive SDK integration layers for all new commands