### PR TITLE
Add ForceCreateNewServicePlanVersion and IsNewServicePlanVersionCreated for BuildService APIs

### DIFF
--- a/cmd/build/build_from_repo.go
+++ b/cmd/build/build_from_repo.go
@@ -96,6 +96,9 @@ func init() {
 	// Dry run flag
 	BuildFromRepoCmd.Flags().Bool("dry-run", false, "Run in dry-run mode: only build the Docker image locally without pushing, skip service creation, and write the generated spec to a local file with '-dry-run' suffix. Cannot be used with any --skip-* flags.")
 
+	// Force create version set flag
+	BuildFromRepoCmd.Flags().Bool("force-create-service-plan-version", false, "Force create a new service plan version on release.")
+
 	// Platform flag
 	BuildFromRepoCmd.Flags().StringArray("platforms", []string{"linux/amd64"}, "Specify the platforms to build for. Use the format: --platforms linux/amd64 --platforms linux/arm64. Default is linux/amd64.")
 
@@ -186,6 +189,13 @@ func runBuildFromRepo(cmd *cobra.Command, args []string) error {
 
 	// Get dry-run flag
 	dryRun, err := cmd.Flags().GetBool("dry-run")
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	// Get force-create-service-plan-version flag
+	forceCreateServicePlanVersion, err := cmd.Flags().GetBool("force-create-service-plan-version")
 	if err != nil {
 		utils.PrintError(err)
 		return err
@@ -974,7 +984,7 @@ x-omnistrate-image-registry-attributes:
 	}
 
 	// Build the service
-	serviceID, devEnvironmentID, devPlanID, undefinedResources, err := buildService(
+	serviceID, devEnvironmentID, devPlanID, undefinedResources, _, err := buildService(
 		cmd.Context(),
 		fileData,
 		token,
@@ -988,6 +998,7 @@ x-omnistrate-image-registry-attributes:
 		true,
 		releaseDescriptionPtr,
 		false,
+		forceCreateServicePlanVersion,
 	)
 	if err != nil {
 		utils.HandleSpinnerError(spinner, sm, err)

--- a/cmd/instance/adopt.go
+++ b/cmd/instance/adopt.go
@@ -340,15 +340,15 @@ func convertToSDKHelmAdoptionConfiguration(yamlConfig *HelmAdoptionConfig) opena
 // convertToSDKHelmRuntimeConfiguration converts YAML runtime config to SDK format
 func convertToSDKHelmRuntimeConfiguration(yamlConfig *HelmRuntimeConfig) openapiclientfleet.HelmRuntimeConfiguration {
 	return openapiclientfleet.HelmRuntimeConfiguration{
-		DisableHooks:         yamlConfig.DisableHooks,
-		Recreate:             yamlConfig.Recreate,
-		ResetThenReuseValues: yamlConfig.ResetThenReuseValues,
-		ResetValues:          yamlConfig.ResetValues,
-		ReuseValues:          yamlConfig.ReuseValues,
-		SkipCRDs:             yamlConfig.SkipCRDs,
-		TimeoutNanos:         yamlConfig.TimeoutNanos,
-		UpgradeCRDs:          yamlConfig.UpgradeCRDs,
-		Wait:                 yamlConfig.Wait,
-		WaitForJobs:          yamlConfig.WaitForJobs,
+		DisableHooks:         utils.ToPtr(yamlConfig.DisableHooks),
+		Recreate:             utils.ToPtr(yamlConfig.Recreate),
+		ResetThenReuseValues: utils.ToPtr(yamlConfig.ResetThenReuseValues),
+		ResetValues:          utils.ToPtr(yamlConfig.ResetValues),
+		ReuseValues:          utils.ToPtr(yamlConfig.ReuseValues),
+		SkipCRDs:             utils.ToPtr(yamlConfig.SkipCRDs),
+		TimeoutNanos:         utils.ToPtr(yamlConfig.TimeoutNanos),
+		UpgradeCRDs:          utils.ToPtr(yamlConfig.UpgradeCRDs),
+		Wait:                 utils.ToPtr(yamlConfig.Wait),
+		WaitForJobs:          utils.ToPtr(yamlConfig.WaitForJobs),
 	}
 }

--- a/cmd/instance/debug.go
+++ b/cmd/instance/debug.go
@@ -46,15 +46,15 @@ type DebugData struct {
 }
 
 type ResourceInfo struct {
-	ID             string                               `json:"id"`
-	Name           string                               `json:"name"`
-	Type           string                               `json:"type"` // "helm" or "terraform"
-	DebugData      interface{}                          `json:"debugData"`
-	HelmData       *HelmData                            `json:"helmData,omitempty"`
-	TerraformData  *TerraformData                       `json:"terraformData,omitempty"`
-	GenericData    *GenericData                         `json:"genericData,omitempty"`    // For generic resources
+	ID             string                                 `json:"id"`
+	Name           string                                 `json:"name"`
+	Type           string                                 `json:"type"` // "helm" or "terraform"
+	DebugData      interface{}                            `json:"debugData"`
+	HelmData       *HelmData                              `json:"helmData,omitempty"`
+	TerraformData  *TerraformData                         `json:"terraformData,omitempty"`
+	GenericData    *GenericData                           `json:"genericData,omitempty"`    // For generic resources
 	WorkflowEvents *dataaccess.DebugEventsByWorkflowSteps `json:"workflowEvents,omitempty"` // Debug events
-	WorkflowInfo   *dataaccess.WorkflowInfo             `json:"workflowInfo,omitempty"`   // Workflow metadata
+	WorkflowInfo   *dataaccess.WorkflowInfo               `json:"workflowInfo,omitempty"`   // Workflow metadata
 }
 
 type GenericData struct {
@@ -236,7 +236,7 @@ func processHelmResource(resourceInfo *ResourceInfo, actualDebugData map[string]
 	}
 
 	// Fetch workflow events for all resources in this instance
-resourcesData, workflowInfo, err := dataaccess.GetDebugEventsForAllResources(ctx, token, serviceID, environmentID, instanceID, false,"")
+	resourcesData, workflowInfo, err := dataaccess.GetDebugEventsForAllResources(ctx, token, serviceID, environmentID, instanceID, false, "")
 	if err == nil && len(resourcesData) > 0 {
 		// Find the matching resource and assign its events
 		for _, resData := range resourcesData {
@@ -263,7 +263,7 @@ func processTerraformResource(resourceInfo *ResourceInfo, actualDebugData map[st
 	resourceInfo.TerraformData = parseTerraformData(actualDebugData)
 
 	// Fetch workflow events for all resources in this instance
-resourcesData, workflowInfo, err := dataaccess.GetDebugEventsForAllResources(ctx, token, serviceID, environmentID, instanceID, false,"")
+	resourcesData, workflowInfo, err := dataaccess.GetDebugEventsForAllResources(ctx, token, serviceID, environmentID, instanceID, false, "")
 	if err == nil && len(resourcesData) > 0 {
 		// Find the matching resource and assign its events
 		for _, resData := range resourcesData {
@@ -297,7 +297,7 @@ func processGenericResource(resourceInfo *ResourceInfo, instanceData *fleet.Reso
 	}
 
 	// Fetch workflow events for all resources in this instance
-resourcesData, workflowInfo, err := dataaccess.GetDebugEventsForAllResources(ctx, token, serviceID, environmentID, instanceID, false,"")
+	resourcesData, workflowInfo, err := dataaccess.GetDebugEventsForAllResources(ctx, token, serviceID, environmentID, instanceID, false, "")
 	if err == nil && len(resourcesData) > 0 {
 		// Find the matching resource and assign its events
 		for _, resData := range resourcesData {
@@ -2339,7 +2339,7 @@ func pollDebugEventsAndWorkflowStatus(app *tview.Application, rightPanel *tview.
 			// Fetch updated debug events and workflow status for all resources
 			ctx := context.Background()
 			resourcesData, workflowInfo, err := dataaccess.GetDebugEventsForAllResources(
-				ctx, token, serviceID, environmentID, instanceID, false,"")
+				ctx, token, serviceID, environmentID, instanceID, false, "")
 
 			if err != nil {
 				// Log error but continue polling

--- a/cmd/instance/workflow.go
+++ b/cmd/instance/workflow.go
@@ -61,7 +61,7 @@ func displayWorkflowResourceDataWithSpinners(ctx context.Context, token, instanc
 			var messageParts []string
 			for _, workflowStepStatus := range workflowStepStatuses {
 				messageParts = append(messageParts, fmt.Sprintf("%s: %s", workflowStepStatus.Name, workflowStepStatus.Icon))
-			   }
+			}
 
 			// Create dynamic message for this resource
 			message := fmt.Sprintf("%s - %s", resourceData.ResourceName, strings.Join(messageParts, " | "))
@@ -69,53 +69,53 @@ func displayWorkflowResourceDataWithSpinners(ctx context.Context, token, instanc
 			// Update spinner message
 			resourceSpinners[i].Spinner.UpdateMessage(message)
 
-				// Use getResourceStatusFromEvents for status
-				resourceStatus := getResourceStatusFromEvents(resourceData.EventsByWorkflowStep)
-				   switch resourceStatus {
-				   case model.ResourceStatusFailed:
-					   resourceSpinners[i].Spinner.Error()
-				   case model.ResourceStatusCompleted:
-					   resourceSpinners[i].Spinner.Complete()
-				   }
+			// Use getResourceStatusFromEvents for status
+			resourceStatus := getResourceStatusFromEvents(resourceData.EventsByWorkflowStep)
+			switch resourceStatus {
+			case model.ResourceStatusFailed:
+				resourceSpinners[i].Spinner.Error()
+			case model.ResourceStatusCompleted:
+				resourceSpinners[i].Spinner.Complete()
+			}
 		}
 	}
 
 	// Function to complete spinners when deployment is done
-	   completeSpinners := func(resourcesData []dataaccess.ResourceWorkflowDebugEvents, workflowInfo *dataaccess.WorkflowInfo) bool {
-		   hasFailures := false
-		   workflowFailed := strings.ToLower(workflowInfo.WorkflowStatus) == "failed" || strings.ToLower(workflowInfo.WorkflowStatus) == "cancelled"
-		   workflowSucceeded := strings.ToLower(workflowInfo.WorkflowStatus) == "success"
-		   for i, resourceData := range resourcesData {
-			   var resourceStatus model.WorkflowStatus
-			   if resourceData.WorkflowStatus != nil {
-				   resourceStatus = mapResourceStatus(*resourceData.WorkflowStatus)
-			   } else {
-				   // Fallback: parse string status from events
-				   resourceStatus = model.ParseWorkflowStatus(string(getResourceStatusFromEvents(resourceData.EventsByWorkflowStep)))
-			   }
-			   // Track if any resource failed
-			   if resourceStatus == model.WorkflowStatusFailed {
-				   hasFailures = true
-			   }
-			   // Set spinner state based on resource and workflow status
-			   switch resourceStatus {
-			   case model.WorkflowStatusCompleted:
-				   resourceSpinners[i].Spinner.Complete()
-			   case model.WorkflowStatusFailed:
-				   resourceSpinners[i].Spinner.Error()
-			   default:
-				   // For any non-completed/non-failed resource, force final state based on workflow
-				   if workflowSucceeded {
-					   resourceSpinners[i].Spinner.Complete()
-				   } else if workflowFailed {
-					   resourceSpinners[i].Spinner.Error()
-					   hasFailures = true
-				   }
-			   }
-		   }
-		   sm.Stop()
-		   return hasFailures
-	   }
+	completeSpinners := func(resourcesData []dataaccess.ResourceWorkflowDebugEvents, workflowInfo *dataaccess.WorkflowInfo) bool {
+		hasFailures := false
+		workflowFailed := strings.ToLower(workflowInfo.WorkflowStatus) == "failed" || strings.ToLower(workflowInfo.WorkflowStatus) == "cancelled"
+		workflowSucceeded := strings.ToLower(workflowInfo.WorkflowStatus) == "success"
+		for i, resourceData := range resourcesData {
+			var resourceStatus model.WorkflowStatus
+			if resourceData.WorkflowStatus != nil {
+				resourceStatus = mapResourceStatus(*resourceData.WorkflowStatus)
+			} else {
+				// Fallback: parse string status from events
+				resourceStatus = model.ParseWorkflowStatus(string(getResourceStatusFromEvents(resourceData.EventsByWorkflowStep)))
+			}
+			// Track if any resource failed
+			if resourceStatus == model.WorkflowStatusFailed {
+				hasFailures = true
+			}
+			// Set spinner state based on resource and workflow status
+			switch resourceStatus {
+			case model.WorkflowStatusCompleted:
+				resourceSpinners[i].Spinner.Complete()
+			case model.WorkflowStatusFailed:
+				resourceSpinners[i].Spinner.Error()
+			default:
+				// For any non-completed/non-failed resource, force final state based on workflow
+				if workflowSucceeded {
+					resourceSpinners[i].Spinner.Complete()
+				} else if workflowFailed {
+					resourceSpinners[i].Spinner.Error()
+					hasFailures = true
+				}
+			}
+		}
+		sm.Stop()
+		return hasFailures
+	}
 
 	// Function to fetch and display current workflow status for all resources
 	displayCurrentStatus := func() (bool, error) {
@@ -149,22 +149,21 @@ func displayWorkflowResourceDataWithSpinners(ctx context.Context, token, instanc
 		createOrUpdateSpinners(resourcesData)
 
 		// Check for resource-level failures even if workflow is still running
-		   for _, resourceData := range resourcesData {
-			   var resourceStatus model.WorkflowStatus
-			   if resourceData.WorkflowStatus != nil {
-				   resourceStatus = mapResourceStatus(*resourceData.WorkflowStatus)
-			   } else {
-				   // Use ResourceStatus as WorkflowStatus for fallback (string types)
-				   resourceStatus = model.WorkflowStatus(getResourceStatusFromEvents(resourceData.EventsByWorkflowStep))
-			   }
-			   // Use getResourceStatusFromEvents for failure detection (legacy string fallback)
-			   resourceStatusFromEvents := getResourceStatusFromEvents(resourceData.EventsByWorkflowStep)
-			   if resourceStatus == model.WorkflowStatusFailed || resourceStatusFromEvents == model.ResourceStatusFailed {
-				   sm.Stop()
-				   return false, fmt.Errorf("for resource %s", resourceData.ResourceName)
-			   }
-		   }
-
+		for _, resourceData := range resourcesData {
+			var resourceStatus model.WorkflowStatus
+			if resourceData.WorkflowStatus != nil {
+				resourceStatus = mapResourceStatus(*resourceData.WorkflowStatus)
+			} else {
+				// Use ResourceStatus as WorkflowStatus for fallback (string types)
+				resourceStatus = model.WorkflowStatus(getResourceStatusFromEvents(resourceData.EventsByWorkflowStep))
+			}
+			// Use getResourceStatusFromEvents for failure detection (legacy string fallback)
+			resourceStatusFromEvents := getResourceStatusFromEvents(resourceData.EventsByWorkflowStep)
+			if resourceStatus == model.WorkflowStatusFailed || resourceStatusFromEvents == model.ResourceStatusFailed {
+				sm.Stop()
+				return false, fmt.Errorf("for resource %s", resourceData.ResourceName)
+			}
+		}
 
 		// If workflow is complete, complete all spinners and stop
 		if isWorkflowComplete {
@@ -213,7 +212,7 @@ func getHighestPriorityEventType(events []dataaccess.DebugEvent) string {
 
 	// 2. Then check for completed events
 	for _, event := range events {
-		if (event.EventType == string(model.WorkflowStepCompleted)) {
+		if event.EventType == string(model.WorkflowStepCompleted) {
 			return event.EventType
 		}
 	}
@@ -252,7 +251,6 @@ func getEventStatusIconFromType(eventType string) string {
 	}
 }
 
-
 // WorkflowStepStatus represents the status of a workflow step
 type WorkflowStepStatus struct {
 	Name      string
@@ -264,52 +262,52 @@ type WorkflowStepStatus struct {
 // getDynamicWorkflowStepStatuses extracts all available workflow steps and their statuses
 func getDynamicWorkflowStepStatuses(eventsByWorkflowStep *dataaccess.DebugEventsByWorkflowSteps) []WorkflowStepStatus {
 	// Define the preferred order for workflow steps
-	   workflowStepOrder := map[model.WorkflowStep]int{
-		   model.WorkflowStepBootstrap:  1,
-		   model.WorkflowStepStorage:    2,
-		   model.WorkflowStepNetwork:    3,
-		   model.WorkflowStepCompute:    4,
-		   model.WorkflowStepDeployment: 5,
-		   model.WorkflowStepMonitoring: 6,
-		   model.WorkflowStep(model.WorkflowStepUnknown):    7,
-	   }
+	workflowStepOrder := map[model.WorkflowStep]int{
+		model.WorkflowStepBootstrap:                   1,
+		model.WorkflowStepStorage:                     2,
+		model.WorkflowStepNetwork:                     3,
+		model.WorkflowStepCompute:                     4,
+		model.WorkflowStepDeployment:                  5,
+		model.WorkflowStepMonitoring:                  6,
+		model.WorkflowStep(model.WorkflowStepUnknown): 7,
+	}
 
 	var statuses []WorkflowStepStatus
-	
+
 	// Use reflection-like approach to get all workflowSteps dynamically
-	   if eventsByWorkflowStep != nil {
-		   workflowSteps := []struct {
-			   name   model.WorkflowStep
-			   events []dataaccess.DebugEvent
-		   }{
-			   {model.WorkflowStepBootstrap, eventsByWorkflowStep.Bootstrap},
-			   {model.WorkflowStepStorage, eventsByWorkflowStep.Storage},
-			   {model.WorkflowStepNetwork, eventsByWorkflowStep.Network},
-			   {model.WorkflowStepCompute, eventsByWorkflowStep.Compute},
-			   {model.WorkflowStepDeployment, eventsByWorkflowStep.Deployment},
-			   {model.WorkflowStepMonitoring, eventsByWorkflowStep.Monitoring},
-			   {model.WorkflowStep(model.WorkflowStepUnknown), eventsByWorkflowStep.Unknown},
-		   }
+	if eventsByWorkflowStep != nil {
+		workflowSteps := []struct {
+			name   model.WorkflowStep
+			events []dataaccess.DebugEvent
+		}{
+			{model.WorkflowStepBootstrap, eventsByWorkflowStep.Bootstrap},
+			{model.WorkflowStepStorage, eventsByWorkflowStep.Storage},
+			{model.WorkflowStepNetwork, eventsByWorkflowStep.Network},
+			{model.WorkflowStepCompute, eventsByWorkflowStep.Compute},
+			{model.WorkflowStepDeployment, eventsByWorkflowStep.Deployment},
+			{model.WorkflowStepMonitoring, eventsByWorkflowStep.Monitoring},
+			{model.WorkflowStep(model.WorkflowStepUnknown), eventsByWorkflowStep.Unknown},
+		}
 		// Track which workflow steps have actual events
 		for _, step := range workflowSteps {
 			// Check if this step has events
 			if len(step.events) > 0 {
 				eventType := getHighestPriorityEventType(step.events)
 				icon := getEventStatusIconFromType(eventType)
-				   order := workflowStepOrder[step.name]
-				   if order == 0 {
-					   order = 999 // Put unknown categories at the end
-				   }
+				order := workflowStepOrder[step.name]
+				if order == 0 {
+					order = 999 // Put unknown categories at the end
+				}
 
-				   statuses = append(statuses, WorkflowStepStatus{
-					   Name:      string(step.name),
-					   EventType: eventType,
-					   Icon:      icon,
-					   Order:     order,
-				   })
+				statuses = append(statuses, WorkflowStepStatus{
+					Name:      string(step.name),
+					EventType: eventType,
+					Icon:      icon,
+					Order:     order,
+				})
 			}
 		}
-		
+
 	}
 
 	// Sort by order
@@ -319,24 +317,25 @@ func getDynamicWorkflowStepStatuses(eventsByWorkflowStep *dataaccess.DebugEvents
 
 	return statuses
 }
+
 // getResourceStatusFromEvents determines the overall status of a resource based on its events across all categories
 func getResourceStatusFromEvents(eventsByWorkflowStep *dataaccess.DebugEventsByWorkflowSteps) model.ResourceStatus {
-   if eventsByWorkflowStep == nil {
-	   return model.ResourceStatusPending
-   }
+	if eventsByWorkflowStep == nil {
+		return model.ResourceStatusPending
+	}
 
-   // Check all workflowSteps for their highest priority event types
-   workflowSteps := []struct {
-	   name   model.WorkflowStep
-	   events []dataaccess.DebugEvent
-   }{
-	   {model.WorkflowStepBootstrap, eventsByWorkflowStep.Bootstrap},
-	   {model.WorkflowStepStorage, eventsByWorkflowStep.Storage},
-	   {model.WorkflowStepNetwork, eventsByWorkflowStep.Network},
-	   {model.WorkflowStepCompute, eventsByWorkflowStep.Compute},
-	   {model.WorkflowStepDeployment, eventsByWorkflowStep.Deployment},
-	   {model.WorkflowStepMonitoring, eventsByWorkflowStep.Monitoring},
-   }
+	// Check all workflowSteps for their highest priority event types
+	workflowSteps := []struct {
+		name   model.WorkflowStep
+		events []dataaccess.DebugEvent
+	}{
+		{model.WorkflowStepBootstrap, eventsByWorkflowStep.Bootstrap},
+		{model.WorkflowStepStorage, eventsByWorkflowStep.Storage},
+		{model.WorkflowStepNetwork, eventsByWorkflowStep.Network},
+		{model.WorkflowStepCompute, eventsByWorkflowStep.Compute},
+		{model.WorkflowStepDeployment, eventsByWorkflowStep.Deployment},
+		{model.WorkflowStepMonitoring, eventsByWorkflowStep.Monitoring},
+	}
 
 	hasCompleted := false
 	hasFailed := false
@@ -350,15 +349,15 @@ func getResourceStatusFromEvents(eventsByWorkflowStep *dataaccess.DebugEventsByW
 			workflowStepsWithEvents++
 			eventType := getHighestPriorityEventType(step.events)
 
-			   switch model.WorkflowStepEventType(eventType) {
-			   case model.WorkflowStepStarted:
-				   hasEvents = true
-			   case model.WorkflowStepCompleted:
-				   hasCompleted = true
-				   completedWorkflowSteps++
-			   case model.WorkflowStepFailed:
-				   hasFailed = true
-			   }
+			switch model.WorkflowStepEventType(eventType) {
+			case model.WorkflowStepStarted:
+				hasEvents = true
+			case model.WorkflowStepCompleted:
+				hasCompleted = true
+				completedWorkflowSteps++
+			case model.WorkflowStepFailed:
+				hasFailed = true
+			}
 		}
 	}
 
@@ -378,7 +377,6 @@ func getResourceStatusFromEvents(eventsByWorkflowStep *dataaccess.DebugEventsByW
 
 	return model.ResourceStatusPending
 }
-
 
 // mapResourceStatus maps API workflow status values to WorkflowStatus enum
 func mapResourceStatus(apiStatus string) model.WorkflowStatus {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/njayp/ophis v0.3.2
-	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.74
+	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.75
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/rivo/tview v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -203,8 +203,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/njayp/ophis v0.3.2 h1:lMRvbSMLuGUkMnGUPBL/TyYwck+2tMn21xY6dsx8Ij4=
 github.com/njayp/ophis v0.3.2/go.mod h1:kUvQBiqRDtegm7a8J3/YeHYKg1wNrWxsizG+b6MTPcY=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.74 h1:ngSj9QAYkhvECtRorauJywJ/Bd8Altl/9PpDy5Ad/sc=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.74/go.mod h1:DWciGk/FNzCBaCi9e4YAZ3sB1vHPH5mT4fVnAMBkZNY=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.75 h1:4p23OVfnZwbmxSks4UJp+gOVEPA0vW0lebMZ1/S1Yho=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.75/go.mod h1:DWciGk/FNzCBaCi9e4YAZ3sB1vHPH5mT4fVnAMBkZNY=
 github.com/onsi/ginkgo/v2 v2.21.0 h1:7rg/4f3rB88pb5obDgNZrNHrQ4e6WpjonchcpuBRnZM=
 github.com/onsi/ginkgo/v2 v2.21.0/go.mod h1:7Du3c42kxCUegi0IImZ1wUQzMBVecgIHjR1C+NkhLQo=
 github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=

--- a/internal/dataaccess/workflow.go
+++ b/internal/dataaccess/workflow.go
@@ -175,13 +175,13 @@ type WorkflowInfo struct {
 
 // DebugEventsByWorkflowSteps represents workflow debug events organized by workflow step
 type DebugEventsByWorkflowSteps struct {
-		Bootstrap  []DebugEvent `json:"bootstrap"`
-		Storage    []DebugEvent `json:"storage"`
-		Network    []DebugEvent `json:"network"`
-		Compute    []DebugEvent `json:"compute"`
-		Deployment []DebugEvent `json:"deployment"`
-		Monitoring []DebugEvent `json:"monitoring"`
-		Unknown      []DebugEvent `json:"unknown"`
+	Bootstrap  []DebugEvent `json:"bootstrap"`
+	Storage    []DebugEvent `json:"storage"`
+	Network    []DebugEvent `json:"network"`
+	Compute    []DebugEvent `json:"compute"`
+	Deployment []DebugEvent `json:"deployment"`
+	Monitoring []DebugEvent `json:"monitoring"`
+	Unknown    []DebugEvent `json:"unknown"`
 }
 
 // GetDebugEventsForAllResources gets workflow events for all resources in an instance, organized by resource and workflow step.
@@ -196,11 +196,11 @@ func GetDebugEventsForAllResources(ctx context.Context, token string, serviceID,
 	}
 
 	if workflows == nil || workflows.Workflows == nil {
-			return []ResourceWorkflowDebugEvents{}, &WorkflowInfo{}, nil
+		return []ResourceWorkflowDebugEvents{}, &WorkflowInfo{}, nil
 	}
 
 	workflowInfo := &WorkflowInfo{}
-		var resourcesData []ResourceWorkflowDebugEvents
+	var resourcesData []ResourceWorkflowDebugEvents
 
 	// Find the latest workflow that matches the expected action (if specified)
 	var latestWorkflowID string
@@ -266,14 +266,14 @@ func GetDebugEventsForAllResources(ctx context.Context, token string, serviceID,
 		if workflowEvents != nil && workflowEvents.Resources != nil {
 			// Work directly with the struct - no need for marshaling/unmarshaling
 			for _, resource := range workflowEvents.Resources {
-				   eventsByWorkflowStep := &DebugEventsByWorkflowSteps{
-					   Bootstrap:  []DebugEvent{},
-					   Storage:    []DebugEvent{},
-					   Network:    []DebugEvent{},
-					   Compute:    []DebugEvent{},
-					   Deployment: []DebugEvent{},
-					   Monitoring: []DebugEvent{},
-					   Unknown:      []DebugEvent{},
+				eventsByWorkflowStep := &DebugEventsByWorkflowSteps{
+					Bootstrap:  []DebugEvent{},
+					Storage:    []DebugEvent{},
+					Network:    []DebugEvent{},
+					Compute:    []DebugEvent{},
+					Deployment: []DebugEvent{},
+					Monitoring: []DebugEvent{},
+					Unknown:    []DebugEvent{},
 				}
 
 				// Categorize events by workflow step for this resource
@@ -283,8 +283,8 @@ func GetDebugEventsForAllResources(ctx context.Context, token string, serviceID,
 
 						if step.Events != nil {
 							for _, event := range step.Events {
-								   // Create a DebugEvent with proper data
-								   workflowEvent := DebugEvent{
+								// Create a DebugEvent with proper data
+								workflowEvent := DebugEvent{
 									EventTime: event.EventTime,
 									EventType: event.EventType,
 									Message:   event.Message,
@@ -293,19 +293,19 @@ func GetDebugEventsForAllResources(ctx context.Context, token string, serviceID,
 								// Add to appropriate workflowStep
 								switch workflowStep {
 								case "bootstrap":
-									   eventsByWorkflowStep.Bootstrap = append(eventsByWorkflowStep.Bootstrap, workflowEvent)
+									eventsByWorkflowStep.Bootstrap = append(eventsByWorkflowStep.Bootstrap, workflowEvent)
 								case "storage":
-									   eventsByWorkflowStep.Storage = append(eventsByWorkflowStep.Storage, workflowEvent)
+									eventsByWorkflowStep.Storage = append(eventsByWorkflowStep.Storage, workflowEvent)
 								case "network":
-									   eventsByWorkflowStep.Network = append(eventsByWorkflowStep.Network, workflowEvent)
+									eventsByWorkflowStep.Network = append(eventsByWorkflowStep.Network, workflowEvent)
 								case "compute":
-									   eventsByWorkflowStep.Compute = append(eventsByWorkflowStep.Compute, workflowEvent)
+									eventsByWorkflowStep.Compute = append(eventsByWorkflowStep.Compute, workflowEvent)
 								case "deployment":
-									   eventsByWorkflowStep.Deployment = append(eventsByWorkflowStep.Deployment, workflowEvent)
+									eventsByWorkflowStep.Deployment = append(eventsByWorkflowStep.Deployment, workflowEvent)
 								case "monitoring":
-									   eventsByWorkflowStep.Monitoring = append(eventsByWorkflowStep.Monitoring, workflowEvent)
+									eventsByWorkflowStep.Monitoring = append(eventsByWorkflowStep.Monitoring, workflowEvent)
 								default:
-									   eventsByWorkflowStep.Unknown = append(eventsByWorkflowStep.Unknown, workflowEvent)
+									eventsByWorkflowStep.Unknown = append(eventsByWorkflowStep.Unknown, workflowEvent)
 								}
 							}
 						}
@@ -313,60 +313,58 @@ func GetDebugEventsForAllResources(ctx context.Context, token string, serviceID,
 				}
 
 				// Add this resource's data to the result
-				   resourcesData = append(resourcesData, ResourceWorkflowDebugEvents{
-					ResourceID:       resource.ResourceId,
-					ResourceKey:      resource.ResourceKey,
-					ResourceName:     resource.ResourceName,
-					   EventsByWorkflowStep: eventsByWorkflowStep,
+				resourcesData = append(resourcesData, ResourceWorkflowDebugEvents{
+					ResourceID:           resource.ResourceId,
+					ResourceKey:          resource.ResourceKey,
+					ResourceName:         resource.ResourceName,
+					EventsByWorkflowStep: eventsByWorkflowStep,
 				})
 			}
 		}
 	}
 
-	   // Optionally fetch and set resource status from DescribeWorkflow
-	   if fetchResourceStatus && workflowInfo.WorkflowID != "" {
-		   describeResult, err := DescribeWorkflow(ctx, token, serviceID, environmentID, workflowInfo.WorkflowID)
-		   if err != nil {
-			   // If DescribeWorkflow fails, continue with existing data
-			   // Don't fail the entire operation - log the error but continue
-			   return resourcesData, workflowInfo, err
-		   }
-		   if describeResult != nil {
-			   generalStatus := describeResult.Workflow.Status
-			   for i := range resourcesData {
-				   // Only set status if not already set from events analysis
-				   if resourcesData[i].WorkflowStatus == nil {
-					   resourcesData[i].WorkflowStatus = &generalStatus
-				   }
-			   }
-		   }
-	   }
-	   return resourcesData, workflowInfo, nil
+	// Optionally fetch and set resource status from DescribeWorkflow
+	if fetchResourceStatus && workflowInfo.WorkflowID != "" {
+		describeResult, err := DescribeWorkflow(ctx, token, serviceID, environmentID, workflowInfo.WorkflowID)
+		if err != nil {
+			// If DescribeWorkflow fails, continue with existing data
+			// Don't fail the entire operation - log the error but continue
+			return resourcesData, workflowInfo, err
+		}
+		if describeResult != nil {
+			generalStatus := describeResult.Workflow.Status
+			for i := range resourcesData {
+				// Only set status if not already set from events analysis
+				if resourcesData[i].WorkflowStatus == nil {
+					resourcesData[i].WorkflowStatus = &generalStatus
+				}
+			}
+		}
+	}
+	return resourcesData, workflowInfo, nil
 }
 
 // ResourceWorkflowDebugEvents represents workflow debug events for a resource organized by workflow step
 type ResourceWorkflowDebugEvents struct {
-	ResourceID       string                    `json:"resourceId"`
-	ResourceKey      string                    `json:"resourceKey"`
-	ResourceName     string                    `json:"resourceName"`
-		EventsByWorkflowStep *DebugEventsByWorkflowSteps `json:"eventsByWorkflowStep"`
-		WorkflowStatus   *string                    `json:"workflowStatus,omitempty"` // From DescribeWorkflow API
+	ResourceID           string                      `json:"resourceId"`
+	ResourceKey          string                      `json:"resourceKey"`
+	ResourceName         string                      `json:"resourceName"`
+	EventsByWorkflowStep *DebugEventsByWorkflowSteps `json:"eventsByWorkflowStep"`
+	WorkflowStatus       *string                     `json:"workflowStatus,omitempty"` // From DescribeWorkflow API
 }
-
-
 
 // workflowStepName determines the workflow step for a given step name
 func workflowStepName(stepName string) string {
 	stepLower := strings.ToLower(stepName)
 
 	// More comprehensive categorization based on step name patterns
-	if strings.Contains(stepLower, "bootstrap")  {
+	if strings.Contains(stepLower, "bootstrap") {
 		return "bootstrap"
 	}
-	if strings.Contains(stepLower, "storage")  {
+	if strings.Contains(stepLower, "storage") {
 		return "storage"
 	}
-	if strings.Contains(stepLower, "network")  {
+	if strings.Contains(stepLower, "network") {
 		return "network"
 	}
 	if strings.Contains(stepLower, "compute") {
@@ -375,7 +373,7 @@ func workflowStepName(stepName string) string {
 	if strings.Contains(stepLower, "deployment") {
 		return "deployment"
 	}
-	if strings.Contains(stepLower, "monitoring")  {
+	if strings.Contains(stepLower, "monitoring") {
 		return "monitoring"
 	}
 

--- a/internal/model/serviceplan.go
+++ b/internal/model/serviceplan.go
@@ -32,14 +32,15 @@ type ResourceChangeSet struct {
 }
 
 type ServicePlanVersion struct {
-	PlanID             string `json:"plan_id,omitempty"`
-	PlanName           string `json:"plan_name,omitempty"`
-	ServiceID          string `json:"service_id,omitempty"`
-	ServiceName        string `json:"service_name,omitempty"`
-	Environment        string `json:"environment,omitempty"`
-	Version            string `json:"version,omitempty"`
-	ReleaseDescription string `json:"release_description,omitempty"`
-	VersionSetStatus   string `json:"version_set_status,omitempty"`
+	PlanID                         string `json:"plan_id,omitempty"`
+	PlanName                       string `json:"plan_name,omitempty"`
+	ServiceID                      string `json:"service_id,omitempty"`
+	ServiceName                    string `json:"service_name,omitempty"`
+	Environment                    string `json:"environment,omitempty"`
+	Version                        string `json:"version,omitempty"`
+	ReleaseDescription             string `json:"release_description,omitempty"`
+	VersionSetStatus               string `json:"version_set_status,omitempty"`
+	IsNewServicePlanVersionCreated bool   `json:"is_new_service_plan_version_created,omitempty"`
 }
 
 type ServicePlanVersionDetails struct {

--- a/internal/model/workflow.go
+++ b/internal/model/workflow.go
@@ -14,66 +14,64 @@ const (
 	WorkflowStepUnknown   WorkflowStepEventType = "WorkflowStepUnknown"
 )
 
-
-
 // ResourceStatus represents the status of a resource as a string
 type ResourceStatus string
 
 const (
-   ResourceStatusUnknown   ResourceStatus = "UNKNOWN"
-   ResourceStatusCompleted ResourceStatus = "COMPLETED"
-   ResourceStatusFailed    ResourceStatus = "FAILED"
-   ResourceStatusPending   ResourceStatus = "PENDING"
-   ResourceStatusRunning   ResourceStatus = "RUNNING"
+	ResourceStatusUnknown   ResourceStatus = "UNKNOWN"
+	ResourceStatusCompleted ResourceStatus = "COMPLETED"
+	ResourceStatusFailed    ResourceStatus = "FAILED"
+	ResourceStatusPending   ResourceStatus = "PENDING"
+	ResourceStatusRunning   ResourceStatus = "RUNNING"
 )
 
 func (v ResourceStatus) String() string {
-   return string(v)
+	return string(v)
 }
 
 // WorkflowStep represents a workflow step as a string
 type WorkflowStep string
 
 const (
-   WorkflowStepBootstrap   WorkflowStep = "BOOTSTRAP"
-   WorkflowStepStorage     WorkflowStep = "STORAGE"
-   WorkflowStepNetwork     WorkflowStep = "NETWORK"
-   WorkflowStepCompute     WorkflowStep = "COMPUTE"
-   WorkflowStepDeployment  WorkflowStep = "DEPLOYMENT"
-   WorkflowStepMonitoring  WorkflowStep = "MONITORING"
-   WorkflowStepUnknownStep WorkflowStep = "UNKNOWN"
+	WorkflowStepBootstrap   WorkflowStep = "BOOTSTRAP"
+	WorkflowStepStorage     WorkflowStep = "STORAGE"
+	WorkflowStepNetwork     WorkflowStep = "NETWORK"
+	WorkflowStepCompute     WorkflowStep = "COMPUTE"
+	WorkflowStepDeployment  WorkflowStep = "DEPLOYMENT"
+	WorkflowStepMonitoring  WorkflowStep = "MONITORING"
+	WorkflowStepUnknownStep WorkflowStep = "UNKNOWN"
 )
 
 func (v WorkflowStep) String() string {
-   return string(v)
+	return string(v)
 }
 
 // WorkflowStatus represents the status of a workflow as a string (for consistency with UpgradePathStatus)
 type WorkflowStatus string
 
 const (
-   WorkflowStatusUnknown   WorkflowStatus = "UNKNOWN"
-   WorkflowStatusCompleted WorkflowStatus = "COMPLETED"
-   WorkflowStatusFailed    WorkflowStatus = "FAILED"
-   WorkflowStatusPending   WorkflowStatus = "PENDING"
-   WorkflowStatusRunning   WorkflowStatus = "RUNNING"
+	WorkflowStatusUnknown   WorkflowStatus = "UNKNOWN"
+	WorkflowStatusCompleted WorkflowStatus = "COMPLETED"
+	WorkflowStatusFailed    WorkflowStatus = "FAILED"
+	WorkflowStatusPending   WorkflowStatus = "PENDING"
+	WorkflowStatusRunning   WorkflowStatus = "RUNNING"
 )
 
 func (v WorkflowStatus) String() string {
-   return string(v)
+	return string(v)
 }
 
 func ParseWorkflowStatus(apiStatus string) WorkflowStatus {
-   switch strings.ToLower(apiStatus) {
-   case "success":
-	   return WorkflowStatusCompleted
-   case "failed", "error", "cancelled":
-	   return WorkflowStatusFailed
-   case "pending":
-	   return WorkflowStatusPending
-   case "running":
-	   return WorkflowStatusRunning
-   default:
-	   return WorkflowStatusUnknown
-   }
+	switch strings.ToLower(apiStatus) {
+	case "success":
+		return WorkflowStatusCompleted
+	case "failed", "error", "cancelled":
+		return WorkflowStatusFailed
+	case "pending":
+		return WorkflowStatusPending
+	case "running":
+		return WorkflowStatusRunning
+	default:
+		return WorkflowStatusUnknown
+	}
 }

--- a/mkdocs/docs/omnistrate-ctl_build-from-repo.md
+++ b/mkdocs/docs/omnistrate-ctl_build-from-repo.md
@@ -53,23 +53,24 @@ omctl build-from-repo
 ### Options
 
 ```
-      --aws-account-id string        AWS account ID. Must be used with --deployment-type
-      --deployment-type string       Set the deployment type. Options: 'hosted' or 'byoa' (Bring Your Own Account). Only effective when no compose spec exists in the repo.
-      --dry-run                      Run in dry-run mode: only build the Docker image locally without pushing, skip service creation, and write the generated spec to a local file with '-dry-run' suffix. Cannot be used with any --skip-* flags.
-      --env-var stringArray          Specify environment variables required for running the image. Effective only when the compose.yaml is absent. Use the format: --env-var key1=var1 --env-var key2=var2. Only effective when no compose spec exists in the repo.
-  -f, --file string                  Specify the compose file to read and write to (default "compose.yaml")
-      --gcp-project-id string        GCP project ID. Must be used with --gcp-project-number and --deployment-type
-      --gcp-project-number string    GCP project number. Must be used with --gcp-project-id and --deployment-type
-  -h, --help                         help for build-from-repo
-  -o, --output string                Output format. Only text is supported (default "text")
-      --platforms stringArray        Specify the platforms to build for. Use the format: --platforms linux/amd64 --platforms linux/arm64. Default is linux/amd64. (default [linux/amd64])
-      --product-name string          Specify a custom service name. If not provided, the repository name will be used.
-      --release-description string   Provide a description for the release version
-      --reset-pat                    Reset the GitHub Personal Access Token (PAT) for the current user.
-      --skip-docker-build            Skip building and pushing the Docker image
-      --skip-environment-promotion   Skip creating and promoting to the production environment
-      --skip-saas-portal-init        Skip initializing the SaaS Portal
-      --skip-service-build           Skip building the service from the compose spec
+      --aws-account-id string               AWS account ID. Must be used with --deployment-type
+      --deployment-type string              Set the deployment type. Options: 'hosted' or 'byoa' (Bring Your Own Account). Only effective when no compose spec exists in the repo.
+      --dry-run                             Run in dry-run mode: only build the Docker image locally without pushing, skip service creation, and write the generated spec to a local file with '-dry-run' suffix. Cannot be used with any --skip-* flags.
+      --env-var stringArray                 Specify environment variables required for running the image. Effective only when the compose.yaml is absent. Use the format: --env-var key1=var1 --env-var key2=var2. Only effective when no compose spec exists in the repo.
+  -f, --file string                         Specify the compose file to read and write to (default "compose.yaml")
+      --force-create-service-plan-version   Force create a new service plan version on release.
+      --gcp-project-id string               GCP project ID. Must be used with --gcp-project-number and --deployment-type
+      --gcp-project-number string           GCP project number. Must be used with --gcp-project-id and --deployment-type
+  -h, --help                                help for build-from-repo
+  -o, --output string                       Output format. Only text is supported (default "text")
+      --platforms stringArray               Specify the platforms to build for. Use the format: --platforms linux/amd64 --platforms linux/arm64. Default is linux/amd64. (default [linux/amd64])
+      --product-name string                 Specify a custom service name. If not provided, the repository name will be used.
+      --release-description string          Provide a description for the release version
+      --reset-pat                           Reset the GitHub Personal Access Token (PAT) for the current user.
+      --skip-docker-build                   Skip building and pushing the Docker image
+      --skip-environment-promotion          Skip creating and promoting to the production environment
+      --skip-saas-portal-init               Skip initializing the SaaS Portal
+      --skip-service-build                  Skip building the service from the compose spec
 ```
 
 ### Options inherited from parent commands

--- a/mkdocs/docs/omnistrate-ctl_build.md
+++ b/mkdocs/docs/omnistrate-ctl_build.md
@@ -70,20 +70,21 @@ omctl build --image docker.io/namespace/my-image:v1.2 --product-name "My Service
 ### Options
 
 ```
-      --description string           A short description for the whole service. A service can have multiple service plans.
-  -d, --dry-run                      Simulate building the service without actually creating resources
-      --environment string           Name of the environment to build the service in (default "Dev")
-      --environment-type string      Type of environment. Valid options include: 'dev', 'prod', 'qa', 'canary', 'staging', 'private') (default "dev")
-  -f, --file string                  Path to the docker compose file (defaults to compose.yaml or spec.yaml)
-  -h, --help                         help for build
-  -i, --interactive                  Interactive mode
-      --no-release-as-preferred      Do not release the service as preferred (overrides --release-as-preferred)
-      --product-name string          Name of the service. A service can have multiple service plans. The build command will build a new or existing service plan inside the specified service.
-      --release                      Release the service after building it
-      --release-as-preferred         Release the service as preferred after building it
-      --release-description string   Used together with --release or --release-as-preferred flag. Provide a description for the release version
-      --service-logo-url string      URL to the service logo
-  -s, --spec-type string             Spec type (will infer from file if not provided). Valid options include: 'DockerCompose', 'ServicePlanSpec'
+      --description string                  A short description for the whole service. A service can have multiple service plans.
+  -d, --dry-run                             Simulate building the service without actually creating resources
+      --environment string                  Name of the environment to build the service in (default "Dev")
+      --environment-type string             Type of environment. Valid options include: 'dev', 'prod', 'qa', 'canary', 'staging', 'private') (default "dev")
+  -f, --file string                         Path to the docker compose file (defaults to compose.yaml or spec.yaml)
+      --force-create-service-plan-version   Force create a new service plan version on release.
+  -h, --help                                help for build
+  -i, --interactive                         Interactive mode
+      --no-release-as-preferred             Do not release the service as preferred (overrides --release-as-preferred)
+      --product-name string                 Name of the service. A service can have multiple service plans. The build command will build a new or existing service plan inside the specified service.
+      --release                             Release the service after building it
+      --release-as-preferred                Release the service as preferred after building it
+      --release-description string          Used together with --release or --release-as-preferred flag. Provide a description for the release version
+      --service-logo-url string             URL to the service logo
+  -s, --spec-type string                    Spec type (will infer from file if not provided). Valid options include: 'DockerCompose', 'ServicePlanSpec'
 ```
 
 ### Options inherited from parent commands

--- a/mkdocs/docs/omnistrate-ctl_service-plan_list-versions.md
+++ b/mkdocs/docs/omnistrate-ctl_service-plan_list-versions.md
@@ -22,7 +22,7 @@ omctl service-plan list-versions postgres postgres -f="service_name:postgres,env
 
 ```
       --environment string   Environment name. Use this flag with service name and plan name to describe the version in a specific environment
-  -f, --filter stringArray   Filter to apply to the list of service plan versions. E.g.: key1:value1,key2:value2, which filters service plans where key1 equals value1 and key2 equals value2. Allow use of multiple filters to form the logical OR operation. Supported keys: plan_id,plan_name,service_id,service_name,environment,version,release_description,version_set_status. Check the examples for more details.
+  -f, --filter stringArray   Filter to apply to the list of service plan versions. E.g.: key1:value1,key2:value2, which filters service plans where key1 equals value1 and key2 equals value2. Allow use of multiple filters to form the logical OR operation. Supported keys: plan_id,plan_name,service_id,service_name,environment,version,release_description,version_set_status,is_new_service_plan_version_created. Check the examples for more details.
   -h, --help                 help for list-versions
       --limit int            List only the latest N service plan versions (default -1)
       --plan-id string       Environment ID. Required if plan name is not provided

--- a/mkdocs/docs/omnistrate-ctl_service-plan_list.md
+++ b/mkdocs/docs/omnistrate-ctl_service-plan_list.md
@@ -21,7 +21,7 @@ omctl service-plan list -f="service_name:postgres,environment:prod" -f="service:
 ### Options
 
 ```
-  -f, --filter stringArray   Filter to apply to the list of service plans. E.g.: key1:value1,key2:value2, which filters service plans where key1 equals value1 and key2 equals value2. Allow use of multiple filters to form the logical OR operation. Supported keys: plan_id,plan_name,service_id,service_name,environment,version,release_description,version_set_status. Check the examples for more details.
+  -f, --filter stringArray   Filter to apply to the list of service plans. E.g.: key1:value1,key2:value2, which filters service plans where key1 equals value1 and key2 equals value2. Allow use of multiple filters to form the logical OR operation. Supported keys: plan_id,plan_name,service_id,service_name,environment,version,release_description,version_set_status,is_new_service_plan_version_created. Check the examples for more details.
   -h, --help                 help for list
       --truncate             Truncate long names in the output
 ```


### PR DESCRIPTION
Introduced two key fields: ForceCreateNewServicePlanVersion to force creation of new service plan versions even when specs are identical, and IsNewServicePlanVersionCreated to indicate whether a new version was actually created.