### PR TITLE
fix: CleanupArgsAndFlags corrupts StringArray flag defaults

### DIFF
--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -220,7 +220,25 @@ func CleanupArgsAndFlags(cmd *cobra.Command, args *[]string) {
 	// Clean up flags
 	cmd.Flags().VisitAll(
 		func(f *pflag.Flag) {
-			_ = cmd.Flags().Set(f.Name, f.DefValue)
+			// For slice/array flags, use Replace() to avoid the StringArray
+			// Set() bug where DefValue brackets get treated as literal characters.
+			if sv, ok := f.Value.(pflag.SliceValue); ok {
+				if f.DefValue == "[]" {
+					_ = sv.Replace([]string{})
+				} else {
+					_ = sv.Replace(sv.GetSlice()[:0])
+					// Re-parse default value by stripping brackets and splitting CSV
+					defVal := strings.TrimPrefix(f.DefValue, "[")
+					defVal = strings.TrimSuffix(defVal, "]")
+					if defVal != "" {
+						for _, v := range strings.Split(defVal, ",") {
+							_ = sv.Append(v)
+						}
+					}
+				}
+			} else {
+				_ = cmd.Flags().Set(f.Name, f.DefValue)
+			}
 		})
 
 	// Clean up arguments by resetting the slice to nil or an empty slice

--- a/internal/config/configuration_test.go
+++ b/internal/config/configuration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -193,4 +194,46 @@ func TestGetRetryMaxCustom(t *testing.T) {
 	t.Setenv(retryMax, "10")
 	n := GetRetryMax()
 	assert.Equal(t, 10, n)
+}
+
+func TestCleanupArgsAndFlags_StringArray(t *testing.T) {
+	cmd := &cobra.Command{Use: "test", RunE: func(cmd *cobra.Command, args []string) error { return nil }}
+	cmd.Flags().StringArray("platforms", []string{"linux/amd64"}, "platforms")
+	cmd.Flags().String("name", "default", "a string flag")
+
+	// Simulate first execution modifying the flag
+	_ = cmd.Flags().Set("platforms", "linux/arm64")
+	val, _ := cmd.Flags().GetStringArray("platforms")
+	assert.Equal(t, []string{"linux/arm64"}, val)
+
+	// Cleanup should reset to default
+	args := []string{}
+	CleanupArgsAndFlags(cmd, &args)
+
+	val, _ = cmd.Flags().GetStringArray("platforms")
+	assert.Equal(t, []string{"linux/amd64"}, val)
+
+	// Second cleanup should still return the same default (no bracket corruption)
+	CleanupArgsAndFlags(cmd, &args)
+	val, _ = cmd.Flags().GetStringArray("platforms")
+	assert.Equal(t, []string{"linux/amd64"}, val)
+
+	// String flags should also reset correctly
+	name, _ := cmd.Flags().GetString("name")
+	assert.Equal(t, "default", name)
+}
+
+func TestCleanupArgsAndFlags_EmptyStringArray(t *testing.T) {
+	cmd := &cobra.Command{Use: "test", RunE: func(cmd *cobra.Command, args []string) error { return nil }}
+	cmd.Flags().StringArray("tags", []string{}, "tags")
+
+	_ = cmd.Flags().Set("tags", "foo")
+	val, _ := cmd.Flags().GetStringArray("tags")
+	assert.Equal(t, []string{"foo"}, val)
+
+	args := []string{}
+	CleanupArgsAndFlags(cmd, &args)
+
+	val, _ = cmd.Flags().GetStringArray("tags")
+	assert.Equal(t, []string{}, val)
 }


### PR DESCRIPTION
## Problem

The `smoke-tests-docker-cache` full test fails with:
```
--platform [linux/amd64]
ERROR: "[linux" is an invalid OS component
```

## Root Cause

`CleanupArgsAndFlags` called `cmd.Flags().Set(f.Name, f.DefValue)` for all flags. For `StringArray` flags:
- `f.DefValue` is the Go `%v` representation: `"[linux/amd64]"`
- `Set()` treats this as a literal string value, storing `"[linux/amd64]"` with brackets
- On next `GetStringArray()`, the brackets are returned as part of the value

This affects any test that runs multiple commands in the same process (cobra command reuse via `SetArgs` + `ExecuteContext`).

## Fix

Use pflag's `SliceValue` interface (`Replace()`/`Append()`) for slice/array flags to properly reset values without bracket corruption. Regular scalar flags continue to use `Set(f.Name, f.DefValue)`.

Added unit tests `TestCleanupArgsAndFlags_StringArray` and `TestCleanupArgsAndFlags_EmptyStringArray` to prevent regression.

Also reverted the workaround from the smoke test (no longer needs explicit `--platforms`).