### PR TITLE
feat: support cache_from and cache_to in compose build config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,6 +142,7 @@ jobs:
     secrets: inherit
     permissions:
       contents: read
+      packages: read
 
   publish:
     if: github.event_name == 'push'

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -86,6 +86,48 @@ jobs:
           OMCTL_GCP_PROJECT_NUMBER: ${{ secrets.OMCTL_GCP_PROJECT_NUMBER }}
         run: gotestsum --format standard-verbose -- ./test/smoke_test/${{ matrix.test-group }} -timeout 1800s -p 1 -p 1 -v
 
+  smoke-tests-docker-cache:
+    environment: ${{ inputs.environment }}
+    if: github.event_name != 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          cache-dependency-path: "**/go.sum"
+
+      - name: Get dependencies
+        timeout-minutes: 10
+        run: make tidy
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Gotestsum installer
+        uses: autero1/action-gotestsum@7263b9d73912eec65f46337689e59fac865c425f # v2.0.0
+        with:
+          gotestsum_version: 1.13.0
+
+      - name: Smoke test build-from-repo with GHA cache
+        timeout-minutes: 15
+        env:
+          ENABLE_SMOKE_TEST: true
+          ENABLE_DOCKER_CACHE_TEST: true
+          TEST_EMAIL: ${{ secrets.SMOKE_TEST_EMAIL }}
+          TEST_PASSWORD: ${{ secrets.SMOKE_TEST_PASSWORD }}
+          OMNISTRATE_ROOT_DOMAIN: ${{ vars.OMNISTRATE_ROOT_DOMAIN }}
+          OMNISTRATE_LOG_LEVEL: debug
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gotestsum --format standard-verbose -- ./test/smoke_test/build/docker_cache/... -timeout 900s -p 1 -v
+
   smoke-tests-auth:
     environment: ${{ inputs.environment }}
     if: github.event_name != 'push'

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      packages: read
 
     steps:
       - name: Checkout repository
@@ -126,7 +126,7 @@ jobs:
           OMNISTRATE_ROOT_DOMAIN: ${{ vars.OMNISTRATE_ROOT_DOMAIN }}
           OMNISTRATE_LOG_LEVEL: debug
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gotestsum --format standard-verbose -- ./test/smoke_test/build/docker_cache/... -timeout 900s -p 1 -v
+        run: gotestsum --format standard-verbose -- ./test/smoke_test/build/dockercache/... -timeout 900s -p 1 -v
 
   smoke-tests-auth:
     environment: ${{ inputs.environment }}

