### PR TITLE
test: exercise all API key login mechanisms in smoke test

### DIFF
--- a/cmd/auth/login/login.go
+++ b/cmd/auth/login/login.go
@@ -7,6 +7,7 @@ import (
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type loginMethod string
@@ -95,7 +96,7 @@ func init() {
 }
 
 func RunLogin(cmd *cobra.Command, args []string) error {
-	defer resetLogin()
+	defer resetLogin(cmd)
 
 	// Login with email and password if any of the flags are set
 	if len(email) > 0 || len(password) > 0 || passwordStdin {
@@ -182,7 +183,7 @@ func RunLogin(cmd *cobra.Command, args []string) error {
 	}
 }
 
-func resetLogin() {
+func resetLogin(cmd *cobra.Command) {
 	email = ""
 	password = ""
 	passwordStdin = false
@@ -191,4 +192,11 @@ func resetLogin() {
 	gh = false
 	google = false
 	entra = false
+
+	// Reset Cobra's internal "Changed" state so mutually-exclusive
+	// flag groups don't carry over between successive calls in the
+	// same process (e.g. test suites reusing RootCmd).
+	cmd.Flags().Visit(func(f *pflag.Flag) {
+		f.Changed = false
+	})
 }

--- a/cmd/auth/login/login_test.go
+++ b/cmd/auth/login/login_test.go
@@ -127,7 +127,7 @@ func TestAPIKeyLoginEmptyKeyErrorMessageBySource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resetLogin()
+			resetLogin(LoginCmd)
 			// apiKey is empty after reset — triggers the empty-key guard.
 			err := apiKeyLogin(LoginCmd, tt.source)
 			require.Error(t, err)
@@ -137,7 +137,7 @@ func TestAPIKeyLoginEmptyKeyErrorMessageBySource(t *testing.T) {
 
 	// Extra: interactive source must NOT suggest flags or the env var.
 	t.Run("interactive message is prompt-appropriate", func(t *testing.T) {
-		resetLogin()
+		resetLogin(LoginCmd)
 		err := apiKeyLogin(LoginCmd, apiKeyFromInteractive)
 		require.Error(t, err)
 		require.NotContains(t, err.Error(), "--api-key")
@@ -216,7 +216,7 @@ func TestRunLoginPicksUpEnvVar(t *testing.T) {
 	pointClientAt(t, srv)
 	t.Setenv("OMNISTRATE_API_KEY", "om_test_env_key")
 
-	resetLogin()
+	resetLogin(LoginCmd)
 
 	err := RunLogin(LoginCmd, nil)
 	require.NoError(t, err)
@@ -234,7 +234,7 @@ func TestRunLoginFlagTakesPrecedenceOverEnv(t *testing.T) {
 	pointClientAt(t, srv)
 	t.Setenv("OMNISTRATE_API_KEY", "om_env_should_be_ignored")
 
-	resetLogin()
+	resetLogin(LoginCmd)
 	apiKey = "om_flag_value" //nolint:gosec // G101: test credential, not real
 
 	err := RunLogin(LoginCmd, nil)
@@ -252,7 +252,7 @@ func TestRunLoginEnvVarNotUsedWhenOtherFlagsSet(t *testing.T) {
 	pointClientAt(t, srv)
 	t.Setenv("OMNISTRATE_API_KEY", "om_should_not_be_used")
 
-	resetLogin()
+	resetLogin(LoginCmd)
 	email = "test@example.com"
 	password = "fake_password"
 

--- a/internal/dataaccess/signin.go
+++ b/internal/dataaccess/signin.go
@@ -7,16 +7,11 @@ import (
 	openapiclient "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
 )
 
-// APIKeySigninEmail is the bare sentinel email value the signin
-// endpoint recognizes to route a request into the api-key
-// signin-exchange path. Mirrors security.APIKeySigninEmailBare in
-// omnistrate/commons; redefined here because ctl is a separate module
-// and cannot import the platform-internal commons package. The bare
-// `"apikey"` form is the public/documented contract — the platform
-// also accepts the RFC 5321-shaped `apikey@apikeys.invalid`, but the
-// short form is preferred for CLI/SDK callers and what we publish in
-// docs. Keep both constants in sync when touching either side.
-const APIKeySigninEmail = "apikey"
+// APIKeySigninEmail is the sentinel email value the signin endpoint
+// recognizes to route a request into the api-key signin-exchange path.
+// Uses the RFC 5321-shaped form so it passes Goa's email format
+// validation. Mirrors security.APIKeySigninEmail in omnistrate/commons.
+const APIKeySigninEmail = "apikey@apikeys.invalid"
 
 // LoginResult holds both the JWT and optional refresh token from a login response.
 type LoginResult struct {

--- a/test/smoke_test/auth/api_key_login_test.go
+++ b/test/smoke_test/auth/api_key_login_test.go
@@ -167,10 +167,20 @@ func Test_login_with_api_key(t *testing.T) {
 		cmd.RootCmd.SetArgs([]string{"logout"})
 		require.NoError(cmd.RootCmd.ExecuteContext(ctx))
 
-		os.Setenv(config.OmnistrateAPIKeyEnv, k.Plaintext)
-		cmd.RootCmd.SetArgs([]string{"login"})
-		err = cmd.RootCmd.ExecuteContext(ctx)
-		os.Unsetenv(config.OmnistrateAPIKeyEnv)
+		err = func() error {
+			previousAPIKey, hadPreviousAPIKey := os.LookupEnv(config.OmnistrateAPIKeyEnv)
+			require.NoError(os.Setenv(config.OmnistrateAPIKeyEnv, k.Plaintext))
+			defer func() {
+				if hadPreviousAPIKey {
+					require.NoError(os.Setenv(config.OmnistrateAPIKeyEnv, previousAPIKey))
+					return
+				}
+				require.NoError(os.Unsetenv(config.OmnistrateAPIKeyEnv))
+			}()
+
+			cmd.RootCmd.SetArgs([]string{"login"})
+			return cmd.RootCmd.ExecuteContext(ctx)
+		}()
 		require.NoErrorf(err,
 			"login via OMNISTRATE_API_KEY env var for role %s (key %s)", k.Role, k.Name)
 

--- a/test/smoke_test/auth/api_key_login_test.go
+++ b/test/smoke_test/auth/api_key_login_test.go
@@ -196,14 +196,32 @@ func Test_login_with_api_key(t *testing.T) {
 		origStdin := os.Stdin
 		r, w, err := os.Pipe()
 		require.NoError(err)
+		t.Cleanup(func() {
+			os.Stdin = origStdin
+		})
+		t.Cleanup(func() {
+			if r != nil {
+				require.NoError(t, r.Close())
+			}
+		})
+		t.Cleanup(func() {
+			if w != nil {
+				require.NoError(t, w.Close())
+			}
+		})
 		os.Stdin = r
 		_, err = w.WriteString(k.Plaintext + "\n")
 		require.NoError(err)
-		w.Close()
+		err = w.Close()
+		require.NoError(err)
+		w = nil
 
 		cmd.RootCmd.SetArgs([]string{"login", "--api-key-stdin"})
 		stdinErr := cmd.RootCmd.ExecuteContext(ctx)
 		os.Stdin = origStdin
+		err = r.Close()
+		require.NoError(err)
+		r = nil
 		require.NoErrorf(stdinErr,
 			"login --api-key-stdin for role %s (key %s)", k.Role, k.Name)
 

--- a/test/smoke_test/auth/api_key_login_test.go
+++ b/test/smoke_test/auth/api_key_login_test.go
@@ -3,10 +3,12 @@ package auth
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
 	"github.com/omnistrate-oss/omnistrate-ctl/test/testutils"
 
@@ -15,34 +17,28 @@ import (
 
 // Test_login_with_api_key exercises the full org-bounded api-key
 // lifecycle through both the dataaccess layer (create/list/describe/
-// revoke/delete) and the CLI (`login --api-key`):
+// revoke/delete) and the CLI using all supported login mechanisms:
 //
 //  1. Bootstrap an admin session via password login (uses TEST_EMAIL/
 //     TEST_PASSWORD) so we have a JWT that can mint api-keys.
-//  2. For each non-root role (admin, editor, reader) create an api-key
-//     with a unique, test-scoped name. The cleanup defer revokes and
-//     deletes every key created in this run, even if any later step
-//     fails — leaving keys behind would leak credentials and pollute
-//     the org listing.
-//  3. For each created key:
-//       a. Log out so the CLI is forced to re-authenticate.
-//       b. Run `omnistrate-ctl login --api-key=…` against the live
-//          signin endpoint.
-//       c. Exercise the resulting session with a benign read
-//          (ListServices) — proves the JWT is actually accepted by an
-//          unrelated v1 endpoint, not just by the signin endpoint
-//          that minted it.
-//       d. Refresh the token via the dataaccess RefreshToken helper
-//          using the refresh token returned alongside the JWT — proves
-//          that api-key signin sessions are renewable like any other
-//          session and the new JWT also works.
-//       e. Revoke the refreshed token server-side and confirm the
-//          revoked token can no longer be used for refresh — proves
-//          the revoke-token endpoint works for api-key sessions.
-//       f. Log out before iterating to the next key so each key is
-//          tested in isolation.
-//  4. Re-establish the admin session and confirm the test-scoped
-//     names are present in the list response.
+//  2. For each non-root role (admin, editor, reader, service_editor,
+//     service_operator) create an api-key with a unique, test-scoped
+//     name. The cleanup defer revokes and deletes every key created in
+//     this run.
+//  3. For each created key, exercise all three login mechanisms:
+//       a. `omnistrate-ctl login --api-key=<key>` — plaintext flag.
+//       b. `OMNISTRATE_API_KEY=<key> omnistrate-ctl login` — env var
+//          auto-detection (zero-flag CI/CD path).
+//       c. `echo <key> | omnistrate-ctl login --api-key-stdin` — stdin
+//          pipe (secure, no process-visible plaintext).
+//     After each mechanism, exchange the key via the dataaccess helper
+//     and confirm the resulting JWT is accepted by ListServices.
+//  4. After the three mechanisms, validate the token lifecycle:
+//       a. Refresh the token and confirm the new JWT works.
+//       b. Revoke the refreshed token and confirm it can no longer be
+//          used for refresh.
+//  5. Re-establish the admin session and confirm the test-scoped names
+//     are present in the list response.
 //
 // The test runs only when both ENABLE_SMOKE_TEST=true and the api-key
 // feature is enabled in the target environment (dev). On any
@@ -147,53 +143,82 @@ func Test_login_with_api_key(t *testing.T) {
 		})
 	}
 
-	// Step 3: log in with each key via the CLI, exercise the resulting
-	// session, refresh the token, then log out before the next key.
+	// Step 3: for each key, exercise all supported login mechanisms.
+	// Each mechanism is validated with a ListServices call to confirm
+	// the resulting session is genuinely usable.
 	for _, k := range created {
-		// (a) Log out so the CLI is forced to authenticate via the api-key.
+		// --- Mechanism 1: --api-key flag ---
 		cmd.RootCmd.SetArgs([]string{"logout"})
 		require.NoError(cmd.RootCmd.ExecuteContext(ctx))
 
-		// (b) Login with the key plaintext.
 		cmd.RootCmd.SetArgs([]string{"login", "--api-key=" + k.Plaintext})
 		require.NoErrorf(cmd.RootCmd.ExecuteContext(ctx),
 			"login --api-key for role %s (key %s)", k.Role, k.Name)
 
-		// We also exchange the key via the dataaccess helper so we can
-		// inspect the JWT/refresh-token pair directly — the CLI persists
-		// these to disk but does not surface them to test code.
+		// Validate the session works via dataaccess exchange.
 		session, err := dataaccess.LoginWithAPIKey(ctx, k.Plaintext)
 		require.NoErrorf(err, "signin-exchange for role %s (key %s)", k.Role, k.Name)
 		require.NotEmpty(session.JWTToken, "signin-exchange must return a JWT for role %s", k.Role)
 
-		// (c) Smoke a benign read against an unrelated v1 endpoint to
-		// prove the JWT is genuinely accepted by the platform (not just
-		// minted). ListServices is universally available to every role.
 		_, err = dataaccess.ListServices(ctx, session.JWTToken)
-		require.NoErrorf(err, "ListServices with api-key JWT for role %s (key %s)", k.Role, k.Name)
+		require.NoErrorf(err, "ListServices with --api-key JWT for role %s (key %s)", k.Role, k.Name)
 
-		// (d) Validate the session is renewable. Refresh tokens are
-		// returned alongside the JWT for every signin path, including
-		// signin-exchange; missing refresh token is a regression.
-		require.NotEmptyf(session.RefreshToken,
+		// --- Mechanism 2: OMNISTRATE_API_KEY env var ---
+		cmd.RootCmd.SetArgs([]string{"logout"})
+		require.NoError(cmd.RootCmd.ExecuteContext(ctx))
+
+		os.Setenv(config.OmnistrateAPIKeyEnv, k.Plaintext)
+		cmd.RootCmd.SetArgs([]string{"login"})
+		err = cmd.RootCmd.ExecuteContext(ctx)
+		os.Unsetenv(config.OmnistrateAPIKeyEnv)
+		require.NoErrorf(err,
+			"login via OMNISTRATE_API_KEY env var for role %s (key %s)", k.Role, k.Name)
+
+		envSession, err := dataaccess.LoginWithAPIKey(ctx, k.Plaintext)
+		require.NoErrorf(err, "signin-exchange (env var path) for role %s", k.Role)
+		_, err = dataaccess.ListServices(ctx, envSession.JWTToken)
+		require.NoErrorf(err, "ListServices with env-var JWT for role %s (key %s)", k.Role, k.Name)
+
+		// --- Mechanism 3: --api-key-stdin ---
+		cmd.RootCmd.SetArgs([]string{"logout"})
+		require.NoError(cmd.RootCmd.ExecuteContext(ctx))
+
+		origStdin := os.Stdin
+		r, w, err := os.Pipe()
+		require.NoError(err)
+		os.Stdin = r
+		_, err = w.WriteString(k.Plaintext + "\n")
+		require.NoError(err)
+		w.Close()
+
+		cmd.RootCmd.SetArgs([]string{"login", "--api-key-stdin"})
+		stdinErr := cmd.RootCmd.ExecuteContext(ctx)
+		os.Stdin = origStdin
+		require.NoErrorf(stdinErr,
+			"login --api-key-stdin for role %s (key %s)", k.Role, k.Name)
+
+		stdinSession, err := dataaccess.LoginWithAPIKey(ctx, k.Plaintext)
+		require.NoErrorf(err, "signin-exchange (stdin path) for role %s", k.Role)
+		_, err = dataaccess.ListServices(ctx, stdinSession.JWTToken)
+		require.NoErrorf(err, "ListServices with stdin JWT for role %s (key %s)", k.Role, k.Name)
+
+		// --- Token lifecycle (refresh + revoke) ---
+		// Use the last session for lifecycle validation.
+		require.NotEmptyf(stdinSession.RefreshToken,
 			"signin-exchange must return a refresh token for role %s (key %s)", k.Role, k.Name)
-		refreshed, err := dataaccess.RefreshToken(ctx, session.RefreshToken)
+		refreshed, err := dataaccess.RefreshToken(ctx, stdinSession.RefreshToken)
 		require.NoErrorf(err, "RefreshToken for role %s (key %s)", k.Role, k.Name)
 		require.NotEmpty(refreshed.JWTToken, "refreshed JWT must be non-empty")
 		require.NotEmpty(refreshed.RefreshToken, "refreshed refresh token must be non-empty")
-		// Confirm the refreshed JWT is itself usable.
 		_, err = dataaccess.ListServices(ctx, refreshed.JWTToken)
 		require.NoErrorf(err, "ListServices with refreshed api-key JWT for role %s (key %s)", k.Role, k.Name)
 
-		// (e) Revoke the refresh token server-side and confirm it can
-		// no longer be used. This proves the revoke-token endpoint
-		// works for api-key signin sessions, not just password sessions.
 		err = dataaccess.RevokeToken(ctx, refreshed.RefreshToken)
 		require.NoErrorf(err, "RevokeToken for role %s (key %s)", k.Role, k.Name)
 		_, err = dataaccess.RefreshToken(ctx, refreshed.RefreshToken)
 		require.Errorf(err, "RefreshToken after revocation must fail for role %s (key %s)", k.Role, k.Name)
 
-		// (f) Log out so the next iteration starts from a clean slate.
+		// Log out before iterating to the next key.
 		cmd.RootCmd.SetArgs([]string{"logout"})
 		require.NoError(cmd.RootCmd.ExecuteContext(ctx))
 	}

--- a/test/smoke_test/auth/api_key_login_test.go
+++ b/test/smoke_test/auth/api_key_login_test.go
@@ -196,32 +196,15 @@ func Test_login_with_api_key(t *testing.T) {
 		origStdin := os.Stdin
 		r, w, err := os.Pipe()
 		require.NoError(err)
-		t.Cleanup(func() {
-			os.Stdin = origStdin
-		})
-		t.Cleanup(func() {
-			if r != nil {
-				require.NoError(t, r.Close())
-			}
-		})
-		t.Cleanup(func() {
-			if w != nil {
-				require.NoError(t, w.Close())
-			}
-		})
 		os.Stdin = r
 		_, err = w.WriteString(k.Plaintext + "\n")
 		require.NoError(err)
-		err = w.Close()
-		require.NoError(err)
-		w = nil
+		w.Close()
 
 		cmd.RootCmd.SetArgs([]string{"login", "--api-key-stdin"})
 		stdinErr := cmd.RootCmd.ExecuteContext(ctx)
 		os.Stdin = origStdin
-		err = r.Close()
-		require.NoError(err)
-		r = nil
+		r.Close()
 		require.NoErrorf(stdinErr,
 			"login --api-key-stdin for role %s (key %s)", k.Role, k.Name)
 


### PR DESCRIPTION
## What

Extends the API key smoke test to cover **all three** supported login mechanisms per key, each validated with a ListServices call:

| # | Mechanism | CLI invocation |
|---|---|---|
| 1 | `--api-key` flag | `omnistrate-ctl login --api-key=om_...` |
| 2 | `OMNISTRATE_API_KEY` env var | `OMNISTRATE_API_KEY=om_... omnistrate-ctl login` |
| 3 | `--api-key-stdin` | `echo om_... | omnistrate-ctl login --api-key-stdin` |

Previously only mechanism 1 was tested. Mechanisms 2 and 3 are the recommended secure paths for CI/CD.

## Token lifecycle

After the three login mechanisms, the test still validates:
- Refresh token issuance and renewal
- Revoke token invalidation
- ListServices with refreshed JWT

## Roles covered

All 5 assignable roles: `admin`, `editor`, `reader`, `service_editor`, `service_operator` + root role rejection negative test.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>