### PR TITLE
fix: add packages:read to release workflow smoke-tests caller

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,6 +199,7 @@ jobs:
     secrets: inherit
     permissions:
       contents: read
+      packages: read
 
   approve-release:
     name: Approve release


### PR DESCRIPTION
The `smoke-tests-docker-cache` job in the reusable workflow requests `packages: read`, but the caller in `release.yml` only granted `contents: read`, causing:

```
The nested job 'smoke-tests-docker-cache' is requesting 'packages: read', but is only allowed 'packages: none'.
```

Adds `packages: read` to the smoke-tests caller permissions in `release.yml` (same fix already applied to `build.yml` in #624).