--- a/cmd/build/build_from_repo.go
+++ b/cmd/build/build_from_repo.go
@@ -649,6 +649,8 @@ func BuildServiceFromRepository(cmd *cobra.Command, ctx context.Context, token, 
 	var parsedYaml map[string]interface{}
 	var project *types.Project
 	dockerfilePaths := make(map[string]string)        // service -> dockerfile path
+	dockerCacheFrom := make(map[string][]string)      // service -> cache_from entries
+	dockerCacheTo := make(map[string][]string)        // service -> cache_to entries
 	versionTaggedImageUrls := make(map[string]string) // service -> image url with digest tag
 	var pat string
 	var ghUsername string
@@ -700,6 +702,12 @@ func BuildServiceFromRepository(cmd *cobra.Command, ctx context.Context, token, 
 				}
 
 				dockerfilePaths[service.Name] = filepath.Join(absContextPath, service.Build.Dockerfile)
+				if len(service.Build.CacheFrom) > 0 {
+					dockerCacheFrom[service.Name] = service.Build.CacheFrom
+				}
+				if len(service.Build.CacheTo) > 0 {
+					dockerCacheTo[service.Name] = service.Build.CacheTo
+				}
 			}
 		}
 	} else {
@@ -988,13 +996,15 @@ func BuildServiceFromRepository(cmd *cobra.Command, ctx context.Context, token, 
 				// Join the platforms list with comma as separator
 				platformsStr := strings.Join(platforms, ",")
 
-				buildCmd := exec.Command("docker", "buildx", "build", "--pull", "--platform", platformsStr, ".", "-f", dockerfilePath, "-t", imageUrl, "--load")
+				buildArgs := BuildDockerBuildArgs(platformsStr, dockerfilePath, imageUrl, dockerCacheFrom[service], dockerCacheTo[service])
+
+				buildCmd := exec.Command("docker", buildArgs...)
 
 				// Redirect stdout and stderr to the terminal
 				buildCmd.Stdout = os.Stdout
 				buildCmd.Stderr = os.Stderr
 
-				fmt.Printf("Invoking 'docker buildx build --pull --platform %s . -f %s -t %s --load'...\n", platformsStr, dockerfilePath, imageUrl)
+				fmt.Printf("Invoking 'docker %s'...\n", strings.Join(buildArgs, " "))
 				err = buildCmd.Run()
 				if err != nil {
 					utils.HandleSpinnerError(spinner, sm, err)

--- a/cmd/build/utils.go
+++ b/cmd/build/utils.go
@@ -497,6 +497,8 @@ func ExpandOmctlEnvVars(data []byte) ([]byte, error) {
 
 // BuildDockerBuildArgs constructs the arguments for a `docker buildx build` command,
 // including optional --cache-from and --cache-to flags from the compose spec.
+// When cacheTo is set, --load is omitted since the build's purpose is cache population
+// (and --load is incompatible with multi-platform builds).
 func BuildDockerBuildArgs(platforms, dockerfilePath, imageURL string, cacheFrom, cacheTo []string) []string {
 	args := []string{"buildx", "build", "--pull", "--platform", platforms, ".", "-f", dockerfilePath, "-t", imageURL}
 	for _, cf := range cacheFrom {
@@ -505,6 +507,8 @@ func BuildDockerBuildArgs(platforms, dockerfilePath, imageURL string, cacheFrom,
 	for _, ct := range cacheTo {
 		args = append(args, "--cache-to", ct)
 	}
-	args = append(args, "--load")
+	if len(cacheTo) == 0 {
+		args = append(args, "--load")
+	}
 	return args
 }

--- a/cmd/build/utils.go
+++ b/cmd/build/utils.go
@@ -497,8 +497,8 @@ func ExpandOmctlEnvVars(data []byte) ([]byte, error) {
 
 // BuildDockerBuildArgs constructs the arguments for a `docker buildx build` command,
 // including optional --cache-from and --cache-to flags from the compose spec.
-// When cacheTo is set, --load is omitted since the build's purpose is cache population
-// (and --load is incompatible with multi-platform builds).
+// --load is omitted when cacheTo is set (build's purpose is cache population)
+// or when multiple platforms are specified (--load is incompatible with multi-platform builds).
 func BuildDockerBuildArgs(platforms, dockerfilePath, imageURL string, cacheFrom, cacheTo []string) []string {
 	args := []string{"buildx", "build", "--pull", "--platform", platforms, ".", "-f", dockerfilePath, "-t", imageURL}
 	for _, cf := range cacheFrom {
@@ -507,7 +507,8 @@ func BuildDockerBuildArgs(platforms, dockerfilePath, imageURL string, cacheFrom,
 	for _, ct := range cacheTo {
 		args = append(args, "--cache-to", ct)
 	}
-	if len(cacheTo) == 0 {
+	isMultiPlatform := strings.Contains(platforms, ",")
+	if len(cacheTo) == 0 && !isMultiPlatform {
 		args = append(args, "--load")
 	}
 	return args

--- a/cmd/build/utils.go
+++ b/cmd/build/utils.go
@@ -494,3 +494,17 @@ func ExpandOmctlEnvVars(data []byte) ([]byte, error) {
 	}
 	return result, nil
 }
+
+// BuildDockerBuildArgs constructs the arguments for a `docker buildx build` command,
+// including optional --cache-from and --cache-to flags from the compose spec.
+func BuildDockerBuildArgs(platforms, dockerfilePath, imageURL string, cacheFrom, cacheTo []string) []string {
+	args := []string{"buildx", "build", "--pull", "--platform", platforms, ".", "-f", dockerfilePath, "-t", imageURL}
+	for _, cf := range cacheFrom {
+		args = append(args, "--cache-from", cf)
+	}
+	for _, ct := range cacheTo {
+		args = append(args, "--cache-to", ct)
+	}
+	args = append(args, "--load")
+	return args
+}

--- a/cmd/build/utils_test.go
+++ b/cmd/build/utils_test.go
@@ -1,11 +1,14 @@
 package build
 
 import (
+	"context"
 	"encoding/base64"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/compose-spec/compose-go/loader"
+	"github.com/compose-spec/compose-go/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -509,4 +512,124 @@ func TestExpandOmctlEnvVars(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildDockerBuildArgs(t *testing.T) {
+	tests := []struct {
+		name      string
+		platforms string
+		dockerfile string
+		imageURL  string
+		cacheFrom []string
+		cacheTo   []string
+		expected  []string
+	}{
+		{
+			name:       "no cache flags",
+			platforms:  "linux/amd64",
+			dockerfile: "Dockerfile",
+			imageURL:   "ghcr.io/owner/repo",
+			cacheFrom:  nil,
+			cacheTo:    nil,
+			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64", ".", "-f", "Dockerfile", "-t", "ghcr.io/owner/repo", "--load"},
+		},
+		{
+			name:       "with gha cache",
+			platforms:  "linux/amd64",
+			dockerfile: "Dockerfile",
+			imageURL:   "ghcr.io/owner/repo",
+			cacheFrom:  []string{"type=gha"},
+			cacheTo:    []string{"type=gha,mode=max"},
+			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64", ".", "-f", "Dockerfile", "-t", "ghcr.io/owner/repo", "--cache-from", "type=gha", "--cache-to", "type=gha,mode=max", "--load"},
+		},
+		{
+			name:       "multiple cache sources",
+			platforms:  "linux/amd64,linux/arm64",
+			dockerfile: "docker/Dockerfile.prod",
+			imageURL:   "ghcr.io/owner/repo",
+			cacheFrom:  []string{"type=gha", "type=registry,ref=ghcr.io/owner/repo:cache"},
+			cacheTo:    []string{"type=gha,mode=max"},
+			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64,linux/arm64", ".", "-f", "docker/Dockerfile.prod", "-t", "ghcr.io/owner/repo", "--cache-from", "type=gha", "--cache-from", "type=registry,ref=ghcr.io/owner/repo:cache", "--cache-to", "type=gha,mode=max", "--load"},
+		},
+		{
+			name:       "cache_from only",
+			platforms:  "linux/amd64",
+			dockerfile: "Dockerfile",
+			imageURL:   "ghcr.io/owner/repo",
+			cacheFrom:  []string{"type=gha"},
+			cacheTo:    nil,
+			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64", ".", "-f", "Dockerfile", "-t", "ghcr.io/owner/repo", "--cache-from", "type=gha", "--load"},
+		},
+		{
+			name:       "cache_to only",
+			platforms:  "linux/amd64",
+			dockerfile: "Dockerfile",
+			imageURL:   "ghcr.io/owner/repo",
+			cacheFrom:  nil,
+			cacheTo:    []string{"type=gha,mode=max"},
+			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64", ".", "-f", "Dockerfile", "-t", "ghcr.io/owner/repo", "--cache-to", "type=gha,mode=max", "--load"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildDockerBuildArgs(tt.platforms, tt.dockerfile, tt.imageURL, tt.cacheFrom, tt.cacheTo)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestComposeCacheFromCacheToParsing(t *testing.T) {
+	composeYAML := `
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      cache_from:
+        - type=gha
+      cache_to:
+        - type=gha,mode=max
+  api:
+    build:
+      context: ./api
+      dockerfile: Dockerfile.api
+      cache_from:
+        - type=registry,ref=ghcr.io/owner/api:cache
+  db:
+    image: postgres:15
+`
+	parsedYaml, err := loader.ParseYAML([]byte(composeYAML))
+	require.NoError(t, err)
+
+	project, err := loader.LoadWithContext(context.Background(), types.ConfigDetails{
+		ConfigFiles: []types.ConfigFile{{Config: parsedYaml}},
+	})
+	require.NoError(t, err)
+
+	cacheFrom := make(map[string][]string)
+	cacheTo := make(map[string][]string)
+
+	for _, svc := range project.Services {
+		if svc.Build != nil {
+			if len(svc.Build.CacheFrom) > 0 {
+				cacheFrom[svc.Name] = svc.Build.CacheFrom
+			}
+			if len(svc.Build.CacheTo) > 0 {
+				cacheTo[svc.Name] = svc.Build.CacheTo
+			}
+		}
+	}
+
+	// web service has both cache_from and cache_to
+	assert.Equal(t, []string{"type=gha"}, cacheFrom["web"])
+	assert.Equal(t, []string{"type=gha,mode=max"}, cacheTo["web"])
+
+	// api service has only cache_from
+	assert.Equal(t, []string{"type=registry,ref=ghcr.io/owner/api:cache"}, cacheFrom["api"])
+	assert.Empty(t, cacheTo["api"])
+
+	// db service has no build context, no cache entries
+	assert.Empty(t, cacheFrom["db"])
+	assert.Empty(t, cacheTo["db"])
 }

--- a/cmd/build/utils_test.go
+++ b/cmd/build/utils_test.go
@@ -569,6 +569,15 @@ func TestBuildDockerBuildArgs(t *testing.T) {
 			cacheTo:    []string{"type=gha,mode=max"},
 			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64", ".", "-f", "Dockerfile", "-t", "ghcr.io/owner/repo", "--cache-to", "type=gha,mode=max"},
 		},
+		{
+			name:       "multi-platform without cache skips load",
+			platforms:  "linux/amd64,linux/arm64",
+			dockerfile: "Dockerfile",
+			imageURL:   "ghcr.io/owner/repo",
+			cacheFrom:  nil,
+			cacheTo:    nil,
+			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64,linux/arm64", ".", "-f", "Dockerfile", "-t", "ghcr.io/owner/repo"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/build/utils_test.go
+++ b/cmd/build/utils_test.go
@@ -540,7 +540,7 @@ func TestBuildDockerBuildArgs(t *testing.T) {
 			imageURL:   "ghcr.io/owner/repo",
 			cacheFrom:  []string{"type=gha"},
 			cacheTo:    []string{"type=gha,mode=max"},
-			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64", ".", "-f", "Dockerfile", "-t", "ghcr.io/owner/repo", "--cache-from", "type=gha", "--cache-to", "type=gha,mode=max", "--load"},
+			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64", ".", "-f", "Dockerfile", "-t", "ghcr.io/owner/repo", "--cache-from", "type=gha", "--cache-to", "type=gha,mode=max"},
 		},
 		{
 			name:       "multiple cache sources",
@@ -549,7 +549,7 @@ func TestBuildDockerBuildArgs(t *testing.T) {
 			imageURL:   "ghcr.io/owner/repo",
 			cacheFrom:  []string{"type=gha", "type=registry,ref=ghcr.io/owner/repo:cache"},
 			cacheTo:    []string{"type=gha,mode=max"},
-			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64,linux/arm64", ".", "-f", "docker/Dockerfile.prod", "-t", "ghcr.io/owner/repo", "--cache-from", "type=gha", "--cache-from", "type=registry,ref=ghcr.io/owner/repo:cache", "--cache-to", "type=gha,mode=max", "--load"},
+			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64,linux/arm64", ".", "-f", "docker/Dockerfile.prod", "-t", "ghcr.io/owner/repo", "--cache-from", "type=gha", "--cache-from", "type=registry,ref=ghcr.io/owner/repo:cache", "--cache-to", "type=gha,mode=max"},
 		},
 		{
 			name:       "cache_from only",
@@ -567,7 +567,7 @@ func TestBuildDockerBuildArgs(t *testing.T) {
 			imageURL:   "ghcr.io/owner/repo",
 			cacheFrom:  nil,
 			cacheTo:    []string{"type=gha,mode=max"},
-			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64", ".", "-f", "Dockerfile", "-t", "ghcr.io/owner/repo", "--cache-to", "type=gha,mode=max", "--load"},
+			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64", ".", "-f", "Dockerfile", "-t", "ghcr.io/owner/repo", "--cache-to", "type=gha,mode=max"},
 		},
 	}
 

--- a/test/smoke_test/build/docker_cache/docker_cache_test.go
+++ b/test/smoke_test/build/docker_cache/docker_cache_test.go
@@ -1,0 +1,149 @@
+package docker_cache
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd"
+	"github.com/omnistrate-oss/omnistrate-ctl/test/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_build_from_repo_with_docker_cache_parsing validates that build-from-repo
+// correctly parses cache_from and cache_to from a compose file. Uses
+// --skip-docker-build to exercise the compose parsing path without Docker.
+func Test_build_from_repo_with_docker_cache_parsing(t *testing.T) {
+	testutils.SmokeTest(t)
+
+	ctx := context.TODO()
+	require := require.New(t)
+	defer testutils.Cleanup()
+
+	// Login
+	testEmail, testPassword, err := testutils.GetTestAccount()
+	require.NoError(err)
+	cmd.RootCmd.SetArgs([]string{"login", fmt.Sprintf("--email=%s", testEmail), fmt.Sprintf("--password=%s", testPassword)})
+	err = cmd.RootCmd.ExecuteContext(ctx)
+	require.NoError(err)
+
+	// Create a temp directory with a git repo, Dockerfile, and compose file with cache config
+	tmpDir, err := os.MkdirTemp("", "omctl-cache-test-*")
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	origDir, err := os.Getwd()
+	require.NoError(err)
+	defer func() { _ = os.Chdir(origDir) }()
+
+	initGitRepo(t, tmpDir)
+	writeDockerfile(t, tmpDir)
+	composeFile := writeComposeWithCache(t, tmpDir)
+
+	require.NoError(os.Chdir(tmpDir))
+
+	// Run build-from-repo with --skip-docker-build to validate compose parsing
+	// (including cache_from/cache_to extraction) without needing Docker
+	cmd.RootCmd.SetArgs([]string{
+		"build-from-repo",
+		"--file", composeFile,
+		"--skip-docker-build",
+		"--skip-service-build",
+		"--skip-environment-promotion",
+		"--skip-saas-portal-init",
+	})
+	err = cmd.RootCmd.ExecuteContext(ctx)
+	require.NoError(err)
+}
+
+// Test_build_from_repo_with_docker_cache_full performs a full build-from-repo
+// with --dry-run, including an actual docker buildx build using GHA cache.
+// Requires Docker, buildx, GH_TOKEN, and ENABLE_DOCKER_CACHE_TEST=true.
+func Test_build_from_repo_with_docker_cache_full(t *testing.T) {
+	testutils.SmokeTest(t)
+	if os.Getenv("ENABLE_DOCKER_CACHE_TEST") != "true" {
+		t.Skip("Skipping full docker cache test (set ENABLE_DOCKER_CACHE_TEST=true to enable)")
+	}
+
+	ctx := context.TODO()
+	require := require.New(t)
+	defer testutils.Cleanup()
+
+	// Verify Docker is available
+	err := exec.Command("docker", "version").Run()
+	require.NoError(err, "Docker is required for this test")
+
+	// Login
+	testEmail, testPassword, err := testutils.GetTestAccount()
+	require.NoError(err)
+	cmd.RootCmd.SetArgs([]string{"login", fmt.Sprintf("--email=%s", testEmail), fmt.Sprintf("--password=%s", testPassword)})
+	err = cmd.RootCmd.ExecuteContext(ctx)
+	require.NoError(err)
+
+	// Create a temp directory with git repo, Dockerfile, and compose with cache config
+	tmpDir, err := os.MkdirTemp("", "omctl-cache-full-test-*")
+	require.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	origDir, err := os.Getwd()
+	require.NoError(err)
+	defer func() { _ = os.Chdir(origDir) }()
+
+	initGitRepo(t, tmpDir)
+	writeDockerfile(t, tmpDir)
+	composeFile := writeComposeWithCache(t, tmpDir)
+
+	require.NoError(os.Chdir(tmpDir))
+
+	// Run build-from-repo --dry-run: builds the Docker image locally with GHA
+	// cache flags but skips pushing to GHCR and creating the service.
+	cmd.RootCmd.SetArgs([]string{
+		"build-from-repo",
+		"--file", composeFile,
+		"--dry-run",
+	})
+	err = cmd.RootCmd.ExecuteContext(ctx)
+	require.NoError(err)
+}
+
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	for _, args := range [][]string{
+		{"git", "init", dir},
+		{"git", "-C", dir, "config", "user.email", "test@test.com"},
+		{"git", "-C", dir, "config", "user.name", "Test"},
+		{"git", "-C", dir, "remote", "add", "origin", "https://github.com/test-owner/test-repo.git"},
+	} {
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput() //nolint:gosec
+		require.NoError(t, err, "git command %v failed: %s", args, string(out))
+	}
+}
+
+func writeDockerfile(t *testing.T, dir string) {
+	t.Helper()
+	content := "FROM alpine:3.18\nRUN echo hello\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(content), 0600))
+}
+
+func writeComposeWithCache(t *testing.T, dir string) string {
+	t.Helper()
+	composeContent := `services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      cache_from:
+        - type=gha
+      cache_to:
+        - type=gha,mode=max
+    image: alpine:3.18
+    ports:
+      - "8080:8080"
+`
+	composeFile := filepath.Join(dir, "omnistrate-compose.yaml")
+	require.NoError(t, os.WriteFile(composeFile, []byte(composeContent), 0600))
+	return composeFile
+}

--- a/test/smoke_test/build/dockercache/dockercache_test.go
+++ b/test/smoke_test/build/dockercache/dockercache_test.go
@@ -1,4 +1,4 @@
-package docker_cache
+package dockercache
 
 import (
 	"context"


### PR DESCRIPTION
## Summary

Support `cache_from` and `cache_to` fields in the compose file's `build` section, passing them as `--cache-from` and `--cache-to` flags to the `docker buildx build` command. This enables GitHub Actions cache (`type=gha`) and other Docker BuildKit cache backends when using `build-from-repo`.

### Example compose config:
```yaml
services:
  web:
    build:
      context: .
      cache_from:
        - type=gha
      cache_to:
        - type=gha,mode=max
```

## Changes

- **`cmd/build/build_from_repo.go`**: Extract `CacheFrom`/`CacheTo` per service from compose-go parsed project and pass to docker build
- **`cmd/build/utils.go`**: Add `BuildDockerBuildArgs()` helper for testable arg construction; skip `--load` when `--cache-to` is set or when building for multiple platforms (incompatible with `docker buildx --load`)
- **`cmd/build/utils_test.go`**: Unit tests for arg construction (6 cases including multi-platform) and compose cache parsing
- **`test/smoke_test/build/dockercache/`**: E2E smoke test with full `build-from-repo --dry-run` using GHA cache
- **`.github/workflows/smoke-tests.yml`**: Dedicated `smoke-tests-docker-cache` job with Docker Buildx setup

## Key behavior

- `--load` is skipped when `--cache-to` is set (build purpose is cache population)
- `--load` is skipped when multiple platforms are specified (e.g., `linux/amd64,linux/arm64`) since Docker cannot load multi-arch images into the local daemon