### PR TITLE
update sdk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Gotestsum installer
         uses: autero1/action-gotestsum@v2.0.0
         with:
-          gotestsum_version: 1.11.0
+          gotestsum_version: 1.13.0
 
       - name: Integraiton test
         timeout-minutes: 30

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -35,7 +35,6 @@ jobs:
         test-group:
           [
             "account/...",
-            "auth/...",
             "build/compose/...",
             "build/image/...",
             "build/helm/...",
@@ -83,6 +82,59 @@ jobs:
           OMNISTRATE_RETRY_WAIT_MIN_IN_SECONDS: 60
           OMNISTRATE_RETRY_WAIT_MAX_IN_SECONDS: 600
         run: gotestsum --format standard-verbose -- ./test/smoke_test/${{ matrix.test-group }} -timeout 1800s -p 1 -p 1 -v
+
+  smoke-tests-auth:
+    environment: ${{ inputs.environment }}
+    if: github.event_name != 'push'
+    permissions:
+      contents: read
+    concurrency:
+      group: ${{ github.workflow }}-${{ inputs.environment }}-auth-${{ matrix.os }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-latest
+          - windows-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+          cache-dependency-path: "**/go.sum"
+
+      - name: Get dependencies
+        timeout-minutes: 10
+        run: go mod tidy
+
+      - name: Gotestsum installer
+        uses: autero1/action-gotestsum@v2.0.0
+        with:
+          gotestsum_version: 1.11.0
+
+      - name: Smoke test auth (${{ matrix.os }})
+        timeout-minutes: 30
+        env:
+          ENABLE_SMOKE_TEST: true
+          TEST_EMAIL: ${{ secrets.SMOKE_TEST_EMAIL }}
+          TEST_PASSWORD: ${{ secrets.SMOKE_TEST_PASSWORD}}
+          OMNISTRATE_ROOT_DOMAIN: ${{ vars.OMNISTRATE_ROOT_DOMAIN}}
+          OMNISTRATE_LOG_LEVEL: debug
+          OMNISTRATE_DRY_RUN: true
+          OMNISTRATE_RETRY_MAX: 8
+          OMNISTRATE_RETRY_WAIT_MIN_IN_SECONDS: 60
+          OMNISTRATE_RETRY_WAIT_MAX_IN_SECONDS: 600
+        run: gotestsum --format standard-verbose -- ./test/smoke_test/auth/... -timeout 1800s -p 1 -v
 
   smoke-tests-with-provisioning:
     environment: ${{ inputs.environment }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Gotestsum installer
         uses: autero1/action-gotestsum@v2.0.0
         with:
-          gotestsum_version: 1.11.0
+          gotestsum_version: 1.13.0
 
       - name: Smoke test ${{ matrix.test-group }}
         timeout-minutes: 30
@@ -171,7 +171,7 @@ jobs:
       - name: Gotestsum installer
         uses: autero1/action-gotestsum@v2.0.0
         with:
-          gotestsum_version: 1.11.0
+          gotestsum_version: 1.13.0
 
       - name: Smoke test ${{ matrix.test-group }}
         timeout-minutes: 30

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -117,10 +117,8 @@ jobs:
         timeout-minutes: 10
         run: go mod tidy
 
-      - name: Gotestsum installer
-        uses: autero1/action-gotestsum@v2.0.0
-        with:
-          gotestsum_version: 1.11.0
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@v1.11.0
 
       - name: Smoke test auth (${{ matrix.os }})
         timeout-minutes: 30

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -117,9 +117,6 @@ jobs:
         timeout-minutes: 10
         run: go mod tidy
 
-      - name: Install gotestsum
-        run: go install gotest.tools/gotestsum@v1.11.0
-
       - name: Smoke test auth (${{ matrix.os }})
         timeout-minutes: 30
         env:
@@ -132,7 +129,7 @@ jobs:
           OMNISTRATE_RETRY_MAX: 8
           OMNISTRATE_RETRY_WAIT_MIN_IN_SECONDS: 60
           OMNISTRATE_RETRY_WAIT_MAX_IN_SECONDS: 600
-        run: gotestsum --format standard-verbose -- ./test/smoke_test/auth/... -timeout 1800s -p 1 -v
+        run: go test -v -timeout 1800s -p 1 ./test/smoke_test/auth/...
 
   smoke-tests-with-provisioning:
     environment: ${{ inputs.environment }}

--- a/cmd/auth/login/sso_login.go
+++ b/cmd/auth/login/sso_login.go
@@ -29,7 +29,7 @@ type DeviceCodeResponse struct {
 
 // AccessTokenResponse represents the response from the jwt token request
 type AccessTokenResponse struct {
-	JWTToken string `json:"jwt_token"`
+	JWTToken string `json:"jwt_token"` // #nosec G117 -- field must hold the JWT token value
 }
 
 // SSO identity provider credentials and endpoints
@@ -152,7 +152,7 @@ func requestDeviceCodeWithHttpClient(ctx context.Context, client *http.Client, i
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704 -- URL is constructed from hardcoded identity provider constants
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/build/utils.go
+++ b/cmd/build/utils.go
@@ -120,17 +120,30 @@ func ArchiveArtifactPaths(baseDir string, artifactPaths []string) (map[string]st
 		// Clean the path
 		resolvedPath = filepath.Clean(resolvedPath)
 
+		// Validate the resolved path stays within baseDir to prevent path traversal
+		absBase, err := filepath.Abs(baseDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve base directory: %w", err)
+		}
+		absResolved, err := filepath.Abs(resolvedPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve artifact path '%s': %w", artifactPath, err)
+		}
+		if !strings.HasPrefix(absResolved, absBase+string(filepath.Separator)) && absResolved != absBase {
+			return nil, fmt.Errorf("artifact path '%s' escapes base directory", artifactPath)
+		}
+
 		// Check if the path exists
-		info, err := os.Stat(resolvedPath)
+		info, err := os.Stat(absResolved) // #nosec G703 -- path validated against baseDir above
 		if err != nil {
 			return nil, fmt.Errorf("artifact path '%s' does not exist: %w", artifactPath, err)
 		}
 
 		if !info.IsDir() {
 			// Path is a file - check if it's already a .tar.gz / .tgz file
-			if isGzipTarFile(resolvedPath) {
+			if isGzipTarFile(absResolved) {
 				// Already a tar.gz file, just read and base64 encode it directly
-				fileContent, readErr := os.ReadFile(resolvedPath)
+				fileContent, readErr := os.ReadFile(absResolved) // #nosec G703 -- path validated against baseDir above
 				if readErr != nil {
 					return nil, fmt.Errorf("failed to read tar.gz file '%s': %w", artifactPath, readErr)
 				}
@@ -141,7 +154,7 @@ func ArchiveArtifactPaths(baseDir string, artifactPaths []string) (map[string]st
 		}
 
 		// Create the tar.gz archive in memory and encode to base64
-		base64Content, err := createTarGzBase64(resolvedPath)
+		base64Content, err := createTarGzBase64(absResolved)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create archive for '%s': %w", artifactPath, err)
 		}
@@ -164,7 +177,7 @@ func createTarGzBase64(sourceDir string) (string, error) {
 	tarWriter := tar.NewWriter(gzWriter)
 
 	// Walk through the source directory
-	err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk(sourceDir, func(path string, info os.FileInfo, err error) error { // #nosec G703 -- callers validate sourceDir
 		if err != nil {
 			return err
 		}
@@ -244,7 +257,7 @@ func isGzipTarFile(filePath string) bool {
 	hasExtension := strings.HasSuffix(lower, ".tar.gz") || strings.HasSuffix(lower, ".tgz")
 
 	// Also verify by reading the first two bytes (gzip magic number)
-	f, err := os.Open(filePath)
+	f, err := os.Open(filePath) // #nosec G703 -- callers validate filePath against baseDir
 	if err != nil {
 		return hasExtension
 	}

--- a/cmd/build/utils_test.go
+++ b/cmd/build/utils_test.go
@@ -208,7 +208,7 @@ func TestArchiveArtifactPaths_NilPaths(t *testing.T) {
 func TestArchiveArtifactPaths_NonExistentPath(t *testing.T) {
 	_, err := ArchiveArtifactPaths("/tmp", []string{"/non/existent/path/that/does/not/exist"})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "does not exist")
+	assert.Contains(t, err.Error(), "escapes base directory")
 }
 
 func TestArchiveArtifactPaths_FileNotDirectory(t *testing.T) {

--- a/cmd/instance/adopt.go
+++ b/cmd/instance/adopt.go
@@ -28,7 +28,7 @@ type ResourceAdoptionConfig struct {
 // HelmAdoptionConfig represents the Helm adoption configuration
 type HelmAdoptionConfig struct {
 	ChartRepoURL         string             `yaml:"chartRepoURL"`
-	Password             *string            `yaml:"password,omitempty"`
+	Password             *string            `yaml:"password,omitempty"` // #nosec G117 -- field must hold helm repo credentials
 	ReleaseName          string             `yaml:"releaseName"`
 	ReleaseNamespace     string             `yaml:"releaseNamespace"`
 	RuntimeConfiguration *HelmRuntimeConfig `yaml:"runtimeConfiguration,omitempty"`

--- a/cmd/instance/debug_helm_detail_tui.go
+++ b/cmd/instance/debug_helm_detail_tui.go
@@ -689,9 +689,9 @@ func (m helmDetailModel) renderHelmLogsTab() string {
 	if m.logFollow {
 		followText = " [following]"
 	}
-	b.WriteString(fmt.Sprintf("  %s\n\n",
+	fmt.Fprintf(&b, "  %s\n\n",
 		headerStyle.Render(fmt.Sprintf("Helm Install Log (%d lines%s%s)", len(m.logLines), statusText, followText)),
-	))
+	)
 
 	bodyH := m.helmBodyHeight() - 4
 	if bodyH < 1 {
@@ -730,9 +730,9 @@ func (m helmDetailModel) renderHelmLogsTab() string {
 		styled := highlightHelmLogLine(vl.text)
 		if vl.sourceNum > 0 {
 			lineNum := lineNumStyle.Render(fmt.Sprintf("%4d", vl.sourceNum))
-			b.WriteString(fmt.Sprintf("  %s │ %s\n", lineNum, styled))
+			fmt.Fprintf(&b, "  %s │ %s\n", lineNum, styled)
 		} else {
-			b.WriteString(fmt.Sprintf("  %s   %s\n", "    ", styled))
+			fmt.Fprintf(&b, "  %s   %s\n", "    ", styled)
 		}
 	}
 
@@ -753,8 +753,8 @@ func (m helmDetailModel) renderHelmLogsTab() string {
 			pct := (scroll * 100) / maxScroll
 			pos = fmt.Sprintf("%d%%", pct)
 		}
-		b.WriteString(fmt.Sprintf("  %s\n", dimStyle.Render(
-			fmt.Sprintf("[%d/%d %s]", scroll+bodyH, totalLines, pos))))
+		fmt.Fprintf(&b, "  %s\n", dimStyle.Render(
+			fmt.Sprintf("[%d/%d %s]", scroll+bodyH, totalLines, pos)))
 	}
 
 	return b.String()
@@ -782,7 +782,7 @@ func (m helmDetailModel) renderHelmValuesTab() string {
 		chartInfo = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render(
 			fmt.Sprintf("  (%s)", m.helmData.ChartRepoName))
 	}
-	b.WriteString(fmt.Sprintf("  %s%s\n\n", headerStyle.Render("Chart Values"), chartInfo))
+	fmt.Fprintf(&b, "  %s%s\n\n", headerStyle.Render("Chart Values"), chartInfo)
 
 	visibleNodes := flattenOutputTree(m.valuesTree)
 
@@ -861,7 +861,7 @@ func (m helmDetailModel) renderHelmValuesTab() string {
 			line = selectedBg.Render(line)
 		}
 
-		b.WriteString(fmt.Sprintf("  %s%s\n", cursor, line))
+		fmt.Fprintf(&b, "  %s%s\n", cursor, line)
 	}
 
 	// Scroll indicator
@@ -876,9 +876,9 @@ func (m helmDetailModel) renderHelmValuesTab() string {
 			pct := (scrollOffset * 100) / (totalEntries - visibleRows)
 			pos = fmt.Sprintf("%d%%", pct)
 		}
-		b.WriteString(fmt.Sprintf("\n  %s\n", dimStyle.Render(fmt.Sprintf("↑↓: navigate  enter: expand/collapse  [%d/%d %s]", m.valuesCursor+1, totalEntries, pos))))
+		fmt.Fprintf(&b, "\n  %s\n", dimStyle.Render(fmt.Sprintf("↑↓: navigate  enter: expand/collapse  [%d/%d %s]", m.valuesCursor+1, totalEntries, pos)))
 	} else {
-		b.WriteString(fmt.Sprintf("\n  %s\n", lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render("↑↓: navigate  enter: expand/collapse")))
+		fmt.Fprintf(&b, "\n  %s\n", lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render("↑↓: navigate  enter: expand/collapse"))
 	}
 
 	return b.String()

--- a/cmd/instance/debug_terraform_detail_tui.go
+++ b/cmd/instance/debug_terraform_detail_tui.go
@@ -950,9 +950,9 @@ func (m terraformDetailModel) renderErrorModal() string {
 		vl := vlines[i]
 		if vl.sourceNum > 0 {
 			lineNum := lineNumStyle.Render(fmt.Sprintf("%4d", vl.sourceNum))
-			b.WriteString(fmt.Sprintf("  %s │ %s\n", lineNum, errStyle.Render(vl.text)))
+			fmt.Fprintf(&b, "  %s │ %s\n", lineNum, errStyle.Render(vl.text))
 		} else {
-			b.WriteString(fmt.Sprintf("  %s   %s\n", "    ", errStyle.Render(vl.text)))
+			fmt.Fprintf(&b, "  %s   %s\n", "    ", errStyle.Render(vl.text))
 		}
 	}
 	// Pad remaining lines
@@ -1231,7 +1231,7 @@ func (m terraformDetailModel) renderProgressTab() string {
 
 	if p.OperationID != "" {
 		subtleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-		b.WriteString(fmt.Sprintf("  Operation: %s\n", subtleStyle.Render(p.OperationID)))
+		fmt.Fprintf(&b, "  Operation: %s\n", subtleStyle.Render(p.OperationID))
 	}
 
 	// Progress bar
@@ -1248,18 +1248,18 @@ func (m terraformDetailModel) renderProgressTab() string {
 
 	bar := m.progressBar.ViewAs(percent)
 	readyText := fmt.Sprintf("%d/%d resources ready", ready, total)
-	b.WriteString(fmt.Sprintf("  %s  %s\n", bar, readyText))
+	fmt.Fprintf(&b, "  %s  %s\n", bar, readyText)
 
 	// Status counts
 	b.WriteString("\n")
 	counts := countResourceStates(p.Resources)
 	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
-	b.WriteString(fmt.Sprintf("  %s\n", headerStyle.Render("Resource Status Summary")))
+	fmt.Fprintf(&b, "  %s\n", headerStyle.Render("Resource Status Summary"))
 
 	for _, entry := range counts {
 		icon := stateIcon(entry.state)
 		sStyle := styleForStatus(entry.state)
-		b.WriteString(fmt.Sprintf("    %s %s %d\n", icon, sStyle.Render(entry.state), entry.count))
+		fmt.Fprintf(&b, "    %s %s %d\n", icon, sStyle.Render(entry.state), entry.count)
 	}
 
 	// Timing
@@ -1267,16 +1267,16 @@ func (m terraformDetailModel) renderProgressTab() string {
 		b.WriteString("\n")
 		subtleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
 		if p.StartedAt != "" {
-			b.WriteString(fmt.Sprintf("  Started:   %s\n", subtleStyle.Render(p.StartedAt)))
+			fmt.Fprintf(&b, "  Started:   %s\n", subtleStyle.Render(p.StartedAt))
 		}
 		if p.CompletedAt != "" {
-			b.WriteString(fmt.Sprintf("  Completed: %s\n", subtleStyle.Render(p.CompletedAt)))
+			fmt.Fprintf(&b, "  Completed: %s\n", subtleStyle.Render(p.CompletedAt))
 		}
 	}
 
 	// Resource list
 	b.WriteString("\n")
-	b.WriteString(fmt.Sprintf("  %s\n", headerStyle.Render(fmt.Sprintf("Resources (%d)", len(p.Resources)))))
+	fmt.Fprintf(&b, "  %s\n", headerStyle.Render(fmt.Sprintf("Resources (%d)", len(p.Resources))))
 	b.WriteString("\n")
 
 	// Table header
@@ -1289,7 +1289,7 @@ func (m terraformDetailModel) renderProgressTab() string {
 		stateStr := sStyle.Render(fmt.Sprintf("%-12s", res.State))
 		addr := addrStyle.Render(res.Address)
 		resType := typeStyle.Render(res.Type)
-		b.WriteString(fmt.Sprintf("  %s %s  %s  %s\n", icon, stateStr, addr, resType))
+		fmt.Fprintf(&b, "  %s %s  %s  %s\n", icon, stateStr, addr, resType)
 	}
 
 	return b.String()
@@ -1583,9 +1583,9 @@ func (m terraformDetailModel) renderOperationHistoryTab() string {
 			totalAttempts += len(g.attempts)
 		}
 	}
-	b.WriteString(fmt.Sprintf("  %s\n\n", headerStyle.Render(
+	fmt.Fprintf(&b, "  %s\n\n", headerStyle.Render(
 		fmt.Sprintf("Operation History (%d days, %d generations, %d attempts, %d entries)",
-			len(m.historyDates), totalGenerations, totalAttempts, len(m.history)))))
+			len(m.historyDates), totalGenerations, totalAttempts, len(m.history))))
 
 	rows := flattenTimeline(m.historyDates, m.planPreviewByOpID, m.planPreviewErrByOpID)
 
@@ -1642,7 +1642,7 @@ func (m terraformDetailModel) renderOperationHistoryTab() string {
 			if selected {
 				line = selectedBg.Render(line)
 			}
-			b.WriteString(fmt.Sprintf("  %s%s\n", cursor, line))
+			fmt.Fprintf(&b, "  %s%s\n", cursor, line)
 		} else if row.isGroupHeader {
 			g := row.group
 
@@ -1676,7 +1676,7 @@ func (m terraformDetailModel) renderOperationHistoryTab() string {
 				line = selectedBg.Render(line)
 			}
 
-			b.WriteString(fmt.Sprintf("  %s%s\n", cursor, line))
+			fmt.Fprintf(&b, "  %s%s\n", cursor, line)
 		} else if row.isAttemptHeader {
 			attempt := row.attempt
 
@@ -1711,7 +1711,7 @@ func (m terraformDetailModel) renderOperationHistoryTab() string {
 				line = selectedBg.Render(line)
 			}
 
-			b.WriteString(fmt.Sprintf("  %s%s\n", cursor, line))
+			fmt.Fprintf(&b, "  %s%s\n", cursor, line)
 		} else if row.isPlanPreviewRow {
 			// Dedicated plan preview row inserted before "apply"
 			connector := "│   │   ├─"
@@ -1726,7 +1726,7 @@ func (m terraformDetailModel) renderOperationHistoryTab() string {
 			if selected {
 				line = selectedBg.Render(line)
 			}
-			b.WriteString(fmt.Sprintf("  %s%s\n", cursor, line))
+			fmt.Fprintf(&b, "  %s%s\n", cursor, line)
 		} else {
 			// Child entry row
 			e := row.entry
@@ -1762,7 +1762,7 @@ func (m terraformDetailModel) renderOperationHistoryTab() string {
 				line = selectedBg.Render(line)
 			}
 
-			b.WriteString(fmt.Sprintf("  %s%s\n", cursor, line))
+			fmt.Fprintf(&b, "  %s%s\n", cursor, line)
 		}
 	}
 
@@ -1781,8 +1781,8 @@ func (m terraformDetailModel) renderOperationHistoryTab() string {
 			pct := (scrollOffset * 100) / maxOffset
 			pos = fmt.Sprintf("%d%%", pct)
 		}
-		b.WriteString(fmt.Sprintf("\n  %s\n", dimStyle.Render(
-			fmt.Sprintf("↑↓: navigate  enter: expand/collapse  [%d/%d %s]", m.historyCursor+1, totalRows, pos))))
+		fmt.Fprintf(&b, "\n  %s\n", dimStyle.Render(
+			fmt.Sprintf("↑↓: navigate  enter: expand/collapse  [%d/%d %s]", m.historyCursor+1, totalRows, pos)))
 	}
 
 	return b.String()
@@ -1852,7 +1852,7 @@ func (m terraformDetailModel) renderTerraformFilesTab() string {
 	var b strings.Builder
 
 	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
-	b.WriteString(fmt.Sprintf("  %s\n\n", headerStyle.Render(fmt.Sprintf("Files in %s", m.fileTree.BasePath))))
+	fmt.Fprintf(&b, "  %s\n\n", headerStyle.Render(fmt.Sprintf("Files in %s", m.fileTree.BasePath)))
 
 	dirStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("117")).Bold(true)
 	fileStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
@@ -1911,7 +1911,7 @@ func (m terraformDetailModel) renderTerraformFilesTab() string {
 			}
 		}
 
-		b.WriteString(fmt.Sprintf("  %s%s%s %s\n", cursor, indent, icon, name))
+		fmt.Fprintf(&b, "  %s%s%s %s\n", cursor, indent, icon, name)
 	}
 
 	// Scroll indicator
@@ -1926,9 +1926,9 @@ func (m terraformDetailModel) renderTerraformFilesTab() string {
 			pos = fmt.Sprintf("%d%%", pct)
 		}
 		dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
-		b.WriteString(fmt.Sprintf("\n  %s\n", dimStyle.Render(fmt.Sprintf("↑↓: navigate  enter: open/expand  esc: back  [%d/%d %s]", m.fileCursor+1, totalEntries, pos))))
+		fmt.Fprintf(&b, "\n  %s\n", dimStyle.Render(fmt.Sprintf("↑↓: navigate  enter: open/expand  esc: back  [%d/%d %s]", m.fileCursor+1, totalEntries, pos)))
 	} else {
-		b.WriteString(fmt.Sprintf("\n  %s\n", lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render("↑↓: navigate  enter: open/expand  esc: back")))
+		fmt.Fprintf(&b, "\n  %s\n", lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render("↑↓: navigate  enter: open/expand  esc: back"))
 	}
 
 	return b.String()
@@ -1948,8 +1948,8 @@ func (m terraformDetailModel) renderFileContent() string {
 	if m.fileTree != nil && m.fileCursor >= 0 && m.fileCursor < len(m.fileTree.Flat) {
 		entry := m.fileTree.Flat[m.fileCursor]
 		headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("117"))
-		b.WriteString(fmt.Sprintf("  %s\n", headerStyle.Render(entry.RelPath)))
-		b.WriteString(fmt.Sprintf("  %s\n\n", lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render("esc: back to file list  ↑↓/pgup/pgdn: scroll")))
+		fmt.Fprintf(&b, "  %s\n", headerStyle.Render(entry.RelPath))
+		fmt.Fprintf(&b, "  %s\n\n", lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render("esc: back to file list  ↑↓/pgup/pgdn: scroll"))
 		headerLines = 3
 	}
 
@@ -1997,9 +1997,9 @@ func (m terraformDetailModel) renderFileContent() string {
 		code := syntaxHighlightLine(vl.text, filename)
 		if vl.sourceNum > 0 {
 			lineNum := lineNumStyle.Render(fmt.Sprintf("%4d", vl.sourceNum))
-			b.WriteString(fmt.Sprintf("  %s │ %s\n", lineNum, code))
+			fmt.Fprintf(&b, "  %s │ %s\n", lineNum, code)
 		} else {
-			b.WriteString(fmt.Sprintf("  %s   %s\n", "    ", code))
+			fmt.Fprintf(&b, "  %s   %s\n", "    ", code)
 		}
 	}
 
@@ -2218,7 +2218,7 @@ func (m terraformDetailModel) renderPreviewModal() string {
 			style = headerLineStyle
 		}
 
-		b.WriteString(fmt.Sprintf("  %s\n", style.Render(text)))
+		fmt.Fprintf(&b, "  %s\n", style.Render(text))
 	}
 	for i := end - scroll; i < bodyH; i++ {
 		b.WriteString("\n")

--- a/cmd/instance/debug_terraform_logs.go
+++ b/cmd/instance/debug_terraform_logs.go
@@ -289,12 +289,12 @@ func (m terraformDetailModel) renderLogsTab() string {
 	if m.logLabel != "" {
 		labelText = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render("  " + m.logLabel)
 	}
-	b.WriteString(fmt.Sprintf("  %s%s%s%s\n\n",
+	fmt.Fprintf(&b, "  %s%s%s%s\n\n",
 		headerStyle.Render(fmt.Sprintf("Operation Logs (%d lines)", len(m.logLines))),
 		statusText,
 		followText,
 		labelText,
-	))
+	)
 
 	bodyH := m.bodyHeight() - 4
 	if bodyH < 1 {
@@ -335,9 +335,9 @@ func (m terraformDetailModel) renderLogsTab() string {
 		styled := highlightLogLine(vl.text)
 		if vl.sourceNum > 0 {
 			lineNum := lineNumStyle.Render(fmt.Sprintf("%4d", vl.sourceNum))
-			b.WriteString(fmt.Sprintf("  %s │ %s\n", lineNum, styled))
+			fmt.Fprintf(&b, "  %s │ %s\n", lineNum, styled)
 		} else {
-			b.WriteString(fmt.Sprintf("  %s   %s\n", "    ", styled))
+			fmt.Fprintf(&b, "  %s   %s\n", "    ", styled)
 		}
 	}
 
@@ -358,8 +358,8 @@ func (m terraformDetailModel) renderLogsTab() string {
 			pct := (scroll * 100) / maxScroll
 			pos = fmt.Sprintf("%d%%", pct)
 		}
-		b.WriteString(fmt.Sprintf("  %s\n", dimStyle.Render(
-			fmt.Sprintf("[%d/%d %s]", scroll+bodyH, totalLines, pos))))
+		fmt.Fprintf(&b, "  %s\n", dimStyle.Render(
+			fmt.Sprintf("[%d/%d %s]", scroll+bodyH, totalLines, pos)))
 	}
 
 	return b.String()

--- a/cmd/instance/debug_terraform_output_tree.go
+++ b/cmd/instance/debug_terraform_output_tree.go
@@ -271,7 +271,7 @@ func (m terraformDetailModel) renderTerraformOutputTab() string {
 	var b strings.Builder
 
 	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
-	b.WriteString(fmt.Sprintf("  %s\n\n", headerStyle.Render("Terraform Output")))
+	fmt.Fprintf(&b, "  %s\n\n", headerStyle.Render("Terraform Output"))
 
 	visibleNodes := flattenOutputTree(m.outputTree)
 
@@ -352,7 +352,7 @@ func (m terraformDetailModel) renderTerraformOutputTab() string {
 			line = selectedBg.Render(line)
 		}
 
-		b.WriteString(fmt.Sprintf("  %s%s\n", cursor, line))
+		fmt.Fprintf(&b, "  %s%s\n", cursor, line)
 	}
 
 	// Scroll indicator
@@ -367,9 +367,9 @@ func (m terraformDetailModel) renderTerraformOutputTab() string {
 			pct := (scrollOffset * 100) / (totalEntries - visibleRows)
 			pos = fmt.Sprintf("%d%%", pct)
 		}
-		b.WriteString(fmt.Sprintf("\n  %s\n", dimStyle.Render(fmt.Sprintf("↑↓: navigate  enter: expand/collapse  [%d/%d %s]", m.outputCursor+1, totalEntries, pos))))
+		fmt.Fprintf(&b, "\n  %s\n", dimStyle.Render(fmt.Sprintf("↑↓: navigate  enter: expand/collapse  [%d/%d %s]", m.outputCursor+1, totalEntries, pos)))
 	} else {
-		b.WriteString(fmt.Sprintf("\n  %s\n", lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render("↑↓: navigate  enter: expand/collapse")))
+		fmt.Fprintf(&b, "\n  %s\n", lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render("↑↓: navigate  enter: expand/collapse"))
 	}
 
 	return b.String()

--- a/cmd/instance/debug_workflow_errors_tab.go
+++ b/cmd/instance/debug_workflow_errors_tab.go
@@ -428,8 +428,8 @@ func renderWorkflowEventsTab(steps *ResourceWorkflowSteps, state *workflowErrors
 			pct := (scroll * 100) / maxScroll
 			pos = fmt.Sprintf("%d%%", pct)
 		}
-		b.WriteString(fmt.Sprintf("  %s\n", dimStyle.Render(
-			fmt.Sprintf("[%d/%d %s]", scroll+viewH, totalLines, pos))))
+		fmt.Fprintf(&b, "  %s\n", dimStyle.Render(
+			fmt.Sprintf("[%d/%d %s]", scroll+viewH, totalLines, pos)))
 	}
 
 	return b.String()
@@ -982,9 +982,9 @@ func renderWfEventModal(state *workflowErrorsState, width, height int) string {
 		vl := vlines[i]
 		if vl.sourceNum > 0 {
 			lineNum := lineNumStyle.Render(fmt.Sprintf("%4d", vl.sourceNum))
-			b.WriteString(fmt.Sprintf("  %s │ %s\n", lineNum, textStyle.Render(vl.text)))
+			fmt.Fprintf(&b, "  %s │ %s\n", lineNum, textStyle.Render(vl.text))
 		} else {
-			b.WriteString(fmt.Sprintf("  %s   %s\n", "    ", textStyle.Render(vl.text)))
+			fmt.Fprintf(&b, "  %s   %s\n", "    ", textStyle.Render(vl.text))
 		}
 	}
 	for i := end - scroll; i < bodyH; i++ {
@@ -1034,9 +1034,9 @@ func workflowEventsCopyText(steps *ResourceWorkflowSteps) string {
 	}
 	var b strings.Builder
 	for _, step := range steps.Steps {
-		b.WriteString(fmt.Sprintf("\n=== %s [%s] %s → %s ===\n", step.stepDisplayName(), step.Status, step.StartTime, step.EndTime))
+		fmt.Fprintf(&b, "\n=== %s [%s] %s → %s ===\n", step.stepDisplayName(), step.Status, step.StartTime, step.EndTime)
 		for _, evt := range step.Events {
-			b.WriteString(fmt.Sprintf("[%s] %s: %s\n", evt.EventTime, evt.EventType, evt.Message))
+			fmt.Fprintf(&b, "[%s] %s: %s\n", evt.EventTime, evt.EventType, evt.Message)
 		}
 	}
 	return b.String()

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/denisbrodbeck/machineid v1.0.1 // indirect
 	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/njayp/ophis v1.1.4
-	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.103
+	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.104
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/njayp/ophis v1.1.4 h1:6aq3UdU6MlGIjpg//IzKc2yIxHYMf6Rg1A5MLovM9gg=
 github.com/njayp/ophis v1.1.4/go.mod h1:F9KEnfeCJzCWo3e0JP2QqSCN04bXptXl1ico5lcLeYg=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.103 h1:W9Ar7jpy3LQxs5UrB1CDSLEjzaj3omnyeFV7RZ7/DZ4=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.103/go.mod h1:q0FPYLbtm+Aw6GW0xbeaMPHR4WGzoV61iTGFoOhO72M=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.104 h1:ANuzw2AZrouTYtw89xu28EB+dC090OfzV/4h7/Q0qYw=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.104/go.mod h1:q0FPYLbtm+Aw6GW0xbeaMPHR4WGzoV61iTGFoOhO72M=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
+github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5QvfrDyIgxBk=
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj1Br63c=

--- a/internal/config/config_file.go
+++ b/internal/config/config_file.go
@@ -35,9 +35,10 @@ type AuthConfig struct {
 }
 
 var (
-	ErrConfigFileNotFound = errors.New("auth failure: config file not found, please login first")
-	ErrAuthConfigNotFound = errors.New("auth failure: auth credentials not found, please login first")
-	ErrGitHubPATNotFound  = errors.New("no github personal access token found")
+	ErrConfigFileNotFound   = errors.New("auth failure: config file not found, please login first")
+	ErrAuthConfigNotFound   = errors.New("auth failure: auth credentials not found, please login first")
+	ErrRefreshTokenNotFound = errors.New("no refresh token available — please login again")
+	ErrGitHubPATNotFound    = errors.New("no github personal access token found")
 )
 
 // New initializes a config file for the given file path.
@@ -151,6 +152,16 @@ func CreateOrUpdateAuthConfig(authConfig AuthConfig) error {
 		return err
 	}
 
+	// Encrypt the refresh token before writing to disk
+	if authConfig.RefreshToken != "" {
+		encrypted, encErr := EncryptToken(authConfig.RefreshToken)
+		if encErr != nil {
+			authConfig.RefreshToken = ""
+		} else {
+			authConfig.RefreshToken = encrypted
+		}
+	}
+
 	if len(cfg.AuthConfigs) == 0 {
 		cfg.AuthConfigs = append(cfg.AuthConfigs, authConfig)
 	} else {
@@ -183,7 +194,17 @@ func LookupAuthConfig() (AuthConfig, error) {
 	}
 
 	if len(cfg.AuthConfigs) > 0 && cfg.AuthConfigs[0].Token != "" {
-		return cfg.AuthConfigs[0], nil
+		ac := cfg.AuthConfigs[0]
+		// Decrypt the refresh token after reading from disk
+		if ac.RefreshToken != "" {
+			decrypted, decErr := DecryptToken(ac.RefreshToken)
+			if decErr != nil {
+				ac.RefreshToken = ""
+			} else {
+				ac.RefreshToken = decrypted
+			}
+		}
+		return ac, nil
 	}
 
 	return authConfig, ErrAuthConfigNotFound

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -28,7 +29,8 @@ const (
 	omnistrateHostSchema = "OMNISTRATE_HOST_SCHEME"
 	omnistrateDocsDomain = "OMNISTRATE_DOCS_DOMAIN"
 	defaultRootDomain    = "omnistrate.cloud"
-	clientTimeout        = "CLIENT_TIMEOUT_IN_SECONDS"
+	clientTimeoutOld     = "CLIENT_TIMEOUT_IN_SECONDS"
+	clientTimeout        = "OMNISTRATE_CLIENT_TIMEOUT_IN_SECONDS"
 	retryWaitMin         = "OMNISTRATE_RETRY_WAIT_MIN_IN_SECONDS"
 	retryWaitMax         = "OMNISTRATE_RETRY_WAIT_MAX_IN_SECONDS"
 	retryMax             = "OMNISTRATE_RETRY_MAX"
@@ -168,7 +170,12 @@ func IsDryRun() bool {
 }
 
 func GetClientTimeout() time.Duration {
-	timeoutInSeconds := GetEnvAsInteger(clientTimeout, "300")
+	// Prefer OMNISTRATE_CLIENT_TIMEOUT_IN_SECONDS, fall back to CLIENT_TIMEOUT_IN_SECONDS
+	if v := os.Getenv(clientTimeout); v != "" {
+		timeoutInSeconds := GetEnvAsInteger(clientTimeout, "300")
+		return time.Duration(timeoutInSeconds) * time.Second
+	}
+	timeoutInSeconds := GetEnvAsInteger(clientTimeoutOld, "300")
 	return time.Duration(timeoutInSeconds) * time.Second
 }
 

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -67,7 +67,7 @@ func GetRefreshToken() (string, error) {
 		return "", err
 	}
 	if authConfig.RefreshToken == "" {
-		return "", ErrAuthConfigNotFound
+		return "", ErrRefreshTokenNotFound
 	}
 	return authConfig.RefreshToken, nil
 }

--- a/internal/config/configuration_test.go
+++ b/internal/config/configuration_test.go
@@ -82,9 +82,22 @@ func TestGetClientTimeout(t *testing.T) {
 }
 
 func TestGetClientTimeoutOverride(t *testing.T) {
-	t.Setenv(clientTimeout, "1")
+	t.Setenv(clientTimeoutOld, "1")
 	clientTimeout := GetClientTimeout()
 	assert.Equal(t, time.Duration(1)*time.Second, clientTimeout)
+}
+
+func TestGetClientTimeoutNewEnvVar(t *testing.T) {
+	t.Setenv(clientTimeout, "10")
+	clientTimeout := GetClientTimeout()
+	assert.Equal(t, time.Duration(10)*time.Second, clientTimeout)
+}
+
+func TestGetClientTimeoutNewEnvVarTakesPrecedence(t *testing.T) {
+	t.Setenv(clientTimeoutOld, "1")
+	t.Setenv(clientTimeout, "10")
+	clientTimeout := GetClientTimeout()
+	assert.Equal(t, time.Duration(10)*time.Second, clientTimeout)
 }
 
 func TestDryRun(t *testing.T) {

--- a/internal/config/crypto.go
+++ b/internal/config/crypto.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	"github.com/denisbrodbeck/machineid"
+)
+
+const appID = "omnistrate-ctl"
+
+// deriveKey returns a 32-byte AES-256 key derived from the machine ID.
+func deriveKey() ([]byte, error) {
+	id, err := machineid.ProtectedID(appID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get machine id: %w", err)
+	}
+	h := sha256.Sum256([]byte(id))
+	return h[:], nil
+}
+
+// EncryptToken encrypts plaintext using AES-256-GCM with a machine-bound key.
+// Returns a hex-encoded string of nonce+ciphertext.
+func EncryptToken(plaintext string) (string, error) {
+	key, err := deriveKey()
+	if err != nil {
+		return "", err
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return "", fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, []byte(plaintext), nil)
+	return hex.EncodeToString(ciphertext), nil
+}
+
+// DecryptToken decrypts a hex-encoded AES-256-GCM ciphertext using the machine-bound key.
+func DecryptToken(encoded string) (string, error) {
+	key, err := deriveKey()
+	if err != nil {
+		return "", err
+	}
+
+	data, err := hex.DecodeString(encoded)
+	if err != nil {
+		return "", fmt.Errorf("failed to decode token: %w", err)
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return "", fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(data) < nonceSize {
+		return "", fmt.Errorf("ciphertext too short")
+	}
+
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to decrypt token: %w", err)
+	}
+
+	return string(plaintext), nil
+}

--- a/internal/config/crypto_test.go
+++ b/internal/config/crypto_test.go
@@ -1,0 +1,64 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEncryptDecryptToken(t *testing.T) {
+	require := require.New(t)
+
+	token := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test-refresh-token"
+
+	encrypted, err := EncryptToken(token)
+	require.NoError(err)
+	require.NotEmpty(encrypted)
+	require.NotEqual(token, encrypted, "encrypted should differ from plaintext")
+
+	decrypted, err := DecryptToken(encrypted)
+	require.NoError(err)
+	require.Equal(token, decrypted)
+}
+
+func TestEncryptTokenProducesDifferentCiphertexts(t *testing.T) {
+	require := require.New(t)
+
+	token := "same-token-value"
+
+	enc1, err := EncryptToken(token)
+	require.NoError(err)
+
+	enc2, err := EncryptToken(token)
+	require.NoError(err)
+
+	require.NotEqual(enc1, enc2, "each encryption should use a unique nonce")
+
+	// Both should decrypt to the same value
+	dec1, err := DecryptToken(enc1)
+	require.NoError(err)
+	dec2, err := DecryptToken(enc2)
+	require.NoError(err)
+	require.Equal(dec1, dec2)
+}
+
+func TestDecryptTokenInvalidData(t *testing.T) {
+	require := require.New(t)
+
+	_, err := DecryptToken("not-hex")
+	require.Error(err)
+
+	_, err = DecryptToken("deadbeef")
+	require.Error(err)
+}
+
+func TestEncryptDecryptEmptyString(t *testing.T) {
+	require := require.New(t)
+
+	encrypted, err := EncryptToken("")
+	require.NoError(err)
+
+	decrypted, err := DecryptToken(encrypted)
+	require.NoError(err)
+	require.Equal("", decrypted)
+}

--- a/internal/config/crypto_test.go
+++ b/internal/config/crypto_test.go
@@ -9,7 +9,7 @@ import (
 func TestEncryptDecryptToken(t *testing.T) {
 	require := require.New(t)
 
-	token := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test-refresh-token"
+	token := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test-refresh-token" // #nosec G101 -- test data, not a real credential
 
 	encrypted, err := EncryptToken(token)
 	require.NoError(err)

--- a/internal/dataaccess/deploymententity.go
+++ b/internal/dataaccess/deploymententity.go
@@ -31,7 +31,7 @@ func GetInstanceDeploymentEntity(ctx context.Context, token string, instanceID s
 		}
 	}()
 
-	response, err = httpClient.Do(request)
+	response, err = httpClient.Do(request) // #nosec G704 -- URL host is hardcoded to localhost
 	if err != nil {
 		err = errors.Wrap(err, "Could not retrieve instance deployment information. Please try executing the command within the dataplane agent pod.")
 		return "", err
@@ -67,7 +67,7 @@ func PauseInstanceDeploymentEntity(ctx context.Context, token string, instanceID
 		}
 	}()
 
-	response, err = httpClient.Do(request)
+	response, err = httpClient.Do(request) // #nosec G704 -- URL host is hardcoded to localhost
 	if err != nil {
 		err = errors.Wrap(err, "failed to pause instance deployment entity, you need to run it on dataplane agent")
 		return err
@@ -126,7 +126,7 @@ func ResumeInstanceDeploymentEntity(ctx context.Context, token string, instanceI
 		}
 	}()
 
-	response, err = httpClient.Do(request)
+	response, err = httpClient.Do(request) // #nosec G704 -- URL host is hardcoded to localhost
 	if err != nil {
 		err = errors.Wrap(err, "failed to resume instance deployment entity, you need to run it on dataplane agent")
 		return err
@@ -194,7 +194,7 @@ func PatchInstanceDeploymentEntity(ctx context.Context, token string, instanceID
 		}
 	}()
 
-	response, err = httpClient.Do(request)
+	response, err = httpClient.Do(request) // #nosec G704 -- URL host is hardcoded to localhost
 	if err != nil {
 		err = errors.Wrap(err, "failed to patch instance deployment entity, you need to run it on dataplane agent")
 		return err

--- a/internal/dataaccess/deploymententity.go
+++ b/internal/dataaccess/deploymententity.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/pkg/errors"
 	"os"
 	"path/filepath"
+
+	"github.com/pkg/errors"
 
 	"fmt"
 	"io"

--- a/internal/dataaccess/logs.go
+++ b/internal/dataaccess/logs.go
@@ -19,7 +19,7 @@ type LogsStream struct {
 type LogsConfig struct {
 	BaseURL  string
 	Username string
-	Password string
+	Password string // #nosec G117 -- field must hold log service credentials
 }
 
 // LogsService provides methods for log-related operations

--- a/internal/dataaccess/refresh_token.go
+++ b/internal/dataaccess/refresh_token.go
@@ -37,7 +37,7 @@ func RefreshToken(ctx context.Context, refreshToken string) (LoginResult, error)
 	req.Header.Set("User-Agent", config.GetUserAgent())
 
 	client := getRetryableHttpClient()
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704 -- URL constructed from config constants
 	if err != nil {
 		return LoginResult{}, fmt.Errorf("refresh token request failed: %w", err)
 	}

--- a/internal/dataaccess/signin.go
+++ b/internal/dataaccess/signin.go
@@ -29,10 +29,7 @@ func LoginWithPassword(ctx context.Context, email string, pass string) (LoginRes
 		return LoginResult{}, err
 	}
 
-	result := LoginResult{JWTToken: resp.JwtToken}
-	if rt, ok := resp.AdditionalProperties["refreshToken"].(string); ok {
-		result.RefreshToken = rt
-	}
+	result := LoginResult{JWTToken: resp.JwtToken, RefreshToken: utils.FromPtr(resp.RefreshToken)}
 	return result, nil
 }
 
@@ -52,9 +49,6 @@ func LoginWithIdentityProvider(ctx context.Context, deviceCode, identityProvider
 		return LoginResult{}, err
 	}
 
-	result := LoginResult{JWTToken: resp.JwtToken}
-	if rt, ok := resp.AdditionalProperties["refreshToken"].(string); ok {
-		result.RefreshToken = rt
-	}
+	result := LoginResult{JWTToken: resp.JwtToken, RefreshToken: utils.FromPtr(resp.RefreshToken)}
 	return result, nil
 }

--- a/internal/utils/crash.go
+++ b/internal/utils/crash.go
@@ -55,13 +55,13 @@ func buildCrashLog(panicValue interface{}, stack string) string {
 	var b strings.Builder
 
 	b.WriteString("=== omnistrate-ctl crash report ===\n")
-	b.WriteString(fmt.Sprintf("Time:    %s\n", time.Now().UTC().Format(time.RFC3339)))
-	b.WriteString(fmt.Sprintf("Version: %s\n", config.Version))
-	b.WriteString(fmt.Sprintf("Commit:  %s\n", config.CommitID))
-	b.WriteString(fmt.Sprintf("OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH))
-	b.WriteString(fmt.Sprintf("Go:      %s\n", runtime.Version()))
-	b.WriteString(fmt.Sprintf("\nPanic: %v\n", panicValue))
-	b.WriteString(fmt.Sprintf("\nStack trace:\n%s\n", stack))
+	fmt.Fprintf(&b, "Time:    %s\n", time.Now().UTC().Format(time.RFC3339))
+	fmt.Fprintf(&b, "Version: %s\n", config.Version)
+	fmt.Fprintf(&b, "Commit:  %s\n", config.CommitID)
+	fmt.Fprintf(&b, "OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+	fmt.Fprintf(&b, "Go:      %s\n", runtime.Version())
+	fmt.Fprintf(&b, "\nPanic: %v\n", panicValue)
+	fmt.Fprintf(&b, "\nStack trace:\n%s\n", stack)
 
 	return b.String()
 }


### PR DESCRIPTION
## Summary

Update SDK and encrypt refresh tokens at rest.

## Refresh Token Encryption

The refresh token stored in `~/.omnistrate/config.yml` is now encrypted using **AES-256-GCM** with a machine-bound key, so the token cannot be used if the config file is copied to a different machine.

### How it works

1. **Machine ID** — `machineid.ProtectedID("omnistrate-ctl")` returns an HMAC-SHA256 of the platform-specific hardware identifier (macOS `IOPlatformUUID`, Linux `/etc/machine-id`, Windows `MachineGuid` registry key), keyed with the app name `omnistrate-ctl`.
2. **Key derivation** — The machine ID hash is passed through SHA-256 to produce a 32-byte AES-256 key.
3. **Encryption** — A random 12-byte nonce is generated per encryption. The refresh token is encrypted with AES-256-GCM and stored as hex-encoded `nonce || ciphertext` in the config file.
4. **Decryption** — On read, the nonce is split from the ciphertext and decrypted using the same machine-bound key.

### Failure handling

- If decryption fails (e.g. config copied from another machine, or pre-encryption plaintext token), the refresh token is silently cleared — the user will need to re-login.
- If encryption fails, the refresh token is stored empty rather than blocking the login flow.
- The `omnistrate-ctl refresh` command returns a clear error message: `"no refresh token available — please login again"`.

### CI

The auth smoke tests now run on a multi-platform matrix (Linux AMD64, Linux ARM64, macOS, Windows) to validate the machine-bound encryption works across all supported platforms.

### Dependencies

- Added `github.com/denisbrodbeck/machineid` for cross-platform machine identification.