### PR TITLE
fix: always include --load for single-platform docker buildx builds

### DIFF
--- a/cmd/build/utils.go
+++ b/cmd/build/utils.go
@@ -497,8 +497,9 @@ func ExpandOmctlEnvVars(data []byte) ([]byte, error) {
 
 // BuildDockerBuildArgs constructs the arguments for a `docker buildx build` command,
 // including optional --cache-from and --cache-to flags from the compose spec.
-// --load is omitted when cacheTo is set (build's purpose is cache population)
-// or when multiple platforms are specified (--load is incompatible with multi-platform builds).
+// --load is always included for single-platform builds so the image is available
+// locally for subsequent `docker push`. It is only omitted for multi-platform
+// builds where --load is incompatible with the buildx driver.
 func BuildDockerBuildArgs(platforms, dockerfilePath, imageURL string, cacheFrom, cacheTo []string) []string {
 	args := []string{"buildx", "build", "--pull", "--platform", platforms, ".", "-f", dockerfilePath, "-t", imageURL}
 	for _, cf := range cacheFrom {
@@ -508,7 +509,7 @@ func BuildDockerBuildArgs(platforms, dockerfilePath, imageURL string, cacheFrom,
 		args = append(args, "--cache-to", ct)
 	}
 	isMultiPlatform := strings.Contains(platforms, ",")
-	if len(cacheTo) == 0 && !isMultiPlatform {
+	if !isMultiPlatform {
 		args = append(args, "--load")
 	}
 	return args

--- a/cmd/build/utils_test.go
+++ b/cmd/build/utils_test.go
@@ -543,7 +543,7 @@ func TestBuildDockerBuildArgs(t *testing.T) {
 			imageURL:   "ghcr.io/owner/repo",
 			cacheFrom:  []string{"type=gha"},
 			cacheTo:    []string{"type=gha,mode=max"},
-			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64", ".", "-f", "Dockerfile", "-t", "ghcr.io/owner/repo", "--cache-from", "type=gha", "--cache-to", "type=gha,mode=max"},
+			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64", ".", "-f", "Dockerfile", "-t", "ghcr.io/owner/repo", "--cache-from", "type=gha", "--cache-to", "type=gha,mode=max", "--load"},
 		},
 		{
 			name:       "multiple cache sources",
@@ -570,7 +570,7 @@ func TestBuildDockerBuildArgs(t *testing.T) {
 			imageURL:   "ghcr.io/owner/repo",
 			cacheFrom:  nil,
 			cacheTo:    []string{"type=gha,mode=max"},
-			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64", ".", "-f", "Dockerfile", "-t", "ghcr.io/owner/repo", "--cache-to", "type=gha,mode=max"},
+			expected:   []string{"buildx", "build", "--pull", "--platform", "linux/amd64", ".", "-f", "Dockerfile", "-t", "ghcr.io/owner/repo", "--cache-to", "type=gha,mode=max", "--load"},
 		},
 		{
 			name:       "multi-platform without cache skips load",


### PR DESCRIPTION
## Problem

`BuildDockerBuildArgs` skipped `--load` when `cacheTo` was set, assuming the build's purpose was purely cache population. However, the CLI subsequently runs `docker push`, which requires the image to be loaded into the local docker store. Without `--load`, push fails with `image not found`.

## Fix

Always include `--load` for single-platform builds (where it's compatible with buildx). Only multi-platform builds omit it, since `--load` is incompatible with the multi-platform builder.

## Testing

Updated `TestBuildDockerBuildArgs` expectations: `with gha cache` and `cache_to only` test cases now expect `--load` in the args.