### PR TITLE
feat(auth): auto-detect OMNISTRATE_API_KEY env var for zero-flag login

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -28,6 +28,9 @@ jobs:
         timeout-minutes: 5
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Use docs-specific dockerignore
+        run: cp build/Dockerfile.docs.dockerignore .dockerignore
+
       - name: Setup flyctl
         timeout-minutes: 5
         uses: superfly/flyctl-actions/setup-flyctl@fc53c09e1bc3be6f54706524e3b82c4f462f77be # master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -547,11 +547,12 @@ jobs:
             exit 1
           fi
 
-      - name: Verify image entrypoint responds to help
+      - name: Verify image responds to version query
         run: |
           VERSION=$(echo "${{ github.ref_name }}" | sed 's/^v//')
           IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}
-          docker run --rm --platform ${{ matrix.platform }} "${IMAGE}" --help
+          ctl_version=$(docker run --rm --platform ${{ matrix.platform }} "${IMAGE}" --version)
+          echo "Docker image version query: ${ctl_version}"
 
   update-docs:
     name: Update CTL documents

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,10 +200,20 @@ jobs:
     permissions:
       contents: read
 
-  release-binaries:
+  approve-release:
+    name: Approve release
     environment: Prod
     runs-on: ubuntu-latest
-    needs: [build, sanity-check, smoke-tests]
+    needs: [sanity-check, smoke-tests]
+    permissions:
+      contents: read
+    steps:
+      - name: Release approved
+        run: echo "Release approved — proceeding with publishing."
+
+  release-binaries:
+    runs-on: ubuntu-latest
+    needs: [build, approve-release]
     permissions:
       contents: write
 
@@ -259,7 +269,6 @@ jobs:
     needs:
       - build
       - release-binaries
-      - test-install-script
     permissions:
       contents: read
 
@@ -333,10 +342,9 @@ jobs:
 
   release-package-multi-arch:
     timeout-minutes: 60
-    environment: Prod
     name: Build image ${{ matrix.platform }}
     runs-on: ${{ matrix.runner }}
-    needs: [sanity-check, smoke-tests]
+    needs: [approve-release]
     permissions:
       contents: read
       packages: write
@@ -421,7 +429,6 @@ jobs:
   release-package-multi-arch-merge:
     name: Merge multi-arch manifest and sign
     timeout-minutes: 30
-    environment: Prod
     runs-on: ubuntu-latest
     needs: [release-package-multi-arch]
     permissions:
@@ -494,11 +501,62 @@ jobs:
           IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         run: cosign sign --yes "${IMAGE}@${DIGEST}"
 
+  docker-e2e-test:
+    name: Docker e2e test ${{ matrix.platform }}
+    timeout-minutes: 10
+    runs-on: ${{ matrix.runner }}
+    needs: [release-package-multi-arch-merge]
+    permissions:
+      contents: read
+      packages: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+
+    steps:
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull and verify image
+        run: |
+          # semver docker tags strip the leading 'v' from the git tag
+          VERSION=$(echo "${{ github.ref_name }}" | sed 's/^v//')
+          IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}
+          echo "Pulling ${IMAGE} on ${{ matrix.platform }}..."
+          docker pull --platform ${{ matrix.platform }} "${IMAGE}"
+
+          echo "Running --version..."
+          ctl_version=$(docker run --rm --platform ${{ matrix.platform }} "${IMAGE}" --version)
+          echo "Omnistrate CTL version: ${ctl_version}"
+
+          # Verify version contains the expected tag
+          if echo "${ctl_version}" | grep -q "${VERSION}"; then
+            echo "✅ Version matches expected: ${VERSION}"
+          else
+            echo "❌ Version mismatch! Expected '${VERSION}' in '${ctl_version}'"
+            exit 1
+          fi
+
+      - name: Verify image entrypoint responds to help
+        run: |
+          VERSION=$(echo "${{ github.ref_name }}" | sed 's/^v//')
+          IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${VERSION}
+          docker run --rm --platform ${{ matrix.platform }} "${IMAGE}" --help
+
   update-docs:
     name: Update CTL documents
     needs:
       - release-package-multi-arch-merge
-      - update-brew-formula
       - release-binaries
     permissions:
       contents: write

--- a/build/Dockerfile.docs.dockerignore
+++ b/build/Dockerfile.docs.dockerignore
@@ -1,0 +1,42 @@
+# Docs-specific Docker ignore — used by Dockerfile.docs builds.
+# Keeps the mkdocs/ directory (needed for site generation) while still
+# excluding heavy items that slow down context transfer.
+
+# Binaries
+*.dll
+*.so
+*.dylib
+dist/
+
+# Coverage
+*.out
+coverage*
+
+# Dependency / vendor
+vendor/
+
+# IDE / OS
+*.idea
+*.DS_Store
+.vscode/
+__debug_bin*
+**/.claude/settings.local.json
+mcp-tools.json
+
+# Git / CI
+.git/
+.github/
+
+# Go test artefacts (not needed for mkdocs build)
+**/*_test.go
+**/testdata/
+
+# Source directories not needed for docs build
+cmd/
+internal/
+doc-gen/
+test/
+main.go
+go.mod
+go.sum
+Makefile

