### PR TITLE
fix: ReplaceBuildContext now consumes entire build block

### DIFF
--- a/internal/utils/regex.go
+++ b/internal/utils/regex.go
@@ -8,41 +8,92 @@ import (
 )
 
 func ReplaceBuildContext(input string, dockerPathsToImageUrls map[string]string) string {
-	// Define the pattern to match the build section in the YAML structure.
-	// This pattern captures the indentation of the build section as well.
-	pattern := `(?m)(^\s*)build:\s*\n\s*context:\s*(?P<context>.+)\n\s*dockerfile:\s*(?P<dockerfile>.+)`
+	// Replace entire build: blocks (including extra keys like cache_from,
+	// cache_to) with a single image: line. Block boundaries are determined by
+	// indentation: every line indented deeper than the build: key is part of
+	// the block.
+	contextRe := regexp.MustCompile(`^\s*context:\s*(.+)`)
+	dockerfileRe := regexp.MustCompile(`^\s*dockerfile:\s*(.+)`)
 
-	// Compile the regular expression.
-	re := regexp.MustCompile(pattern)
+	lines := strings.Split(input, "\n")
+	var result []string
 
-	// Use FindAllStringSubmatch to find all matches in the input text.
-	updated := re.ReplaceAllStringFunc(input, func(match string) string {
-		// Extract the indentation, context, and dockerfile values.
-		indentation := ""
-		context := ""
-		dockerfile := ""
+	i := 0
+	for i < len(lines) {
+		line := lines[i]
+		trimmed := strings.TrimRight(line, " \t")
 
-		// Extract the indentation, context, and dockerfile using regex capture groups.
-		submatches := re.FindStringSubmatch(match)
-		if len(submatches) > 0 {
-			indentation = submatches[1]
-			context = strings.TrimSpace(submatches[2])
-			dockerfile = strings.TrimSpace(submatches[3])
+		// Detect a build: key.
+		idx := strings.Index(trimmed, "build:")
+		if idx < 0 || strings.TrimSpace(trimmed) != "build:" {
+			result = append(result, line)
+			i++
+			continue
 		}
 
-		absContextPath, err := filepath.Abs(context)
-		if err != nil {
-			return ""
+		buildIndent := idx // number of leading spaces before "build:"
+
+		// Collect the child lines of the build: block (indented deeper).
+		blockLines := []string{}
+		j := i + 1
+		for j < len(lines) {
+			child := lines[j]
+			if strings.TrimSpace(child) == "" {
+				// Blank line: peek ahead to see if the next non-blank line
+				// is still indented deeper than build: (YAML allows blank
+				// lines inside a mapping). If so, skip the blank line and
+				// continue consuming the block.
+				k := j + 1
+				for k < len(lines) && strings.TrimSpace(lines[k]) == "" {
+					k++
+				}
+				if k < len(lines) {
+					nextIndent := len(lines[k]) - len(strings.TrimLeft(lines[k], " \t"))
+					if nextIndent > buildIndent {
+						// Still inside the build block — skip blank lines.
+						j = k
+						continue
+					}
+				}
+				break
+			}
+			childIndent := len(child) - len(strings.TrimLeft(child, " \t"))
+			if childIndent <= buildIndent {
+				break
+			}
+			blockLines = append(blockLines, child)
+			j++
 		}
-		dockerfilePath := filepath.Join(absContextPath, dockerfile)
 
-		// Construct the replacement string based on the context and dockerfile.
-		// Here, we use fmt.Sprintf to generate the images URL and preserve the indentation.
-		replacement := fmt.Sprintf(`%simage: "%s"`, indentation, dockerPathsToImageUrls[dockerfilePath])
+		// Extract context and dockerfile from the block.
+		var context, dockerfile string
+		for _, bl := range blockLines {
+			if m := contextRe.FindStringSubmatch(bl); m != nil {
+				context = strings.TrimSpace(m[1])
+			}
+			if m := dockerfileRe.FindStringSubmatch(bl); m != nil {
+				dockerfile = strings.TrimSpace(m[1])
+			}
+		}
 
-		return replacement
-	})
+		if context != "" && dockerfile != "" {
+			absContextPath, err := filepath.Abs(context)
+			if err != nil {
+				// Can't resolve path — keep original.
+				result = append(result, line)
+				i++
+				continue
+			}
+			dockerfilePath := filepath.Join(absContextPath, dockerfile)
+			indentation := line[:buildIndent]
+			result = append(result, fmt.Sprintf(`%simage: "%s"`, indentation, dockerPathsToImageUrls[dockerfilePath]))
+			i = j // skip past the block
+		} else {
+			// Not a build context block — keep as-is.
+			result = append(result, line)
+			i++
+		}
+	}
 
-	// Return the modified input string.
-	return updated
+	return strings.Join(result, "\n")
 }

--- a/internal/utils/regex_test.go
+++ b/internal/utils/regex_test.go
@@ -105,6 +105,571 @@ some random content here without build section
 some random content here without build section
 `,
 		},
+		{
+			name: "Build section with cache_from and cache_to",
+			input: `
+services:
+  hello-world:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.frontend
+      cache_from:
+        - type=gha
+      cache_to:
+        - type=gha,mode=max
+    environment:
+      FOO: bar
+`,
+			versionTaggedImageURIs: map[string]string{
+				filepath.Join(cwd, "./frontend", "Dockerfile.frontend"): "ghcr.io/user/ai-chatbot-frontend:v1.0",
+			},
+			expectedOutput: `
+services:
+  hello-world:
+    image: "ghcr.io/user/ai-chatbot-frontend:v1.0"
+    environment:
+      FOO: bar
+`,
+		},
+		{
+			name: "Build section with cache_from only",
+			input: `
+services:
+  web:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+      cache_from:
+        - type=gha
+    ports:
+      - "8080:8080"
+`,
+			versionTaggedImageURIs: map[string]string{
+				filepath.Join(cwd, "./app", "Dockerfile"): "ghcr.io/user/web:v2.0",
+			},
+			expectedOutput: `
+services:
+  web:
+    image: "ghcr.io/user/web:v2.0"
+    ports:
+      - "8080:8080"
+`,
+		},
+		{
+			name: "Cache fields before context and dockerfile",
+			input: `
+services:
+  hello-world:
+    build:
+      cache_from:
+        - type=gha
+      cache_to:
+        - type=gha,mode=max
+      context: ./frontend
+      dockerfile: Dockerfile.frontend
+    environment:
+      FOO: bar
+`,
+			versionTaggedImageURIs: map[string]string{
+				filepath.Join(cwd, "./frontend", "Dockerfile.frontend"): "ghcr.io/user/ai-chatbot-frontend:v1.0",
+			},
+			expectedOutput: `
+services:
+  hello-world:
+    image: "ghcr.io/user/ai-chatbot-frontend:v1.0"
+    environment:
+      FOO: bar
+`,
+		},
+		{
+			name: "Cache between context and dockerfile",
+			input: `
+services:
+  api:
+    build:
+      context: ./api
+      cache_from:
+        - type=gha
+        - type=registry,ref=ghcr.io/owner/api:cache
+      dockerfile: Dockerfile
+      cache_to:
+        - type=gha,mode=max
+    ports:
+      - "3000:3000"
+`,
+			versionTaggedImageURIs: map[string]string{
+				filepath.Join(cwd, "./api", "Dockerfile"): "ghcr.io/user/api:v1.0",
+			},
+			expectedOutput: `
+services:
+  api:
+    image: "ghcr.io/user/api:v1.0"
+    ports:
+      - "3000:3000"
+`,
+		},
+		{
+			name: "Multiple services with mixed cache positions",
+			input: `
+services:
+  web:
+    build:
+      cache_from:
+        - type=gha
+      context: ./frontend
+      dockerfile: Dockerfile
+      cache_to:
+        - type=gha,mode=max
+    ports:
+      - "8080:8080"
+  api:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile.api
+      cache_from:
+        - type=gha
+    environment:
+      DB_HOST: localhost
+`,
+			versionTaggedImageURIs: map[string]string{
+				filepath.Join(cwd, "./frontend", "Dockerfile"): "ghcr.io/user/web:v1.0",
+				filepath.Join(cwd, "./backend", "Dockerfile.api"): "ghcr.io/user/api:v1.0",
+			},
+			expectedOutput: `
+services:
+  web:
+    image: "ghcr.io/user/web:v1.0"
+    ports:
+      - "8080:8080"
+  api:
+    image: "ghcr.io/user/api:v1.0"
+    environment:
+      DB_HOST: localhost
+`,
+		},
+		// --- Additional regression tests ---
+		{
+			name: "Build with args field preserved (no context/dockerfile = keep as-is)",
+			input: `
+services:
+  web:
+    build:
+      args:
+        NODE_ENV: production
+    ports:
+      - "8080:8080"
+`,
+			versionTaggedImageURIs: map[string]string{},
+			expectedOutput: `
+services:
+  web:
+    build:
+      args:
+        NODE_ENV: production
+    ports:
+      - "8080:8080"
+`,
+		},
+		{
+			name: "Build with context only (no dockerfile) is kept",
+			input: `
+services:
+  web:
+    build:
+      context: ./app
+    ports:
+      - "8080:8080"
+`,
+			versionTaggedImageURIs: map[string]string{},
+			expectedOutput: `
+services:
+  web:
+    build:
+      context: ./app
+    ports:
+      - "8080:8080"
+`,
+		},
+		{
+			name: "Build with dockerfile only (no context) is kept",
+			input: `
+services:
+  web:
+    build:
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+`,
+			versionTaggedImageURIs: map[string]string{},
+			expectedOutput: `
+services:
+  web:
+    build:
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+`,
+		},
+		{
+			name: "Build with args alongside context and dockerfile",
+			input: `
+services:
+  web:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+      args:
+        NODE_ENV: production
+        VERSION: "1.0"
+    ports:
+      - "8080:8080"
+`,
+			versionTaggedImageURIs: map[string]string{
+				filepath.Join(cwd, "./app", "Dockerfile"): "ghcr.io/user/web:v1.0",
+			},
+			expectedOutput: `
+services:
+  web:
+    image: "ghcr.io/user/web:v1.0"
+    ports:
+      - "8080:8080"
+`,
+		},
+		{
+			name: "Build with target and shm_size",
+			input: `
+services:
+  web:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+      target: builder
+      shm_size: '2gb'
+    ports:
+      - "8080:8080"
+`,
+			versionTaggedImageURIs: map[string]string{
+				filepath.Join(cwd, "./app", "Dockerfile"): "ghcr.io/user/web:v1.0",
+			},
+			expectedOutput: `
+services:
+  web:
+    image: "ghcr.io/user/web:v1.0"
+    ports:
+      - "8080:8080"
+`,
+		},
+		{
+			name: "Build keyword in a string value is not replaced",
+			input: `
+services:
+  web:
+    image: "myapp:latest"
+    environment:
+      BUILD_MODE: "build: context"
+      DESCRIPTION: "This will build: things"
+    ports:
+      - "8080:8080"
+`,
+			versionTaggedImageURIs: map[string]string{},
+			expectedOutput: `
+services:
+  web:
+    image: "myapp:latest"
+    environment:
+      BUILD_MODE: "build: context"
+      DESCRIPTION: "This will build: things"
+    ports:
+      - "8080:8080"
+`,
+		},
+		{
+			name: "Blank line inside build block is consumed",
+			input: `
+services:
+  web:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+
+      cache_from:
+        - type=gha
+    ports:
+      - "8080:8080"
+`,
+			versionTaggedImageURIs: map[string]string{
+				filepath.Join(cwd, "./app", "Dockerfile"): "ghcr.io/user/web:v1.0",
+			},
+			expectedOutput: `
+services:
+  web:
+    image: "ghcr.io/user/web:v1.0"
+    ports:
+      - "8080:8080"
+`,
+		},
+		{
+			name: "Multiple blank lines inside build block",
+			input: `
+services:
+  web:
+    build:
+      context: ./app
+
+
+      dockerfile: Dockerfile
+      cache_from:
+        - type=gha
+    ports:
+      - "8080:8080"
+`,
+			versionTaggedImageURIs: map[string]string{
+				filepath.Join(cwd, "./app", "Dockerfile"): "ghcr.io/user/web:v1.0",
+			},
+			expectedOutput: `
+services:
+  web:
+    image: "ghcr.io/user/web:v1.0"
+    ports:
+      - "8080:8080"
+`,
+		},
+		{
+			name: "Build block at end of file without trailing newline",
+			input: `services:
+  web:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+      cache_from:
+        - type=gha`,
+			versionTaggedImageURIs: map[string]string{
+				filepath.Join(cwd, "./app", "Dockerfile"): "ghcr.io/user/web:v1.0",
+			},
+			expectedOutput: `services:
+  web:
+    image: "ghcr.io/user/web:v1.0"`,
+		},
+		{
+			name: "Build at different indentation levels (2 vs 4 spaces)",
+			input: `
+services:
+  web:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+  api:
+        build:
+            context: ./api
+            dockerfile: Dockerfile.api
+`,
+			versionTaggedImageURIs: map[string]string{
+				filepath.Join(cwd, "./app", "Dockerfile"):     "ghcr.io/user/web:v1.0",
+				filepath.Join(cwd, "./api", "Dockerfile.api"): "ghcr.io/user/api:v1.0",
+			},
+			expectedOutput: `
+services:
+  web:
+    image: "ghcr.io/user/web:v1.0"
+  api:
+        image: "ghcr.io/user/api:v1.0"
+`,
+		},
+		{
+			name: "Real-world ray-cluster spec layout",
+			input: `
+version: '3'
+services:
+  hello-world:
+    build:
+      cache_from:
+        - type=gha
+      cache_to:
+        - type=gha,mode=max
+      context: ./jobs/hello-world
+      dockerfile: Dockerfile
+    environment:
+      RAY_ADDRESS: "ray://cluster:10001"
+      SCRIPT_PATH: "submit_job.py"
+    deploy:
+      resources:
+        reservations:
+          cpus: "0.1"
+          memory: 256M
+    x-omnistrate-compute:
+      replicaCountApiParam: numReplicas
+  hello-cuda:
+    build:
+      context: ./jobs/hello-cuda
+      dockerfile: Dockerfile
+    environment:
+      RAY_ADDRESS: "ray://cluster:10001"
+      SCRIPT_PATH: "submit_job.py"
+x-omnistrate-image-registry-attributes:
+  ghcr.io:
+    auth:
+      password: secret
+      username: user
+`,
+			versionTaggedImageURIs: map[string]string{
+				filepath.Join(cwd, "./jobs/hello-world", "Dockerfile"): "ghcr.io/org/ray-cluster-hello-world:sha-abc123",
+				filepath.Join(cwd, "./jobs/hello-cuda", "Dockerfile"):  "ghcr.io/org/ray-cluster-hello-cuda:sha-def456",
+			},
+			expectedOutput: `
+version: '3'
+services:
+  hello-world:
+    image: "ghcr.io/org/ray-cluster-hello-world:sha-abc123"
+    environment:
+      RAY_ADDRESS: "ray://cluster:10001"
+      SCRIPT_PATH: "submit_job.py"
+    deploy:
+      resources:
+        reservations:
+          cpus: "0.1"
+          memory: 256M
+    x-omnistrate-compute:
+      replicaCountApiParam: numReplicas
+  hello-cuda:
+    image: "ghcr.io/org/ray-cluster-hello-cuda:sha-def456"
+    environment:
+      RAY_ADDRESS: "ray://cluster:10001"
+      SCRIPT_PATH: "submit_job.py"
+x-omnistrate-image-registry-attributes:
+  ghcr.io:
+    auth:
+      password: secret
+      username: user
+`,
+		},
+		{
+			name: "Service with image field is untouched",
+			input: `
+services:
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+  web:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+`,
+			versionTaggedImageURIs: map[string]string{
+				filepath.Join(cwd, "./app", "Dockerfile"): "ghcr.io/user/web:v1.0",
+			},
+			expectedOutput: `
+services:
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+  web:
+    image: "ghcr.io/user/web:v1.0"
+    ports:
+      - "8080:8080"
+`,
+		},
+		{
+			name: "Build with multiple cache_from entries",
+			input: `
+services:
+  web:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+      cache_from:
+        - type=gha
+        - type=registry,ref=ghcr.io/user/web:cache
+        - type=local,src=/tmp/.buildx-cache
+      cache_to:
+        - type=gha,mode=max
+        - type=registry,ref=ghcr.io/user/web:cache
+    ports:
+      - "8080:8080"
+`,
+			versionTaggedImageURIs: map[string]string{
+				filepath.Join(cwd, "./app", "Dockerfile"): "ghcr.io/user/web:v1.0",
+			},
+			expectedOutput: `
+services:
+  web:
+    image: "ghcr.io/user/web:v1.0"
+    ports:
+      - "8080:8080"
+`,
+		},
+		{
+			name: "Dockerfile reversed before context",
+			input: `
+services:
+  web:
+    build:
+      dockerfile: Dockerfile
+      context: ./app
+    ports:
+      - "8080:8080"
+`,
+			versionTaggedImageURIs: map[string]string{
+				filepath.Join(cwd, "./app", "Dockerfile"): "ghcr.io/user/web:v1.0",
+			},
+			expectedOutput: `
+services:
+  web:
+    image: "ghcr.io/user/web:v1.0"
+    ports:
+      - "8080:8080"
+`,
+		},
+		{
+			name: "Three services one without build",
+			input: `
+services:
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+      cache_from:
+        - type=gha
+    ports:
+      - "3000:3000"
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+  backend:
+    build:
+      cache_to:
+        - type=gha,mode=max
+      context: ./backend
+      dockerfile: Dockerfile.prod
+      cache_from:
+        - type=gha
+    environment:
+      REDIS_URL: redis://redis:6379
+`,
+			versionTaggedImageURIs: map[string]string{
+				filepath.Join(cwd, "./frontend", "Dockerfile"):      "ghcr.io/user/frontend:v1.0",
+				filepath.Join(cwd, "./backend", "Dockerfile.prod"): "ghcr.io/user/backend:v1.0",
+			},
+			expectedOutput: `
+services:
+  frontend:
+    image: "ghcr.io/user/frontend:v1.0"
+    ports:
+      - "3000:3000"
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"
+  backend:
+    image: "ghcr.io/user/backend:v1.0"
+    environment:
+      REDIS_URL: redis://redis:6379
+`,
+		},
 	}
 
 	// Iterate over each test case


### PR DESCRIPTION
## Problem

`ReplaceBuildContext` used a regex that only matched `context:` and `dockerfile:` lines under `build:`. When additional keys like `cache_from` and `cache_to` were present (added in #624), they were left behind as orphaned YAML after the `build:` block was replaced with `image:`, causing YAML parse errors on the backend.

## Root Cause

The old regex pattern:
```
(?m)(^\s*)build:\s*\n\s*context:\s*(?P<context>.+)\n\s*dockerfile:\s*(?P<dockerfile>.+)
```
only matched exactly 3 lines (build + context + dockerfile) and didn't consume any remaining child lines.

## Fix

Replace the regex approach with a line-by-line parser that determines block boundaries by indentation level. All lines indented deeper than the `build:` key are consumed, including `cache_from`, `cache_to`, and their list items.

## Tests

- All existing tests pass unchanged
- Added 2 new test cases: build block with `cache_from`+`cache_to`, and build block with `cache_from` only