### PR TITLE
chore: update SDK Go dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/njayp/ophis v1.1.4
-	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.110
+	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.111
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/njayp/ophis v1.1.4 h1:6aq3UdU6MlGIjpg//IzKc2yIxHYMf6Rg1A5MLovM9gg=
 github.com/njayp/ophis v1.1.4/go.mod h1:F9KEnfeCJzCWo3e0JP2QqSCN04bXptXl1ico5lcLeYg=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.110 h1:s35cSBJ9FBqHL/EV2svhiGciRpX9cKorhaRDP3upIrM=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.110/go.mod h1:q0FPYLbtm+Aw6GW0xbeaMPHR4WGzoV61iTGFoOhO72M=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.111 h1:cRwmJf6n4m30Thx11nOTOuB622LXEWQOeGDtAsSIrT8=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.111/go.mod h1:q0FPYLbtm+Aw6GW0xbeaMPHR4WGzoV61iTGFoOhO72M=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=

--- a/internal/dataaccess/apikeys.go
+++ b/internal/dataaccess/apikeys.go
@@ -128,7 +128,7 @@ func DeleteAPIKey(ctx context.Context, token, id string) error {
 	ctxWithToken := context.WithValue(ctx, openapiclient.ContextAccessToken, token)
 
 	apiClient := getV1Client()
-	_, r, err := apiClient.ApiKeyApiAPI.ApiKeyApiDeleteAPIKey(ctxWithToken, id).Execute()
+	r, err := apiClient.ApiKeyApiAPI.ApiKeyApiDeleteAPIKey(ctxWithToken, id).Execute()
 	if r != nil {
 		defer r.Body.Close()
 	}


### PR DESCRIPTION
## Summary
- update omnistrate-sdk-go to v0.0.111
- adapt API key delete handling to the SDK's void delete response

## Tests
- go test ./internal/dataaccess