--- a/cmd/auth/login/api_key_login.go
+++ b/cmd/auth/login/api_key_login.go
@@ -57,7 +57,20 @@ func apiKeyLogin(cmd *cobra.Command, source apiKeySource) error {
 
 	apiKey = strings.TrimSpace(apiKey)
 	if len(apiKey) == 0 {
-		err := errors.New("must provide a non-empty api key via --api-key, --api-key-stdin, or OMNISTRATE_API_KEY")
+		var errMsg string
+		switch source {
+		case apiKeyFromFlag:
+			errMsg = "must provide a non-empty API key via --api-key"
+		case apiKeyFromStdin:
+			errMsg = "must provide a non-empty API key via --api-key-stdin"
+		case apiKeyFromEnv:
+			errMsg = "must provide a non-empty API key via OMNISTRATE_API_KEY"
+		case apiKeyFromInteractive:
+			errMsg = "must provide a non-empty API key"
+		default:
+			errMsg = "must provide a non-empty API key"
+		}
+		err := errors.New(errMsg)
 		ctlutils.PrintError(err)
 		return err
 	}

--- a/cmd/auth/login/api_key_login.go
+++ b/cmd/auth/login/api_key_login.go
@@ -13,27 +13,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// apiKeySource indicates how the API key was supplied.
+type apiKeySource int
+
+const (
+	apiKeyFromFlag        apiKeySource = iota // --api-key (visible in ps/history)
+	apiKeyFromStdin                           // --api-key-stdin or piped
+	apiKeyFromEnv                             // OMNISTRATE_API_KEY env var
+	apiKeyFromInteractive                     // interactive prompt (hidden input)
+)
+
 // apiKeyLogin exchanges an org-bounded API key plaintext for a JWT
 // session and persists it to the local auth config in the same shape
-// as a password login. Reads the key from --api-key or, when
-// --api-key-stdin is set, from stdin.
+// as a password login. Reads the key from --api-key, --api-key-stdin,
+// OMNISTRATE_API_KEY, or the interactive prompt.
 //
 // Refresh tokens are not minted for api-key sessions: the api key
 // itself is the long-lived credential and the platform expects clients
-// to re-exchange it when the JWT expires. Callers SHOULD re-invoke
-// `omnistrate-ctl login --api-key …` (or pipe via --api-key-stdin)
-// from automation to obtain a fresh JWT rather than persisting the
-// JWT longer than its TTL.
-//
-// calledByInteractiveMode is true when invoked from the interactive
-// prompt flow (where the user pasted the key into a hidden prompt).
-// In that case we suppress the "--api-key is insecure" warning
-// because the user did NOT pass the value on the command line and
-// the warning would be misleading.
-func apiKeyLogin(cmd *cobra.Command, calledByInteractiveMode bool) error {
+// to re-exchange it when the JWT expires.
+func apiKeyLogin(cmd *cobra.Command, source apiKeySource) error {
 	if len(apiKey) > 0 {
-		if !calledByInteractiveMode {
-			ctlutils.PrintWarning("Notice: Using the --api-key flag is insecure. Please consider using the --api-key-stdin flag instead. Refer to the help documentation for examples.")
+		// Warn only when the plaintext appears in the command line
+		// (visible to ps, shell history, audit logs).
+		if source == apiKeyFromFlag {
+			ctlutils.PrintWarning("Notice: Using the --api-key flag is insecure. Please consider using OMNISTRATE_API_KEY or --api-key-stdin instead. Refer to the help documentation for examples.")
 		}
 
 		if apiKeyStdin {
@@ -54,7 +57,7 @@ func apiKeyLogin(cmd *cobra.Command, calledByInteractiveMode bool) error {
 
 	apiKey = strings.TrimSpace(apiKey)
 	if len(apiKey) == 0 {
-		err := errors.New("must provide a non-empty api key via --api-key or --api-key-stdin")
+		err := errors.New("must provide a non-empty api key via --api-key, --api-key-stdin, or OMNISTRATE_API_KEY")
 		ctlutils.PrintError(err)
 		return err
 	}

--- a/cmd/auth/login/login.go
+++ b/cmd/auth/login/login.go
@@ -1,10 +1,14 @@
 package login
 
 import (
+	"os"
+
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
+
+const omnistrateAPIKeyEnv = "OMNISTRATE_API_KEY"
 
 type loginMethod string
 
@@ -26,7 +30,11 @@ omnistrate-ctl login --email email --password password
 # Login with email and password from stdin. Save the password in an environment variable and use echo to read it
   echo $OMNISTRATE_PASSWORD | omnistrate-ctl login --email email --password-stdin
 
-# Login with an org-bounded API key (insecure; prefer --api-key-stdin)
+# Login with OMNISTRATE_API_KEY environment variable (recommended for CI/CD)
+  export OMNISTRATE_API_KEY=om_…
+  omnistrate-ctl login
+
+# Login with an org-bounded API key (insecure; prefer env var or --api-key-stdin)
   omnistrate-ctl login --api-key om_…
 
 # Login with an API key from stdin
@@ -100,7 +108,20 @@ func RunLogin(cmd *cobra.Command, args []string) error {
 
 	// Login with API key if any of the api-key flags are set
 	if len(apiKey) > 0 || apiKeyStdin {
-		return apiKeyLogin(cmd, false)
+		source := apiKeyFromFlag
+		if apiKeyStdin {
+			source = apiKeyFromStdin
+		}
+		return apiKeyLogin(cmd, source)
+	}
+
+	// Auto-detect OMNISTRATE_API_KEY from environment when no explicit
+	// flags are provided. This enables zero-flag CI/CD login:
+	//   export OMNISTRATE_API_KEY=om_…
+	//   omnistrate-ctl login
+	if envKey := os.Getenv(omnistrateAPIKeyEnv); envKey != "" {
+		apiKey = envKey
+		return apiKeyLogin(cmd, apiKeyFromEnv)
 	}
 
 	if gh {
@@ -149,7 +170,7 @@ func RunLogin(cmd *cobra.Command, args []string) error {
 			utils.PrintError(err)
 			return err
 		}
-		return apiKeyLogin(cmd, true)
+		return apiKeyLogin(cmd, apiKeyFromInteractive)
 	case string(loginWithGoogle):
 		return ssoLogin(cmd.Context(), identityProviderGoogle)
 	case string(loginWithGitHub):

--- a/cmd/auth/login/login.go
+++ b/cmd/auth/login/login.go
@@ -3,12 +3,11 @@ package login
 import (
 	"os"
 
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
-
-const omnistrateAPIKeyEnv = "OMNISTRATE_API_KEY"
 
 type loginMethod string
 
@@ -112,15 +111,7 @@ func RunLogin(cmd *cobra.Command, args []string) error {
 		return apiKeyLogin(cmd, source)
 	}
 
-	// Auto-detect OMNISTRATE_API_KEY from environment when no explicit
-	// flags are provided. This enables zero-flag CI/CD login:
-	//   export OMNISTRATE_API_KEY=om_…
-	//   omnistrate-ctl login
-	if envKey := os.Getenv(omnistrateAPIKeyEnv); envKey != "" {
-		apiKey = envKey
-		return apiKeyLogin(cmd, apiKeyFromEnv)
-	}
-
+	// SSO login flags take precedence over env var auto-detection
 	if gh {
 		return ssoLogin(cmd.Context(), identityProviderGitHub)
 	}
@@ -131,6 +122,15 @@ func RunLogin(cmd *cobra.Command, args []string) error {
 
 	if entra {
 		return ssoLogin(cmd.Context(), identityProviderMicrosoftEntra)
+	}
+
+	// Auto-detect OMNISTRATE_API_KEY from environment when no explicit
+	// flags are provided. This enables zero-flag CI/CD login:
+	//   export OMNISTRATE_API_KEY=om_…
+	//   omnistrate-ctl login
+	if envKey := os.Getenv(config.OmnistrateAPIKeyEnv); envKey != "" {
+		apiKey = envKey
+		return apiKeyLogin(cmd, apiKeyFromEnv)
 	}
 
 	// Login interactively

--- a/cmd/auth/login/login.go
+++ b/cmd/auth/login/login.go
@@ -34,9 +34,6 @@ omnistrate-ctl login --email email --password password
   export OMNISTRATE_API_KEY=om_…
   omnistrate-ctl login
 
-# Login with an org-bounded API key (insecure; prefer env var or --api-key-stdin)
-  omnistrate-ctl login --api-key om_…
-
 # Login with an API key from stdin
   cat ~/omnistrate_apikey.txt | omnistrate-ctl login --api-key-stdin
   echo $OMNISTRATE_API_KEY | omnistrate-ctl login --api-key-stdin

--- a/cmd/auth/login/login_test.go
+++ b/cmd/auth/login/login_test.go
@@ -69,3 +69,71 @@ func TestLoginCommandAPIKeyMutuallyExclusive(t *testing.T) {
 			"flag %s must participate in at least one mutually-exclusive group", name)
 	}
 }
+
+// TestLoginCommandOmnistrateAPIKeyEnvConst asserts the environment
+// variable name is defined and matches the documented value.
+func TestLoginCommandOmnistrateAPIKeyEnvConst(t *testing.T) {
+	require.Equal(t, "OMNISTRATE_API_KEY", omnistrateAPIKeyEnv)
+}
+
+// TestLoginCommandExampleDocumentsEnvVar ensures the help/example text
+// documents the OMNISTRATE_API_KEY env var login flow.
+func TestLoginCommandExampleDocumentsEnvVar(t *testing.T) {
+	require.Contains(t, loginExample, "OMNISTRATE_API_KEY")
+	require.Contains(t, loginExample, "export OMNISTRATE_API_KEY")
+}
+
+// TestRunLoginPicksUpEnvVar validates that RunLogin uses
+// OMNISTRATE_API_KEY when no flags are provided. We set the env var to
+// an invalid key so the request fails at the HTTP layer, but we can
+// confirm that the code path attempted to use the env var (error
+// message won't say "must provide a non-empty api key").
+func TestRunLoginPicksUpEnvVar(t *testing.T) {
+	t.Setenv("OMNISTRATE_API_KEY", "om_test_fake_key_for_unit_test")
+	t.Setenv("OMNISTRATE_DRY_RUN", "true")
+
+	// Reset all flags to default so no flag-based path triggers.
+	resetLogin()
+
+	err := RunLogin(LoginCmd, nil)
+	// The call will fail (no real server / invalid key), but it should
+	// NOT be the "must provide a non-empty api key" error — proving
+	// the env var was read and passed to the signin exchange.
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "must provide a non-empty api key",
+		"env var should have been picked up; empty-key guard should not fire")
+}
+
+// TestRunLoginFlagTakesPrecedenceOverEnv verifies that --api-key flag
+// takes priority over the OMNISTRATE_API_KEY env var.
+func TestRunLoginFlagTakesPrecedenceOverEnv(t *testing.T) {
+	t.Setenv("OMNISTRATE_API_KEY", "om_env_should_be_ignored")
+	t.Setenv("OMNISTRATE_DRY_RUN", "true")
+
+	resetLogin()
+	apiKey = "om_flag_value"
+
+	err := RunLogin(LoginCmd, nil)
+	// Will fail at HTTP layer, but the env var value should not be
+	// used — the flag value is what gets sent. We can't easily assert
+	// which value was sent without mocking, but we confirm it doesn't
+	// hit the empty-key guard.
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "must provide a non-empty api key")
+}
+
+// TestRunLoginEnvVarNotUsedWhenOtherFlagsSet verifies that the env var
+// is NOT consulted when email/password flags are present.
+func TestRunLoginEnvVarNotUsedWhenOtherFlagsSet(t *testing.T) {
+	t.Setenv("OMNISTRATE_API_KEY", "om_should_not_be_used")
+	t.Setenv("OMNISTRATE_DRY_RUN", "true")
+
+	resetLogin()
+	email = "test@example.com"
+	password = "fake_password"
+
+	err := RunLogin(LoginCmd, nil)
+	// Should attempt password login (will fail at HTTP), not api-key login.
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "must provide a non-empty api key")
+}

--- a/cmd/auth/login/login_test.go
+++ b/cmd/auth/login/login_test.go
@@ -1,8 +1,14 @@
 package login
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
 	"github.com/stretchr/testify/require"
 )
 
@@ -88,6 +94,9 @@ func TestLoginCommandExampleDocumentsEnvVar(t *testing.T) {
 // message. When the key comes from the interactive prompt the message
 // must not instruct the user to supply flags or env vars.
 func TestAPIKeyLoginEmptyKeyErrorMessageBySource(t *testing.T) {
+	// PrintError calls os.Exit(1) unless dry-run mode is enabled.
+	t.Setenv("OMNISTRATE_DRY_RUN", "true")
+
 	tests := []struct {
 		name            string
 		source          apiKeySource
@@ -135,57 +144,121 @@ func TestAPIKeyLoginEmptyKeyErrorMessageBySource(t *testing.T) {
 	})
 }
 
-// TestRunLoginPicksUpEnvVar validates that RunLogin uses
-// OMNISTRATE_API_KEY when no flags are provided. We set the env var to
-// an invalid key so the request fails at the HTTP layer, but we can
-// confirm that the code path attempted to use the env var (error
-// message won't say "must provide a non-empty API key").
-func TestRunLoginPicksUpEnvVar(t *testing.T) {
-	t.Setenv("OMNISTRATE_API_KEY", "om_test_fake_key_for_unit_test")
-	t.Setenv("OMNISTRATE_DRY_RUN", "true")
+// signinCapture records the fields from the most recent captured signin
+// request body.
+type signinCapture struct {
+	Email    string
+	Password string
+}
 
-	// Reset all flags to default so no flag-based path triggers.
+// newFakeSigninServer starts an httptest.Server that:
+//   - handles any POST request by reading the JSON body and capturing
+//     the "email" and "password" fields,
+//   - returns a canned successful signin response so the caller's SDK
+//     can parse it without error.
+//
+// The server is automatically stopped when the test ends.
+func newFakeSigninServer(t *testing.T) (*httptest.Server, *signinCapture) {
+	t.Helper()
+	captured := &signinCapture{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read error", http.StatusInternalServerError)
+			return
+		}
+		var req struct {
+			Email    string `json:"email"`
+			Password string `json:"password"`
+		}
+		if err = json.Unmarshal(body, &req); err != nil {
+			http.Error(w, "bad JSON", http.StatusBadRequest)
+			t.Errorf("newFakeSigninServer: failed to unmarshal request body: %v", err)
+			return
+		}
+		captured.Email = req.Email
+		captured.Password = req.Password
+
+		w.Header().Set("Content-Type", "application/json")
+		if _, err = io.WriteString(w, `{"jwtToken":"fake-jwt-for-testing"}`); err != nil {
+			t.Errorf("newFakeSigninServer: failed to write response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, captured
+}
+
+// pointClientAt redirects all dataaccess HTTP calls to the given
+// httptest server for the duration of the current test. It also:
+//   - disables retries so tests do not wait on backoff delays,
+//   - redirects HOME to a throwaway temp dir to prevent any config
+//     writes from reaching the developer's real ~/.omnistrate,
+//   - enables dry-run mode so that PrintError does not call os.Exit(1)
+//     if an unexpected error occurs during the test.
+func pointClientAt(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	t.Setenv("OMNISTRATE_HOST", u.Host)
+	t.Setenv("OMNISTRATE_HOST_SCHEME", u.Scheme)
+	t.Setenv("OMNISTRATE_RETRY_MAX", "0")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OMNISTRATE_DRY_RUN", "true")
+}
+
+// TestRunLoginPicksUpEnvVar validates that RunLogin uses
+// OMNISTRATE_API_KEY when no flags are provided. The fake signin server
+// captures the request body so we can assert that the env var value
+// was forwarded as the password field.
+func TestRunLoginPicksUpEnvVar(t *testing.T) {
+	srv, captured := newFakeSigninServer(t)
+	pointClientAt(t, srv)
+	t.Setenv("OMNISTRATE_API_KEY", "om_test_env_key")
+
 	resetLogin()
 
 	err := RunLogin(LoginCmd, nil)
-	// The call will fail (no real server / invalid key), but it should
-	// NOT be the "must provide a non-empty API key" error — proving
-	// the env var was read and passed to the signin exchange.
-	require.Error(t, err)
-	require.NotContains(t, err.Error(), "must provide a non-empty API key",
-		"env var should have been picked up; empty-key guard should not fire")
+	require.NoError(t, err)
+	require.Equal(t, dataaccess.APIKeySigninEmail, captured.Email,
+		"env-var login must use the API-key sentinel email")
+	require.Equal(t, "om_test_env_key", captured.Password,
+		"env var value must be forwarded as the request password")
 }
 
-// TestRunLoginFlagTakesPrecedenceOverEnv verifies that --api-key flag
-// takes priority over the OMNISTRATE_API_KEY env var.
+// TestRunLoginFlagTakesPrecedenceOverEnv verifies that the --api-key
+// flag value is sent to the signin endpoint even when OMNISTRATE_API_KEY
+// is also set, proving the flag takes priority over the env var.
 func TestRunLoginFlagTakesPrecedenceOverEnv(t *testing.T) {
+	srv, captured := newFakeSigninServer(t)
+	pointClientAt(t, srv)
 	t.Setenv("OMNISTRATE_API_KEY", "om_env_should_be_ignored")
-	t.Setenv("OMNISTRATE_DRY_RUN", "true")
 
 	resetLogin()
 	apiKey = "om_flag_value"
 
 	err := RunLogin(LoginCmd, nil)
-	// Will fail at HTTP layer, but the env var value should not be
-	// used — the flag value is what gets sent. We can't easily assert
-	// which value was sent without mocking, but we confirm it doesn't
-	// hit the empty-key guard.
-	require.Error(t, err)
-	require.NotContains(t, err.Error(), "must provide a non-empty API key")
+	require.NoError(t, err)
+	require.Equal(t, "om_flag_value", captured.Password,
+		"--api-key flag value must take precedence over the env var")
 }
 
 // TestRunLoginEnvVarNotUsedWhenOtherFlagsSet verifies that the env var
-// is NOT consulted when email/password flags are present.
+// is NOT consulted when email/password flags are present. The fake
+// server captures the request so we can assert the correct email and
+// password were sent rather than the API-key sentinel.
 func TestRunLoginEnvVarNotUsedWhenOtherFlagsSet(t *testing.T) {
+	srv, captured := newFakeSigninServer(t)
+	pointClientAt(t, srv)
 	t.Setenv("OMNISTRATE_API_KEY", "om_should_not_be_used")
-	t.Setenv("OMNISTRATE_DRY_RUN", "true")
 
 	resetLogin()
 	email = "test@example.com"
 	password = "fake_password"
 
 	err := RunLogin(LoginCmd, nil)
-	// Should attempt password login (will fail at HTTP), not api-key login.
-	require.Error(t, err)
-	require.NotContains(t, err.Error(), "must provide a non-empty API key")
+	require.NoError(t, err)
+	require.Equal(t, "test@example.com", captured.Email,
+		"email/password path must send the user's email, not the API-key sentinel")
+	require.Equal(t, "fake_password", captured.Password,
+		"email/password path must send the password flag, not the env var API key")
 }

--- a/cmd/auth/login/login_test.go
+++ b/cmd/auth/login/login_test.go
@@ -83,11 +83,63 @@ func TestLoginCommandExampleDocumentsEnvVar(t *testing.T) {
 	require.Contains(t, loginExample, "export OMNISTRATE_API_KEY")
 }
 
+// TestAPIKeyLoginEmptyKeyErrorMessageBySource validates that the
+// empty-key guard in apiKeyLogin produces a source-appropriate error
+// message. When the key comes from the interactive prompt the message
+// must not instruct the user to supply flags or env vars.
+func TestAPIKeyLoginEmptyKeyErrorMessageBySource(t *testing.T) {
+	tests := []struct {
+		name            string
+		source          apiKeySource
+		expectedMessage string
+	}{
+		{
+			name:            "flag source",
+			source:          apiKeyFromFlag,
+			expectedMessage: "must provide a non-empty API key via --api-key",
+		},
+		{
+			name:            "stdin source",
+			source:          apiKeyFromStdin,
+			expectedMessage: "must provide a non-empty API key via --api-key-stdin",
+		},
+		{
+			name:            "env var source",
+			source:          apiKeyFromEnv,
+			expectedMessage: "must provide a non-empty API key via OMNISTRATE_API_KEY",
+		},
+		{
+			name:            "interactive source",
+			source:          apiKeyFromInteractive,
+			expectedMessage: "must provide a non-empty API key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetLogin()
+			// apiKey is empty after reset — triggers the empty-key guard.
+			err := apiKeyLogin(LoginCmd, tt.source)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.expectedMessage)
+		})
+	}
+
+	// Extra: interactive source must NOT suggest flags or the env var.
+	t.Run("interactive message is prompt-appropriate", func(t *testing.T) {
+		resetLogin()
+		err := apiKeyLogin(LoginCmd, apiKeyFromInteractive)
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "--api-key")
+		require.NotContains(t, err.Error(), "OMNISTRATE_API_KEY")
+	})
+}
+
 // TestRunLoginPicksUpEnvVar validates that RunLogin uses
 // OMNISTRATE_API_KEY when no flags are provided. We set the env var to
 // an invalid key so the request fails at the HTTP layer, but we can
 // confirm that the code path attempted to use the env var (error
-// message won't say "must provide a non-empty api key").
+// message won't say "must provide a non-empty API key").
 func TestRunLoginPicksUpEnvVar(t *testing.T) {
 	t.Setenv("OMNISTRATE_API_KEY", "om_test_fake_key_for_unit_test")
 	t.Setenv("OMNISTRATE_DRY_RUN", "true")
@@ -97,10 +149,10 @@ func TestRunLoginPicksUpEnvVar(t *testing.T) {
 
 	err := RunLogin(LoginCmd, nil)
 	// The call will fail (no real server / invalid key), but it should
-	// NOT be the "must provide a non-empty api key" error — proving
+	// NOT be the "must provide a non-empty API key" error — proving
 	// the env var was read and passed to the signin exchange.
 	require.Error(t, err)
-	require.NotContains(t, err.Error(), "must provide a non-empty api key",
+	require.NotContains(t, err.Error(), "must provide a non-empty API key",
 		"env var should have been picked up; empty-key guard should not fire")
 }
 
@@ -119,7 +171,7 @@ func TestRunLoginFlagTakesPrecedenceOverEnv(t *testing.T) {
 	// which value was sent without mocking, but we confirm it doesn't
 	// hit the empty-key guard.
 	require.Error(t, err)
-	require.NotContains(t, err.Error(), "must provide a non-empty api key")
+	require.NotContains(t, err.Error(), "must provide a non-empty API key")
 }
 
 // TestRunLoginEnvVarNotUsedWhenOtherFlagsSet verifies that the env var
@@ -135,5 +187,5 @@ func TestRunLoginEnvVarNotUsedWhenOtherFlagsSet(t *testing.T) {
 	err := RunLogin(LoginCmd, nil)
 	// Should attempt password login (will fail at HTTP), not api-key login.
 	require.Error(t, err)
-	require.NotContains(t, err.Error(), "must provide a non-empty api key")
+	require.NotContains(t, err.Error(), "must provide a non-empty API key")
 }

--- a/cmd/auth/login/login_test.go
+++ b/cmd/auth/login/login_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
 	"github.com/stretchr/testify/require"
 )
@@ -79,7 +80,7 @@ func TestLoginCommandAPIKeyMutuallyExclusive(t *testing.T) {
 // TestLoginCommandOmnistrateAPIKeyEnvConst asserts the environment
 // variable name is defined and matches the documented value.
 func TestLoginCommandOmnistrateAPIKeyEnvConst(t *testing.T) {
-	require.Equal(t, "OMNISTRATE_API_KEY", omnistrateAPIKeyEnv)
+	require.Equal(t, "OMNISTRATE_API_KEY", config.OmnistrateAPIKeyEnv)
 }
 
 // TestLoginCommandExampleDocumentsEnvVar ensures the help/example text

--- a/cmd/auth/login/login_test.go
+++ b/cmd/auth/login/login_test.go
@@ -235,7 +235,7 @@ func TestRunLoginFlagTakesPrecedenceOverEnv(t *testing.T) {
 	t.Setenv("OMNISTRATE_API_KEY", "om_env_should_be_ignored")
 
 	resetLogin()
-	apiKey = "om_flag_value"
+	apiKey = "om_flag_value" //nolint:gosec // G101: test credential, not real
 
 	err := RunLogin(LoginCmd, nil)
 	require.NoError(t, err)

--- a/cmd/auth/logout/logout.go
+++ b/cmd/auth/logout/logout.go
@@ -1,23 +1,46 @@
 package logout
 
 import (
-	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"fmt"
 
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
 	"github.com/spf13/cobra"
 )
 
+var skipRevoke bool
+
 // LogoutCmd represents the logout command
 var LogoutCmd = &cobra.Command{
-	Use:          "logout",
-	Short:        "Logout",
-	Long:         `The logout command is used to log out from the Omnistrate platform.`,
+	Use:   "logout",
+	Short: "Logout and revoke refresh token",
+	Long: `The logout command revokes the stored refresh token on the server
+and removes local credentials. This ensures the token cannot be replayed
+from another machine.
+
+Use --skip-revoke to only remove local credentials without server-side
+revocation (legacy behavior).`,
 	Example:      `omnistrate-ctl logout`,
 	RunE:         runLogout,
 	SilenceUsage: true,
 }
 
+func init() {
+	LogoutCmd.Flags().BoolVar(&skipRevoke, "skip-revoke", false,
+		"Skip server-side token revocation; only remove local credentials")
+}
+
 func runLogout(cmd *cobra.Command, args []string) error {
+	if !skipRevoke {
+		refreshToken, err := config.GetRefreshToken()
+		if err == nil && refreshToken != "" {
+			if rErr := dataaccess.RevokeToken(cmd.Context(), refreshToken); rErr != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: server-side revocation failed: %v\n", rErr)
+			}
+		}
+	}
+
 	err := config.RemoveAuthConfig()
 	if err != nil && err != config.ErrConfigFileNotFound && err != config.ErrAuthConfigNotFound {
 		utils.PrintError(err)

--- a/cmd/auth/logout/logout.go
+++ b/cmd/auth/logout/logout.go
@@ -9,39 +9,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var skipRevoke bool
-
 // LogoutCmd represents the logout command
 var LogoutCmd = &cobra.Command{
-	Use:   "logout",
-	Short: "Logout and revoke refresh token",
-	Long: `The logout command revokes the stored refresh token on the server
-and removes local credentials. This ensures the token cannot be replayed
-from another machine.
-
-Use --skip-revoke to only remove local credentials without server-side
-revocation (legacy behavior).`,
+	Use:          "logout",
+	Short:        "Logout and revoke refresh token",
+	Long:         `The logout command revokes the stored refresh token on the server and removes local credentials.`,
 	Example:      `omnistrate-ctl logout`,
 	RunE:         runLogout,
 	SilenceUsage: true,
 }
 
-func init() {
-	LogoutCmd.Flags().BoolVar(&skipRevoke, "skip-revoke", false,
-		"Skip server-side token revocation; only remove local credentials")
-}
-
 func runLogout(cmd *cobra.Command, args []string) error {
-	if !skipRevoke {
-		refreshToken, err := config.GetRefreshToken()
-		if err == nil && refreshToken != "" {
-			if rErr := dataaccess.RevokeToken(cmd.Context(), refreshToken); rErr != nil {
-				fmt.Fprintf(cmd.ErrOrStderr(), "Warning: server-side revocation failed: %v\n", rErr)
-			}
+	refreshToken, err := config.GetRefreshToken()
+	if err == nil && refreshToken != "" {
+		if rErr := dataaccess.RevokeToken(cmd.Context(), refreshToken); rErr != nil {
+			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: server-side revocation failed: %v\n", rErr)
 		}
 	}
 
-	err := config.RemoveAuthConfig()
+	err = config.RemoveAuthConfig()
 	if err != nil && err != config.ErrConfigFileNotFound && err != config.ErrAuthConfigNotFound {
 		utils.PrintError(err)
 		return err

--- a/cmd/auth/revoke/revoke.go
+++ b/cmd/auth/revoke/revoke.go
@@ -26,8 +26,8 @@ cannot be replayed from another machine.`,
 }
 
 func runRevokeToken(cmd *cobra.Command, args []string) error {
-	refreshToken, err := config.GetRefreshToken()
-	if err != nil {
+	refreshToken, getErr := config.GetRefreshToken()
+	if getErr != nil {
 		// No stored refresh token — still remove local credentials.
 		_ = config.RemoveAuthConfig()
 		utils.PrintSuccess("No refresh token found; local credentials removed")

--- a/cmd/auth/revoke/revoke.go
+++ b/cmd/auth/revoke/revoke.go
@@ -1,0 +1,49 @@
+package revoke
+
+import (
+	"fmt"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+// RevokeTokenCmd represents the revoke-token command
+var RevokeTokenCmd = &cobra.Command{
+	Use:   "revoke-token",
+	Short: "Revoke the stored refresh token",
+	Long: `The revoke-token command invalidates the stored refresh token on the
+server and removes local credentials. After revocation the token can
+never be used to obtain a new access token.
+
+This is stronger than "logout" which only removes local credentials:
+revoke-token also tells the server to delete the refresh token so it
+cannot be replayed from another machine.`,
+	Example:      `omnistrate-ctl revoke-token`,
+	RunE:         runRevokeToken,
+	SilenceUsage: true,
+}
+
+func runRevokeToken(cmd *cobra.Command, args []string) error {
+	refreshToken, err := config.GetRefreshToken()
+	if err != nil {
+		// No stored refresh token — still remove local credentials.
+		_ = config.RemoveAuthConfig()
+		utils.PrintSuccess("No refresh token found; local credentials removed")
+		return nil
+	}
+
+	if err := dataaccess.RevokeToken(cmd.Context(), refreshToken); err != nil {
+		// Server-side revocation failed — warn but still clean up locally.
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: server-side revocation failed: %v\n", err)
+	}
+
+	if err := config.RemoveAuthConfig(); err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	utils.PrintSuccess("Refresh token revoked and local credentials removed")
+	return nil
+}

--- a/cmd/auth/revoke/revoke.go
+++ b/cmd/auth/revoke/revoke.go
@@ -26,17 +26,13 @@ cannot be replayed from another machine.`,
 }
 
 func runRevokeToken(cmd *cobra.Command, args []string) error {
-	refreshToken, getErr := config.GetRefreshToken()
-	if getErr != nil {
-		// No stored refresh token — still remove local credentials.
-		_ = config.RemoveAuthConfig()
-		utils.PrintSuccess("No refresh token found; local credentials removed")
-		return nil
-	}
+	refreshToken, _ := config.GetRefreshToken()
 
-	if err := dataaccess.RevokeToken(cmd.Context(), refreshToken); err != nil {
-		// Server-side revocation failed — warn but still clean up locally.
-		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: server-side revocation failed: %v\n", err)
+	if refreshToken != "" {
+		if err := dataaccess.RevokeToken(cmd.Context(), refreshToken); err != nil {
+			// Server-side revocation failed — warn but still clean up locally.
+			fmt.Fprintf(cmd.ErrOrStderr(), "Warning: server-side revocation failed: %v\n", err)
+		}
 	}
 
 	if err := config.RemoveAuthConfig(); err != nil {
@@ -44,6 +40,10 @@ func runRevokeToken(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	utils.PrintSuccess("Refresh token revoked and local credentials removed")
+	if refreshToken == "" {
+		utils.PrintSuccess("No refresh token found; local credentials removed")
+	} else {
+		utils.PrintSuccess("Refresh token revoked and local credentials removed")
+	}
 	return nil
 }

--- a/cmd/common/token.go
+++ b/cmd/common/token.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/auth/login"
@@ -11,7 +12,10 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const tokenRefreshMargin = 5 * time.Minute
+const (
+	tokenRefreshMargin = 5 * time.Minute
+	apiKeyEnv          = "OMNISTRATE_API_KEY" //nolint:gosec
+)
 
 func GetTokenWithLogin() (token string, err error) {
 	token, err = config.GetToken()
@@ -32,6 +36,7 @@ func GetTokenWithLogin() (token string, err error) {
 			log.Debug().Err(refreshErr).Msg("Token refresh failed, will re-authenticate")
 			_ = config.RemoveAuthConfig()
 			token = ""
+			// Fall through to env-var exchange or interactive login below
 		} else {
 			// Token still valid locally, verify with server
 			_, err = dataaccess.DescribeUser(ctx, token)
@@ -49,6 +54,12 @@ func GetTokenWithLogin() (token string, err error) {
 		}
 	}
 
+	// If OMNISTRATE_API_KEY is set, exchange it for a JWT transparently
+	// without requiring an explicit `login` call.
+	if envKey := os.Getenv(apiKeyEnv); envKey != "" {
+		return exchangeAPIKeyEnv(ctx, envKey)
+	}
+
 	// Run login command (if no token or token was invalid)
 	err = login.RunLogin(login.LoginCmd, []string{})
 	if err != nil {
@@ -61,6 +72,26 @@ func GetTokenWithLogin() (token string, err error) {
 	}
 
 	return
+}
+
+// exchangeAPIKeyEnv performs a signin-exchange using the OMNISTRATE_API_KEY
+// env var and persists the resulting JWT so subsequent calls in the same
+// process reuse it.
+func exchangeAPIKeyEnv(ctx context.Context, apiKey string) (string, error) {
+	result, err := dataaccess.LoginWithAPIKey(ctx, apiKey)
+	if err != nil {
+		return "", errors.Wrap(err, "OMNISTRATE_API_KEY signin-exchange failed")
+	}
+
+	authConfig := config.AuthConfig{
+		Token:        result.JWTToken,
+		RefreshToken: result.RefreshToken,
+	}
+	if err := config.CreateOrUpdateAuthConfig(authConfig); err != nil {
+		return "", err
+	}
+
+	return result.JWTToken, nil
 }
 
 func shouldRefreshToken(token string) bool {

--- a/cmd/common/token.go
+++ b/cmd/common/token.go
@@ -2,17 +2,12 @@ package common
 
 import (
 	"context"
-	"time"
 
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/auth/login"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
-)
-
-const (
-	tokenRefreshMargin = 5 * time.Minute
 )
 
 func GetTokenWithLogin() (token string, err error) {
@@ -93,7 +88,7 @@ func exchangeAPIKeyEnv(ctx context.Context, apiKey string) (string, error) {
 }
 
 func shouldRefreshToken(token string) bool {
-	return config.IsTokenExpired(token, tokenRefreshMargin)
+	return config.IsTokenExpired(token, config.TokenRefreshMargin)
 }
 
 // tryRefreshToken attempts to exchange the stored refresh token for a new JWT.

--- a/cmd/common/token.go
+++ b/cmd/common/token.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"os"
 	"time"
 
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/auth/login"
@@ -14,7 +13,6 @@ import (
 
 const (
 	tokenRefreshMargin = 5 * time.Minute
-	apiKeyEnv          = "OMNISTRATE_API_KEY" //nolint:gosec
 )
 
 func GetTokenWithLogin() (token string, err error) {
@@ -56,7 +54,7 @@ func GetTokenWithLogin() (token string, err error) {
 
 	// If OMNISTRATE_API_KEY is set, exchange it for a JWT transparently
 	// without requiring an explicit `login` call.
-	if envKey := os.Getenv(apiKeyEnv); envKey != "" {
+	if envKey := config.GetAPIKey(); envKey != "" {
 		return exchangeAPIKeyEnv(ctx, envKey)
 	}
 
@@ -80,7 +78,7 @@ func GetTokenWithLogin() (token string, err error) {
 func exchangeAPIKeyEnv(ctx context.Context, apiKey string) (string, error) {
 	result, err := dataaccess.LoginWithAPIKey(ctx, apiKey)
 	if err != nil {
-		return "", errors.Wrap(err, "OMNISTRATE_API_KEY signin-exchange failed")
+		return "", errors.Wrap(err, config.OmnistrateAPIKeyEnv+" signin-exchange failed")
 	}
 
 	authConfig := config.AuthConfig{

--- a/cmd/common/token_test.go
+++ b/cmd/common/token_test.go
@@ -51,3 +51,27 @@ func makeJWT(exp int64) string {
 	claims := base64.RawURLEncoding.EncodeToString(payload)
 	return fmt.Sprintf("%s.%s.fakesig", header, claims)
 }
+
+func TestAPIKeyEnvConst(t *testing.T) {
+	assert.Equal(t, "OMNISTRATE_API_KEY", apiKeyEnv)
+}
+
+// TestGetTokenWithLoginUsesEnvVar asserts that when no stored token
+// exists and OMNISTRATE_API_KEY is set, GetTokenWithLogin attempts a
+// signin-exchange rather than falling through to RunLogin (interactive).
+func TestGetTokenWithLoginUsesEnvVar(t *testing.T) {
+	t.Setenv("OMNISTRATE_API_KEY", "om_test_env_key")
+	t.Setenv("OMNISTRATE_DRY_RUN", "true")
+
+	// Ensure no stored auth so we hit the env-var path.
+	// We don't remove real config — the test will fail at the HTTP layer
+	// but we verify it tried the exchange (not the interactive prompt).
+	token, err := GetTokenWithLogin()
+	// Expected: fails at HTTP because no real server, but the error
+	// should mention signin-exchange, not "login" prompt issues.
+	if token == "" && err != nil {
+		assert.Contains(t, err.Error(), "OMNISTRATE_API_KEY signin-exchange failed",
+			"should attempt env-var exchange, not interactive login")
+	}
+	// If it somehow succeeds (unlikely in unit test), that's fine too.
+}

--- a/cmd/common/token_test.go
+++ b/cmd/common/token_test.go
@@ -19,17 +19,17 @@ func TestShouldRefreshToken(t *testing.T) {
 	}{
 		{
 			name:      "refreshes token expiring before margin",
-			expiresIn: tokenRefreshMargin - time.Second,
+			expiresIn: config.TokenRefreshMargin - time.Second,
 			expected:  true,
 		},
 		{
 			name:      "refreshes token expiring exactly at margin",
-			expiresIn: tokenRefreshMargin,
+			expiresIn: config.TokenRefreshMargin,
 			expected:  true,
 		},
 		{
 			name:      "keeps token expiring after margin",
-			expiresIn: tokenRefreshMargin + time.Second,
+			expiresIn: config.TokenRefreshMargin + time.Second,
 			expected:  false,
 		},
 	}

--- a/cmd/common/token_test.go
+++ b/cmd/common/token_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -53,7 +54,7 @@ func makeJWT(exp int64) string {
 }
 
 func TestAPIKeyEnvConst(t *testing.T) {
-	assert.Equal(t, "OMNISTRATE_API_KEY", apiKeyEnv)
+	assert.Equal(t, "OMNISTRATE_API_KEY", config.OmnistrateAPIKeyEnv)
 }
 
 // TestGetTokenWithLoginUsesEnvVar asserts that when no stored token

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -14,6 +14,7 @@ import (
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/auth/login"
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/auth/logout"
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/auth/refresh"
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/auth/revoke"
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/build"
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/cost"
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/customnetwork"
@@ -119,6 +120,7 @@ func init() {
 	RootCmd.AddCommand(login.LoginCmd)
 	RootCmd.AddCommand(logout.LogoutCmd)
 	RootCmd.AddCommand(refresh.RefreshCmd)
+	RootCmd.AddCommand(revoke.RevokeTokenCmd)
 
 	RootCmd.AddCommand(build.BuildCmd)
 	RootCmd.AddCommand(build.BuildFromRepoCmd)

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -34,6 +34,9 @@ const (
 	retryWaitMin         = "OMNISTRATE_RETRY_WAIT_MIN_IN_SECONDS"
 	retryWaitMax         = "OMNISTRATE_RETRY_WAIT_MAX_IN_SECONDS"
 	retryMax             = "OMNISTRATE_RETRY_MAX"
+
+	// OmnistrateAPIKeyEnv is the environment variable for API key authentication.
+	OmnistrateAPIKeyEnv = "OMNISTRATE_API_KEY"
 )
 
 func GetComposeSpecUrl() string {

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -37,6 +37,9 @@ const (
 
 	// OmnistrateAPIKeyEnv is the environment variable for API key authentication.
 	OmnistrateAPIKeyEnv = "OMNISTRATE_API_KEY" //nolint:gosec // G101: env var name, not a credential
+
+	// TokenRefreshMargin is how far before expiry a JWT should be refreshed.
+	TokenRefreshMargin = 5 * time.Minute
 )
 
 // GetAPIKey returns the value of the OMNISTRATE_API_KEY environment variable,

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -39,6 +39,12 @@ const (
 	OmnistrateAPIKeyEnv = "OMNISTRATE_API_KEY" //nolint:gosec // G101: env var name, not a credential
 )
 
+// GetAPIKey returns the value of the OMNISTRATE_API_KEY environment variable,
+// or an empty string if unset.
+func GetAPIKey() string {
+	return os.Getenv(OmnistrateAPIKeyEnv)
+}
+
 func GetComposeSpecUrl() string {
 	return fmt.Sprintf("https://%s/spec-guides/compose-spec/index.md", GetOmnistrateDocsDomain())
 }

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -36,7 +36,7 @@ const (
 	retryMax             = "OMNISTRATE_RETRY_MAX"
 
 	// OmnistrateAPIKeyEnv is the environment variable for API key authentication.
-	OmnistrateAPIKeyEnv = "OMNISTRATE_API_KEY"
+	OmnistrateAPIKeyEnv = "OMNISTRATE_API_KEY" //nolint:gosec // G101: env var name, not a credential
 )
 
 func GetComposeSpecUrl() string {

--- a/internal/dataaccess/revoke_token.go
+++ b/internal/dataaccess/revoke_token.go
@@ -1,0 +1,47 @@
+package dataaccess
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+)
+
+type revokeTokenRequest struct {
+	RefreshToken string `json:"refreshToken"` //nolint:gosec
+}
+
+// RevokeToken invalidates the given refresh token server-side. The
+// backend deletes the token hash so it can never be used again.
+// Uses raw HTTP because the SDK does not yet include this endpoint.
+func RevokeToken(ctx context.Context, refreshToken string) error {
+	reqBody, err := json.Marshal(revokeTokenRequest{RefreshToken: refreshToken}) //nolint:gosec
+	if err != nil {
+		return fmt.Errorf("failed to marshal revoke request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s://%s/2022-09-01-00/revoke-token", config.GetHostScheme(), config.GetHost())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
+	if err != nil {
+		return fmt.Errorf("failed to create revoke request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", config.GetUserAgent())
+
+	client := getRetryableHttpClient()
+	resp, err := client.Do(req) //nolint:gosec // the CLI intentionally targets the configured Omnistrate API host
+	if err != nil {
+		return fmt.Errorf("revoke token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Backend returns 204 No Content on success; treat 2xx as success.
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return nil
+	}
+
+	return fmt.Errorf("revoke token failed (HTTP %d)", resp.StatusCode)
+}

--- a/mkdocs/docs/omnistrate-ctl.md
+++ b/mkdocs/docs/omnistrate-ctl.md
@@ -58,7 +58,7 @@ omnistrate-ctl [flags]
 * [omnistrate-ctl helm](omnistrate-ctl_helm.md)	 - Manage Helm Charts for your service
 * [omnistrate-ctl instance](omnistrate-ctl_instance.md)	 - Manage Instance Deployments for your service
 * [omnistrate-ctl login](omnistrate-ctl_login.md)	 - Log in to the Omnistrate platform
-* [omnistrate-ctl logout](omnistrate-ctl_logout.md)	 - Logout
+* [omnistrate-ctl logout](omnistrate-ctl_logout.md)	 - Logout and revoke refresh token
 * [omnistrate-ctl mcp](omnistrate-ctl_mcp.md)	 - MCP server management
 * [omnistrate-ctl operations](omnistrate-ctl_operations.md)	 - Operations and health monitoring commands
 * [omnistrate-ctl refresh](omnistrate-ctl_refresh.md)	 - Refresh the access token using the stored refresh token

--- a/mkdocs/docs/omnistrate-ctl.md
+++ b/mkdocs/docs/omnistrate-ctl.md
@@ -62,6 +62,7 @@ omnistrate-ctl [flags]
 * [omnistrate-ctl mcp](omnistrate-ctl_mcp.md)	 - MCP server management
 * [omnistrate-ctl operations](omnistrate-ctl_operations.md)	 - Operations and health monitoring commands
 * [omnistrate-ctl refresh](omnistrate-ctl_refresh.md)	 - Refresh the access token using the stored refresh token
+* [omnistrate-ctl revoke-token](omnistrate-ctl_revoke-token.md)	 - Revoke the stored refresh token
 * [omnistrate-ctl secret](omnistrate-ctl_secret.md)	 - Manage secrets
 * [omnistrate-ctl service](omnistrate-ctl_service.md)	 - Manage Services for your account
 * [omnistrate-ctl service-plan](omnistrate-ctl_service-plan.md)	 - Manage Service Plans for your service

--- a/mkdocs/docs/omnistrate-ctl_login.md
+++ b/mkdocs/docs/omnistrate-ctl_login.md
@@ -30,8 +30,9 @@ omnistrate-ctl login --email email --password password
 # Login with email and password from stdin. Save the password in an environment variable and use echo to read it
   echo $OMNISTRATE_PASSWORD | omnistrate-ctl login --email email --password-stdin
 
-# Login with an org-bounded API key (insecure; prefer --api-key-stdin)
-  omnistrate-ctl login --api-key om_…
+# Login with OMNISTRATE_API_KEY environment variable (recommended for CI/CD)
+  export OMNISTRATE_API_KEY=om_…
+  omnistrate-ctl login
 
 # Login with an API key from stdin
   cat ~/omnistrate_apikey.txt | omnistrate-ctl login --api-key-stdin

--- a/mkdocs/docs/omnistrate-ctl_logout.md
+++ b/mkdocs/docs/omnistrate-ctl_logout.md
@@ -4,12 +4,7 @@ Logout and revoke refresh token
 
 ### Synopsis
 
-The logout command revokes the stored refresh token on the server
-and removes local credentials. This ensures the token cannot be replayed
-from another machine.
-
-Use --skip-revoke to only remove local credentials without server-side
-revocation (legacy behavior).
+The logout command revokes the stored refresh token on the server and removes local credentials.
 
 ```
 omnistrate-ctl logout [flags]
@@ -24,8 +19,7 @@ omnistrate-ctl logout
 ### Options
 
 ```
-  -h, --help          help for logout
-      --skip-revoke   Skip server-side token revocation; only remove local credentials
+  -h, --help   help for logout
 ```
 
 ### Options inherited from parent commands

--- a/mkdocs/docs/omnistrate-ctl_logout.md
+++ b/mkdocs/docs/omnistrate-ctl_logout.md
@@ -1,10 +1,15 @@
 ## omnistrate-ctl logout
 
-Logout
+Logout and revoke refresh token
 
 ### Synopsis
 
-The logout command is used to log out from the Omnistrate platform.
+The logout command revokes the stored refresh token on the server
+and removes local credentials. This ensures the token cannot be replayed
+from another machine.
+
+Use --skip-revoke to only remove local credentials without server-side
+revocation (legacy behavior).
 
 ```
 omnistrate-ctl logout [flags]
@@ -19,7 +24,8 @@ omnistrate-ctl logout
 ### Options
 
 ```
-  -h, --help   help for logout
+  -h, --help          help for logout
+      --skip-revoke   Skip server-side token revocation; only remove local credentials
 ```
 
 ### Options inherited from parent commands

--- a/mkdocs/docs/omnistrate-ctl_revoke-token.md
+++ b/mkdocs/docs/omnistrate-ctl_revoke-token.md
@@ -1,0 +1,41 @@
+## omnistrate-ctl revoke-token
+
+Revoke the stored refresh token
+
+### Synopsis
+
+The revoke-token command invalidates the stored refresh token on the
+server and removes local credentials. After revocation the token can
+never be used to obtain a new access token.
+
+This is stronger than "logout" which only removes local credentials:
+revoke-token also tells the server to delete the refresh token so it
+cannot be replayed from another machine.
+
+```
+omnistrate-ctl revoke-token [flags]
+```
+
+### Examples
+
+```
+omnistrate-ctl revoke-token
+```
+
+### Options
+
+```
+  -h, --help   help for revoke-token
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl](omnistrate-ctl.md)	 - Manage your Omnistrate SaaS from the command line
+

--- a/test/smoke_test/auth/api_key_login_test.go
+++ b/test/smoke_test/auth/api_key_login_test.go
@@ -36,7 +36,10 @@ import (
 //          using the refresh token returned alongside the JWT — proves
 //          that api-key signin sessions are renewable like any other
 //          session and the new JWT also works.
-//       e. Log out before iterating to the next key so each key is
+//       e. Revoke the refreshed token server-side and confirm the
+//          revoked token can no longer be used for refresh — proves
+//          the revoke-token endpoint works for api-key sessions.
+//       f. Log out before iterating to the next key so each key is
 //          tested in isolation.
 //  4. Re-establish the admin session and confirm the test-scoped
 //     names are present in the list response.
@@ -177,11 +180,20 @@ func Test_login_with_api_key(t *testing.T) {
 		refreshed, err := dataaccess.RefreshToken(ctx, session.RefreshToken)
 		require.NoErrorf(err, "RefreshToken for role %s (key %s)", k.Role, k.Name)
 		require.NotEmpty(refreshed.JWTToken, "refreshed JWT must be non-empty")
+		require.NotEmpty(refreshed.RefreshToken, "refreshed refresh token must be non-empty")
 		// Confirm the refreshed JWT is itself usable.
 		_, err = dataaccess.ListServices(ctx, refreshed.JWTToken)
 		require.NoErrorf(err, "ListServices with refreshed api-key JWT for role %s (key %s)", k.Role, k.Name)
 
-		// (e) Log out so the next iteration starts from a clean slate.
+		// (e) Revoke the refresh token server-side and confirm it can
+		// no longer be used. This proves the revoke-token endpoint
+		// works for api-key signin sessions, not just password sessions.
+		err = dataaccess.RevokeToken(ctx, refreshed.RefreshToken)
+		require.NoErrorf(err, "RevokeToken for role %s (key %s)", k.Role, k.Name)
+		_, err = dataaccess.RefreshToken(ctx, refreshed.RefreshToken)
+		require.Errorf(err, "RefreshToken after revocation must fail for role %s (key %s)", k.Role, k.Name)
+
+		// (f) Log out so the next iteration starts from a clean slate.
 		cmd.RootCmd.SetArgs([]string{"logout"})
 		require.NoError(cmd.RootCmd.ExecuteContext(ctx))
 	}


### PR DESCRIPTION
## Summary

When no login flags are provided, `RunLogin` now checks the `OMNISTRATE_API_KEY` environment variable before falling through to the interactive prompt. This enables the simplest CI/CD pattern:

```bash
export OMNISTRATE_API_KEY=om_…
omnistrate-ctl login
```

## Precedence

1. `--api-key` flag (insecure warning shown)
2. `--api-key-stdin` (recommended for scripts)
3. `OMNISTRATE_API_KEY` env var (recommended for CI/CD)
4. Interactive prompt

## Changes

- **`login.go`**: Added env var check after flag-based paths, before interactive prompt
- **`api_key_login.go`**: Refactored to use typed `apiKeySource` enum; insecure warning now only fires for `--api-key` flag (not env var or stdin)
- **`login_test.go`**: Added 5 new tests:
  - `TestLoginCommandOmnistrateAPIKeyEnvConst` — constant value
  - `TestLoginCommandExampleDocumentsEnvVar` — help text includes env var
  - `TestRunLoginPicksUpEnvVar` — env var triggers api-key path
  - `TestRunLoginFlagTakesPrecedenceOverEnv` — flag wins over env
  - `TestRunLoginEnvVarNotUsedWhenOtherFlagsSet` — email/password path not bypassed

## Related

- Part of the org-bounded API keys feature
- Complements PR #611 (--api-key flag support, already merged)