### PR TITLE
ci: native multi-arch image builds + Dockerfile build-time optimizations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,16 @@ omnistrate-ctl
 __debug_bin*
 **/.claude/settings.local.json
 mcp-tools.json
+
+# Speed up Docker context transfer: exclude items not needed for `go build`.
+.git/
+.github/
+.vscode/
+mkdocs/
+doc-gen/
+test/
+build/Dockerfile.docs*
+**/*_test.go
+**/testdata/
+coverage*
+*.md

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,11 +4,17 @@ on:
   push:
     paths:
       - build/Dockerfile
+      - .dockerignore
+      - .github/workflows/package.yml
+      - .github/workflows/release.yml
     branches:
       - main
   pull_request:
     paths:
       - build/Dockerfile
+      - .dockerignore
+      - .github/workflows/package.yml
+      - .github/workflows/release.yml
     branches:
       - main
 
@@ -30,13 +36,22 @@ concurrency:
 
 jobs:
   package:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    name: Build image ${{ matrix.platform }} (no push)
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+
     concurrency:
-      group: package-${{ github.workflow }}-${{ github.head_ref }}
+      group: package-${{ github.workflow }}-${{ github.head_ref || github.run_id }}-${{ matrix.platform }}
       cancel-in-progress: true
 
     steps:
