### PR TITLE
fix request

### DIFF
--- a/internal/dataaccess/environment.go
+++ b/internal/dataaccess/environment.go
@@ -88,7 +88,11 @@ func PromoteServiceEnvironment(ctx context.Context, token, serviceID, serviceEnv
 	ctxWithToken := context.WithValue(ctx, openapiclientv1.ContextAccessToken, token)
 	apiClient := getV1Client()
 
-	r, err := apiClient.ServiceEnvironmentApiAPI.ServiceEnvironmentApiPromoteServiceEnvironment(ctxWithToken, serviceID, serviceEnvironmentID).Execute()
+	r, err := apiClient.ServiceEnvironmentApiAPI.ServiceEnvironmentApiPromoteServiceEnvironment(ctxWithToken, serviceID, serviceEnvironmentID).
+		PromoteServiceEnvironmentRequest2(
+			openapiclientv1.PromoteServiceEnvironmentRequest2{},
+		).Execute()
+
 	defer func() {
 		if r != nil {
 			_ = r.Body.Close()


### PR DESCRIPTION
This pull request updates how the `PromoteServiceEnvironment` function constructs its API call, aligning it with the expected method signature for promoting a service environment.

API request update:

* The call to `ServiceEnvironmentApiPromoteServiceEnvironment` now chains the `PromoteServiceEnvironmentRequest2` method, passing an empty `openapiclientv1.PromoteServiceEnvironmentRequest2{}` struct, before executing the request. This ensures the request conforms to the updated API requirements. (`internal/dataaccess/environment.go`)