### PR TITLE
Revert to async status for instance create, modify and update by default

### DIFF
--- a/cmd/instance/create.go
+++ b/cmd/instance/create.go
@@ -21,7 +21,10 @@ const (
 omctl instance create --service=mysql --environment=dev --plan=mysql --version=latest --resource=mySQL --cloud-provider=aws --region=ca-central-1 --param '{"databaseName":"default","password":"a_secure_password","rootPassword":"a_secure_root_password","username":"user"}'
 
 # Create an instance deployment with parameters from a file
-omctl instance create --service=mysql --environment=dev --plan=mysql --version=latest --resource=mySQL --cloud-provider=aws --region=ca-central-1 --param-file /path/to/params.json`
+omctl instance create --service=mysql --environment=dev --plan=mysql --version=latest --resource=mySQL --cloud-provider=aws --region=ca-central-1 --param-file /path/to/params.json
+
+# Create an instance deployment and wait for completion with progress tracking
+omctl instance create --service=mysql --environment=dev --plan=mysql --version=latest --resource=mySQL --cloud-provider=aws --region=ca-central-1 --param-file /path/to/params.json --wait`
 )
 
 var InstanceID string
@@ -46,6 +49,7 @@ func init() {
 	createCmd.Flags().String("param", "", "Parameters for the instance deployment")
 	createCmd.Flags().String("param-file", "", "Json file containing parameters for the instance deployment")
 	createCmd.Flags().StringP("subscription-id", "", "", "Subscription ID to use for the instance deployment. If not provided, instance deployment will be created in your own subscription.")
+	createCmd.Flags().Bool("wait", false, "Wait for deployment to complete and show progress")
 
 	if err := createCmd.MarkFlagRequired("service"); err != nil {
 		return
@@ -123,6 +127,11 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	subscriptionID, err := cmd.Flags().GetString("subscription-id")
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+	waitFlag, err := cmd.Flags().GetBool("wait")
 	if err != nil {
 		utils.PrintError(err)
 		return err
@@ -267,8 +276,8 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Display workflow resource-wise data if output is not JSON
-	if output != "json" {
+	// Display workflow resource-wise data if output is not JSON and wait flag is enabled
+	if output != "json" && waitFlag {
 		fmt.Println("🔄 Deployment progress...")
 		err = displayWorkflowResourceDataWithSpinners(cmd.Context(), token, formattedInstance.InstanceID, "create")
 		if err != nil {

--- a/cmd/instance/list_endpoints.go
+++ b/cmd/instance/list_endpoints.go
@@ -184,7 +184,7 @@ func extractEndpoints(instance *openapiclientfleet.ResourceInstance) (resourceEn
 		}
 	}
 
-	return
+	return resourceEndpoints
 }
 
 // convertToTableRows converts the nested endpoint structure to a flat table format

--- a/cmd/instance/modify.go
+++ b/cmd/instance/modify.go
@@ -17,7 +17,10 @@ const (
 omctl instance modify instance-abcd1234 --network-type PUBLIC / INTERNAL --param '{"databaseName":"default","password":"a_secure_password","rootPassword":"a_secure_root_password","username":"user"}'
 
 # Modify an instance deployment using a parameter file
-omctl instance modify instance-abcd1234 --param-file /path/to/param.json`
+omctl instance modify instance-abcd1234 --param-file /path/to/param.json
+
+# Modify an instance deployment and wait for completion with progress tracking
+omctl instance modify instance-abcd1234 --param-file /path/to/param.json --wait`
 )
 
 var modifyCmd = &cobra.Command{
@@ -33,6 +36,7 @@ func init() {
 	modifyCmd.Flags().String("network-type", "", "Optional network type change for the instance deployment (PUBLIC / INTERNAL)")
 	modifyCmd.Flags().String("param", "", "Parameters for the instance deployment")
 	modifyCmd.Flags().String("param-file", "", "Json file containing parameters for the instance deployment")
+	modifyCmd.Flags().Bool("wait", false, "Wait for modification to complete and show progress")
 
 	if err := modifyCmd.MarkFlagFilename("param-file"); err != nil {
 		return
@@ -64,6 +68,11 @@ func runModify(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	networkType, err := cmd.Flags().GetString("network-type")
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+	waitFlag, err := cmd.Flags().GetBool("wait")
 	if err != nil {
 		utils.PrintError(err)
 		return err
@@ -149,8 +158,8 @@ func runModify(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Display workflow resource-wise data if output is not JSON
-	if output != "json" {
+	// Display workflow resource-wise data if output is not JSON and wait flag is enabled
+	if output != "json" && waitFlag {
 		fmt.Println("🔄 Deployment progress...")
 		err = displayWorkflowResourceDataWithSpinners(cmd.Context(), token, formattedInstance.InstanceID, "modify")
 		if err != nil {

--- a/mkdocs/docs/omnistrate-ctl_instance_create.md
+++ b/mkdocs/docs/omnistrate-ctl_instance_create.md
@@ -18,6 +18,9 @@ omctl instance create --service=mysql --environment=dev --plan=mysql --version=l
 
 # Create an instance deployment with parameters from a file
 omctl instance create --service=mysql --environment=dev --plan=mysql --version=latest --resource=mySQL --cloud-provider=aws --region=ca-central-1 --param-file /path/to/params.json
+
+# Create an instance deployment and wait for completion with progress tracking
+omctl instance create --service=mysql --environment=dev --plan=mysql --version=latest --resource=mySQL --cloud-provider=aws --region=ca-central-1 --param-file /path/to/params.json --wait
 ```
 
 ### Options
@@ -34,6 +37,7 @@ omctl instance create --service=mysql --environment=dev --plan=mysql --version=l
       --service string           Service name
       --subscription-id string   Subscription ID to use for the instance deployment. If not provided, instance deployment will be created in your own subscription.
       --version string           Service plan version (latest|preferred|1.0 etc.) (default "preferred")
+      --wait                     Wait for deployment to complete and show progress
 ```
 
 ### Options inherited from parent commands

--- a/mkdocs/docs/omnistrate-ctl_instance_modify.md
+++ b/mkdocs/docs/omnistrate-ctl_instance_modify.md
@@ -18,6 +18,9 @@ omctl instance modify instance-abcd1234 --network-type PUBLIC / INTERNAL --param
 
 # Modify an instance deployment using a parameter file
 omctl instance modify instance-abcd1234 --param-file /path/to/param.json
+
+# Modify an instance deployment and wait for completion with progress tracking
+omctl instance modify instance-abcd1234 --param-file /path/to/param.json --wait
 ```
 
 ### Options
@@ -27,6 +30,7 @@ omctl instance modify instance-abcd1234 --param-file /path/to/param.json
       --network-type string   Optional network type change for the instance deployment (PUBLIC / INTERNAL)
       --param string          Parameters for the instance deployment
       --param-file string     Json file containing parameters for the instance deployment
+      --wait                  Wait for modification to complete and show progress
 ```
 
 ### Options inherited from parent commands

--- a/mkdocs/docs/omnistrate-ctl_instance_version-upgrade.md
+++ b/mkdocs/docs/omnistrate-ctl_instance_version-upgrade.md
@@ -19,8 +19,11 @@ omctl instance version-upgrade instance-abcd1234 --upgrade-configuration-overrid
 # Issue a version upgrade to a specific target tier version
 omctl instance version-upgrade instance-abcd1234 --upgrade-configuration-override /path/to/config.yaml --target-tier-version 3.0
 
+# Issue a version upgrade and wait for completion with progress tracking
+omctl instance version-upgrade instance-abcd1234 --upgrade-configuration-override /path/to/config.yaml --target-tier-version 3.0 --wait
+
 # [HELM ONLY] Use generate-configuration with a target tier version to generate a default deployment instance configuration file based on the current helm values as well as the proposed helm values for the target tier version
-omctl instance version-upgrade instance-abcd1234 --existing-configuration existing-config.yaml --proposed-configuration proposed-config.yaml --generate-configuration --target-tier-version 3.0 
+omctl instance version-upgrade instance-abcd1234 --existing-configuration existing-config.yaml --proposed-configuration proposed-config.yaml --generate-configuration --target-tier-version 3.0
 
 # Example upgrade configuration override YAML file:
 # resource-key-1:
@@ -43,6 +46,7 @@ omctl instance version-upgrade instance-abcd1234 --existing-configuration existi
       --proposed-configuration string           Path to write the proposed configuration to (optional, used with --generate-configuration)
       --target-tier-version string              Target tier version for the version upgrade
       --upgrade-configuration-override string   YAML file containing upgrade configuration override
+      --wait                                    Wait for upgrade to complete and show progress
 ```
 
 ### Options inherited from parent commands


### PR DESCRIPTION
- This will restore the behavior before the deployment progress update was made
- A new flag has been added to explicitly wait on instance workflow completions