### PR TITLE
ci: force patch-only version bumps on merge to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,3 +159,5 @@ jobs:
         uses: mathieudutour/github-tag-action@a22cf08638b34d5badda920f9daf6e72c477b07b # v6.2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
+          custom_release_rules: "feat:patch,fix:patch,chore:patch,docs:patch,style:patch,refactor:patch,perf:patch,test:patch,ci:patch,build:patch"


### PR DESCRIPTION
## Summary

Forces the automatic version bump on merge to main to always produce a **patch** increment, regardless of conventional commit prefixes (`feat:`, `fix:`, etc.).

## Motivation

Previously, a `feat:` commit would auto-bump the minor version and a `BREAKING CHANGE` would bump the major. This led to unexpected version jumps. Minor and major bumps should be intentional, done via manual release workflow.

## Changes

- Added `default_bump: patch` to `mathieudutour/github-tag-action`
- Added `custom_release_rules` mapping all conventional commit types to `patch`

## When to do minor/major bumps

Create the release tag manually when a minor or major bump is warranted.