@@ -45,8 +60,6 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-        with:
-          platforms: ${{ env.PLATFORMS }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
@@ -61,76 +74,22 @@ jobs:
             type=semver,pattern={{major}}
             type=sha,format=long
 
-      - name: Build on ${{ env.PR_PLATFORMS }} only
+      # Validate the same native-arch build path used by the release workflow,
+      # but never push the resulting image.
+      - name: Build ${{ matrix.platform }}
+        timeout-minutes: 30
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: ./build/Dockerfile
-          platforms: ${{ env.PR_PLATFORMS }}
+          platforms: ${{ matrix.platform }}
           push: false
+          load: false
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            GIT_COMMIT=${{ github.sha }}
-            GIT_VERSION=${{ github.ref_name }}
-            GOPROXY=https://proxy.golang.org,direct
-            GOSUMDB=sum.golang.org
-
-  package-multi-arch:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' }}
-    permissions:
-      contents: read
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
-      id-token: write
-
-    concurrency:
-      group: package-${{ github.workflow }}-${{ github.head_ref }}
-      cancel-in-progress: true
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-        with:
-          platforms: ${{ env.PLATFORMS }}
-
-      # Extract metadata (tags, labels) for Docker
-      # https://github.com/docker/metadata-action
-      - name: Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha,format=long
-
-      # https://github.com/docker/build-push-action
-      - name: Build and push multi-arch
-        timeout-minutes: 60
-        if: github.event_name != 'pull_request'
-        id: build-and-push
-        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
-        with:
-          context: .
-          file: ./build/Dockerfile
-          platforms: ${{ env.PLATFORMS }}
-          push: false
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          annotations: ${{ steps.meta.outputs.annotations }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
           build-args: |
             GIT_COMMIT=${{ github.sha }}
             GIT_VERSION=${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,7 +334,8 @@ jobs:
   release-package-multi-arch:
     timeout-minutes: 60
     environment: Prod
-    runs-on: ubuntu-latest
+    name: Build image ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
     needs: [sanity-check, smoke-tests]
     permissions:
       contents: read
@@ -343,37 +344,25 @@ jobs:
       # with sigstore/fulcio when running outside of PRs.
       id-token: write
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+
     concurrency:
-      group: package-${{ github.workflow }}-${{ github.head_ref }}
+      group: package-${{ github.workflow }}-${{ github.head_ref }}-${{ matrix.platform }}
       cancel-in-progress: true
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
-
-      - name: Check install!
-        run: cosign version
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
-        with:
-          platforms: ${{ env.PLATFORMS }}
-
-      # Login against a Docker registry
-      # https://github.com/docker/login-action
-      - name: Log into registry ${{ env.REGISTRY }}
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
@@ -388,43 +377,134 @@ jobs:
             type=semver,pattern={{major}}
             type=sha,format=long
 
+      # Login against a Docker registry
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Build and push by digest on the native architecture runner.
       # https://github.com/docker/build-push-action
-      - name: Build and push multi-arch
+      - name: Build and push ${{ matrix.platform }} by digest
+        id: build
         timeout-minutes: 60
-        id: build-and-push
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: ./build/Dockerfile
-          platforms: ${{ env.PLATFORMS }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          annotations: ${{ steps.meta.outputs.annotations }}
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
           build-args: |
             GIT_COMMIT=${{ github.sha }}
             GIT_VERSION=${{ github.ref_name }}
             GOPROXY=https://proxy.golang.org,direct
             GOSUMDB=sum.golang.org
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
 
-      # Sign the resulting Docker image digest except on PRs.
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-${{ matrix.runner }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  release-package-multi-arch-merge:
+    name: Merge multi-arch manifest and sign
+    timeout-minutes: 30
+    environment: Prod
+    runs-on: ubuntu-latest
+    needs: [release-package-multi-arch]
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: digests-*
+          merge-multiple: true
+          path: /tmp/digests
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,format=long
+
+      # Login against a Docker registry
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect image
+        id: inspect
+        run: |
+          IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          docker buildx imagetools inspect ${IMAGE}:${{ steps.meta.outputs.version }}
+          DIGEST=$(docker buildx imagetools inspect ${IMAGE}:${{ steps.meta.outputs.version }} --format '{{json .Manifest}}' | jq -r .digest)
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
+      - name: Check install!
+        run: cosign version
+
+      # Sign the resulting Docker image digest by the manifest list digest.
       # https://github.com/sigstore/cosign
       - name: Sign the images with GitHub OIDC Token
         env:
-          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+          DIGEST: ${{ steps.inspect.outputs.digest }}
           TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           images=""
           for tag in ${TAGS}; do
-            images+="${tag}@${DIGEST} "
+            images+="${tag%%:*}@${DIGEST} "
           done
           cosign sign --yes ${images}
 
   update-docs:
     name: Update CTL documents
     needs:
-      - release-package-multi-arch
+      - release-package-multi-arch-merge
       - update-brew-formula
       - release-binaries
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,9 +340,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
-      id-token: write
 
     strategy:
       fail-fast: false
@@ -489,17 +486,13 @@ jobs:
         run: cosign version
 
       # Sign the resulting Docker image digest by the manifest list digest.
+      # Signing once by digest covers all tags pointing at this manifest.
       # https://github.com/sigstore/cosign
-      - name: Sign the images with GitHub OIDC Token
+      - name: Sign the image with GitHub OIDC Token
         env:
           DIGEST: ${{ steps.inspect.outputs.digest }}
-          TAGS: ${{ steps.meta.outputs.tags }}
-        run: |
-          images=""
-          for tag in ${TAGS}; do
-            images+="${tag%%:*}@${DIGEST} "
-          done
-          cosign sign --yes ${images}
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
 
   update-docs:
     name: Update CTL documents

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,12 +1,11 @@
 # syntax=docker/dockerfile:1
 
 ## Build
-FROM golang:1.25-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS builder
 
-RUN apk update && apk add git make
+RUN apk add --no-cache git
 
 WORKDIR /go/src/ctl
-COPY ./ .
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -14,31 +13,40 @@ ARG GOPROXY
 ARG GOSUMDB
 ARG GIT_COMMIT
 ARG GIT_VERSION
-ENV CGO_ENABLED=0
-ENV GIT_COMMIT=${GIT_COMMIT}
-ENV GIT_VERSION=${GIT_VERSION}
 
-RUN echo Fetching project dependencies
-RUN --mount=type=cache,target=/go/pkg/mod \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-    make download
+ENV CGO_ENABLED=0 \
+    GOOS=${TARGETOS} \
+    GOARCH=${TARGETARCH} \
+    GOPROXY=${GOPROXY} \
+    GOSUMDB=${GOSUMDB} \
+    GIT_COMMIT=${GIT_COMMIT} \
+    GIT_VERSION=${GIT_VERSION}
 
-RUN --mount=type=cache,target=/go/pkg/mod \
-    GOOS=${TARGETOS} GOARCH=${TARGETARCH} go mod vendor
+# Download modules first to maximize layer cache reuse across source changes.
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod,sharing=locked \
+    go mod download
 
-RUN echo Building and installing Monitoring Service
-RUN --mount=type=cache,target=/go/pkg/mod \
-    --mount=type=cache,target=/root/.cache/go-build \
-    make build
-    
+# Bring in the rest of the source via bind mount to avoid an extra COPY layer
+# and rely on BuildKit cache mounts for the module and build caches.
+RUN --mount=type=bind,source=.,target=/go/src/ctl,rw \
+    --mount=type=cache,target=/go/pkg/mod,sharing=locked \
+    --mount=type=cache,target=/root/.cache/go-build,id=gobuild-${TARGETOS}-${TARGETARCH} \
+    BUILD_INFO_PKG=github.com/omnistrate-oss/omnistrate-ctl/internal/config && \
+    BUILD_TIMESTAMP=$(date -u +'%Y-%m-%dT%H:%M:%SZ') && \
+    go build -mod=mod -trimpath \
+      -ldflags "-s -w \
+        -X ${BUILD_INFO_PKG}.CommitID=${GIT_COMMIT} \
+        -X ${BUILD_INFO_PKG}.Timestamp=${BUILD_TIMESTAMP} \
+        -X ${BUILD_INFO_PKG}.Version=${GIT_VERSION}" \
+      -o /out/omnistrate-ctl \
+      github.com/omnistrate-oss/omnistrate-ctl
+
 ## Deploy
 FROM alpine:latest AS app
 
-ARG TARGETOS
-ARG TARGETARCH
+RUN apk add --no-cache ca-certificates curl jq
 
-RUN apk update && apk add --no-cache ca-certificates curl jq
-
-COPY --from=builder /go/src/ctl/dist/omnistrate-ctl-${TARGETOS}-${TARGETARCH} /usr/local/bin/omnistrate-ctl
+COPY --from=builder /out/omnistrate-ctl /usr/local/bin/omnistrate-ctl
 WORKDIR /omnistrate
 ENTRYPOINT [ "/usr/local/bin/omnistrate-ctl" ]


### PR DESCRIPTION
## Summary

Speeds up the release container build and fixes the long-running `release-package-multi-arch` job by:

1. **Native per-arch builds** (mirrors the dataplane-agent pipeline)
   - Matrix builds: `linux/amd64` on `ubuntu-latest`, `linux/arm64` on `ubuntu-24.04-arm`.
   - No more QEMU emulation.
   - Each platform pushes by digest (`push-by-digest=true`, `name-canonical=true`) and uploads the digest as an artifact.
   - New `release-package-multi-arch-merge` job downloads digests, assembles the manifest list with `docker buildx imagetools create`, and signs the final manifest digest with cosign.
   - `update-docs` now depends on the merge job.

2. **Dockerfile optimizations** (`build/Dockerfile`)
   - Split `go.mod`/`go.sum` download into its own cached layer so source changes don't reinvalidate module download.
   - Removed redundant `go mod vendor`.
   - Removed `make build` indirection (which also ran `go test -c ./test/integration_test/...` — unused in the image and a significant compile cost). Now invokes `go build` directly with the same ldflags.
   - Bind-mount the source instead of `COPY ./ .` and use BuildKit cache mounts for `/go/pkg/mod` and `/root/.cache/go-build` (per-arch scoped cache id).
   - Use `--platform=$BUILDPLATFORM` on the builder stage; Go cross-compiles via `GOOS`/`GOARCH`.
   - Dropped unused `make` install and `apk update`.

3. **`.dockerignore`** — exclude `.git/`, `.github/`, `mkdocs/`, `doc-gen/`, `test/`, `**/*_test.go`, `testdata/`, `*.md`, etc. Smaller build context = faster context transfer and fewer cache busts from unrelated changes.

## Why
The previous `release-package-multi-arch` job hung in `Build and push multi-arch` (e.g. run [25120647050](https://github.com/omnistrate-oss/omnistrate-ctl/actions/runs/25120647050/job/73632416563)) because cross-arch QEMU compilation of Go + redundant test binary builds took too long. Native runners + a leaner Dockerfile bring the build close to the time of a single `go build`.