### PR TITLE
feat: add Input Parameters and Output Parameters tabs to Helm debug TUI

### DIFF
--- a/cmd/instance/debug.go
+++ b/cmd/instance/debug.go
@@ -110,9 +110,10 @@ func fetchDebugData(instanceID, token string) tea.Cmd {
 				Errors: []string{err.Error()},
 			}
 		}
-		// Extract result_params (resolved output values) from instance additional properties
+		// Extract result_params (resolved output values) from consumption result
 		var resultParams map[string]interface{}
-		if rp, ok := instanceData.AdditionalProperties["result_params"]; ok {
+		consumptionResult := instanceData.GetConsumptionResourceInstanceResult()
+		if rp := consumptionResult.GetResultParams(); rp != nil {
 			if rpMap, ok := rp.(map[string]interface{}); ok {
 				resultParams = rpMap
 			}
@@ -204,9 +205,10 @@ func runDebugJSON(instanceID, token string) error {
 		}
 	}
 
-	// Extract result_params (resolved output values) from instance additional properties
+	// Extract result_params (resolved output values) from consumption result
 	var resultParams map[string]interface{}
-	if rp, ok := instanceData.AdditionalProperties["result_params"]; ok {
+	consumptionResult := instanceData.GetConsumptionResourceInstanceResult()
+	if rp := consumptionResult.GetResultParams(); rp != nil {
 		if rpMap, ok := rp.(map[string]interface{}); ok {
 			resultParams = rpMap
 		}
@@ -261,7 +263,8 @@ func collectResourceDebugInfo(ctx context.Context, token, serviceID, environment
 
 	// Extract result_params for resolving output parameter values
 	var resultParams map[string]interface{}
-	if rp, ok := instanceData.AdditionalProperties["result_params"]; ok {
+	consumptionResult := instanceData.GetConsumptionResourceInstanceResult()
+	if rp := consumptionResult.GetResultParams(); rp != nil {
 		if rpMap, ok := rp.(map[string]interface{}); ok {
 			resultParams = rpMap
 		}

--- a/cmd/instance/debug.go
+++ b/cmd/instance/debug.go
@@ -307,51 +307,18 @@ func collectHelmDebugInfo(ctx context.Context, token, serviceID, environmentID, 
 
 			if nodeID != "" && instanceData != nil {
 				// Fetch input parameters
-				inputParamsResult, inputErr := dataaccess.ListInputParameters(
+				inputParams, _ := fetchInputParams(
 					ctx, token, serviceID, nodeID,
 					instanceData.ProductTierId, instanceData.TierVersion,
 				)
-				if inputErr == nil && inputParamsResult != nil {
-					for _, ip := range inputParamsResult.InputParameters {
-						param := OperatorInputParam{
-							Key:         ip.Key,
-							DisplayName: ip.Name,
-							Description: ip.Description,
-							Type:        ip.Type,
-							Required:    ip.Required,
-							Modifiable:  ip.Modifiable,
-						}
-						if ip.DefaultValue != nil {
-							param.DefaultValue = *ip.DefaultValue
-						}
-						info.Helm.InputParams = append(info.Helm.InputParams, param)
-					}
-				}
+				info.Helm.InputParams = inputParams
 
 				// Fetch output parameters
-				outputParamsResult, outputErr := dataaccess.ListOutputParameters(
+				outputParams, _ := fetchOutputParams(
 					ctx, token, serviceID, nodeID,
 					instanceData.ProductTierId, instanceData.TierVersion,
 				)
-				if outputErr == nil && outputParamsResult != nil {
-					for _, op := range outputParamsResult.OutputParameters {
-						param := OperatorOutputParam{
-							Key:         op.Key,
-							DisplayName: op.Name,
-							Description: op.Description,
-						}
-						if op.Value != nil {
-							param.Value = *op.Value
-						}
-						if op.ValueRef != nil {
-							param.ValueRef = *op.ValueRef
-						}
-						if op.ValueType != nil {
-							param.Type = *op.ValueType
-						}
-						info.Helm.OutputParams = append(info.Helm.OutputParams, param)
-					}
-				}
+				info.Helm.OutputParams = outputParams
 			}
 		}
 	}
@@ -444,51 +411,22 @@ func collectOperatorDebugInfo(ctx context.Context, token, serviceID string, plan
 
 		opData := &OperatorData{}
 
-		// Fetch all input parameters from ListInputParameter V1 API
-		inputParamsResult, inputErr := dataaccess.ListInputParameters(
+		// Fetch all input parameters
+		inputParams, inputErr := fetchInputParams(
 			ctx, token, serviceID, node.ID,
 			instanceData.ProductTierId, instanceData.TierVersion,
 		)
-		if inputErr == nil && inputParamsResult != nil {
-			for _, ip := range inputParamsResult.InputParameters {
-				param := OperatorInputParam{
-					Key:         ip.Key,
-					DisplayName: ip.Name,
-					Description: ip.Description,
-					Type:        ip.Type,
-					Required:    ip.Required,
-					Modifiable:  ip.Modifiable,
-				}
-				if ip.DefaultValue != nil {
-					param.DefaultValue = *ip.DefaultValue
-				}
-				opData.InputParams = append(opData.InputParams, param)
-			}
+		if inputErr == nil {
+			opData.InputParams = inputParams
 		}
 
-		// Fetch exported output parameters from ListOutputParameter V1 API
-		outputParamsResult, listErr := dataaccess.ListOutputParameters(
+		// Fetch exported output parameters
+		outputParams, listErr := fetchOutputParams(
 			ctx, token, serviceID, node.ID,
 			instanceData.ProductTierId, instanceData.TierVersion,
 		)
-		if listErr == nil && outputParamsResult != nil {
-			for _, op := range outputParamsResult.OutputParameters {
-				param := OperatorOutputParam{
-					Key:         op.Key,
-					DisplayName: op.Name,
-					Description: op.Description,
-				}
-				if op.Value != nil {
-					param.Value = *op.Value
-				}
-				if op.ValueRef != nil {
-					param.ValueRef = *op.ValueRef
-				}
-				if op.ValueType != nil {
-					param.Type = *op.ValueType
-				}
-				opData.OutputParams = append(opData.OutputParams, param)
-			}
+		if listErr == nil {
+			opData.OutputParams = outputParams
 		}
 
 		// Fetch CRD output parameters from DescribeResource (operatorCRDConfiguration.outputParameters)

--- a/cmd/instance/debug.go
+++ b/cmd/instance/debug.go
@@ -35,6 +35,7 @@ type DebugData struct {
 	ProductTierID     string                        `json:"productTierId,omitempty"`
 	TierVersion       string                        `json:"tierVersion,omitempty"`
 	Token             string                        `json:"-"`
+	ResultParams      map[string]interface{}         `json:"-"`
 	ResourceDebugInfo map[string]*ResourceDebugInfo `json:"resourceDebugInfo,omitempty"`
 }
 
@@ -109,6 +110,14 @@ func fetchDebugData(instanceID, token string) tea.Cmd {
 				Errors: []string{err.Error()},
 			}
 		}
+		// Extract result_params (resolved output values) from instance additional properties
+		var resultParams map[string]interface{}
+		if rp, ok := instanceData.AdditionalProperties["result_params"]; ok {
+			if rpMap, ok := rp.(map[string]interface{}); ok {
+				resultParams = rpMap
+			}
+		}
+
 		return debugDataMsg{
 			data: DebugData{
 				InstanceID:    instanceID,
@@ -118,6 +127,7 @@ func fetchDebugData(instanceID, token string) tea.Cmd {
 				ProductTierID: instanceData.ProductTierId,
 				TierVersion:   instanceData.TierVersion,
 				Token:         token,
+				ResultParams:  resultParams,
 			},
 		}
 	}
@@ -194,6 +204,14 @@ func runDebugJSON(instanceID, token string) error {
 		}
 	}
 
+	// Extract result_params (resolved output values) from instance additional properties
+	var resultParams map[string]interface{}
+	if rp, ok := instanceData.AdditionalProperties["result_params"]; ok {
+		if rpMap, ok := rp.(map[string]interface{}); ok {
+			resultParams = rpMap
+		}
+	}
+
 	data := DebugData{
 		InstanceID:    instanceID,
 		ServiceID:     serviceID,
@@ -201,6 +219,7 @@ func runDebugJSON(instanceID, token string) error {
 		ProductTierID: instanceData.ProductTierId,
 		TierVersion:   instanceData.TierVersion,
 		PlanDAG:       planDAG,
+		ResultParams:  resultParams,
 	}
 
 	// Collect per-resource debug info (helm data, terraform progress/files/logs)
@@ -240,14 +259,22 @@ func collectResourceDebugInfo(ctx context.Context, token, serviceID, environment
 		}
 	}
 
+	// Extract result_params for resolving output parameter values
+	var resultParams map[string]interface{}
+	if rp, ok := instanceData.AdditionalProperties["result_params"]; ok {
+		if rpMap, ok := rp.(map[string]interface{}); ok {
+			resultParams = rpMap
+		}
+	}
+
 	// Collect helm debug data from the DebugResourceInstance API
-	collectHelmDebugInfo(ctx, token, serviceID, environmentID, instanceID, planDAG, instanceData, result)
+	collectHelmDebugInfo(ctx, token, serviceID, environmentID, instanceID, planDAG, instanceData, resultParams, result)
 
 	// Collect terraform debug data from k8s ConfigMaps
 	collectTerraformDebugInfo(ctx, token, instanceData, instanceID, planDAG, result)
 
 	// Collect operator debug data (input/output parameters) for non-helm, non-terraform resources
-	collectOperatorDebugInfo(ctx, token, serviceID, planDAG, instanceData, result)
+	collectOperatorDebugInfo(ctx, token, serviceID, planDAG, instanceData, resultParams, result)
 
 	// Remove entries that have no debug data
 	for key, info := range result {
@@ -260,7 +287,7 @@ func collectResourceDebugInfo(ctx context.Context, token, serviceID, environment
 }
 
 // collectHelmDebugInfo fetches helm debug data (logs, chart values) and input/output parameters for all helm resources.
-func collectHelmDebugInfo(ctx context.Context, token, serviceID, environmentID, instanceID string, planDAG *PlanDAG, instanceData *openapiclientfleet.ResourceInstance, result map[string]*ResourceDebugInfo) {
+func collectHelmDebugInfo(ctx context.Context, token, serviceID, environmentID, instanceID string, planDAG *PlanDAG, instanceData *openapiclientfleet.ResourceInstance, resultParams map[string]interface{}, result map[string]*ResourceDebugInfo) {
 	debugResult, err := dataaccess.DebugResourceInstance(ctx, token, serviceID, environmentID, instanceID)
 	if err != nil || debugResult.ResourcesDebug == nil {
 		return
@@ -317,6 +344,7 @@ func collectHelmDebugInfo(ctx context.Context, token, serviceID, environmentID, 
 				outputParams, _ := fetchOutputParams(
 					ctx, token, serviceID, nodeID,
 					instanceData.ProductTierId, instanceData.TierVersion,
+					resultParams,
 				)
 				info.Helm.OutputParams = outputParams
 			}
@@ -393,7 +421,7 @@ func collectTerraformDebugInfo(ctx context.Context, token string, instanceData *
 
 // collectOperatorDebugInfo fetches operator debug data (input/output parameters, CRD outputs)
 // for operator-type resources.
-func collectOperatorDebugInfo(ctx context.Context, token, serviceID string, planDAG *PlanDAG, instanceData *openapiclientfleet.ResourceInstance, result map[string]*ResourceDebugInfo) {
+func collectOperatorDebugInfo(ctx context.Context, token, serviceID string, planDAG *PlanDAG, instanceData *openapiclientfleet.ResourceInstance, resultParams map[string]interface{}, result map[string]*ResourceDebugInfo) {
 	for _, node := range planDAG.Nodes {
 		lower := strings.ToLower(node.Type)
 		if !strings.Contains(lower, "operator") {
@@ -424,6 +452,7 @@ func collectOperatorDebugInfo(ctx context.Context, token, serviceID string, plan
 		outputParams, listErr := fetchOutputParams(
 			ctx, token, serviceID, node.ID,
 			instanceData.ProductTierId, instanceData.TierVersion,
+			resultParams,
 		)
 		if listErr == nil {
 			opData.OutputParams = outputParams

--- a/cmd/instance/debug.go
+++ b/cmd/instance/debug.go
@@ -241,7 +241,7 @@ func collectResourceDebugInfo(ctx context.Context, token, serviceID, environment
 	}
 
 	// Collect helm debug data from the DebugResourceInstance API
-	collectHelmDebugInfo(ctx, token, serviceID, environmentID, instanceID, result)
+	collectHelmDebugInfo(ctx, token, serviceID, environmentID, instanceID, planDAG, instanceData, result)
 
 	// Collect terraform debug data from k8s ConfigMaps
 	collectTerraformDebugInfo(ctx, token, instanceData, instanceID, planDAG, result)
@@ -259,8 +259,8 @@ func collectResourceDebugInfo(ctx context.Context, token, serviceID, environment
 	return result
 }
 
-// collectHelmDebugInfo fetches helm debug data (logs, chart values) for all helm resources.
-func collectHelmDebugInfo(ctx context.Context, token, serviceID, environmentID, instanceID string, result map[string]*ResourceDebugInfo) {
+// collectHelmDebugInfo fetches helm debug data (logs, chart values) and input/output parameters for all helm resources.
+func collectHelmDebugInfo(ctx context.Context, token, serviceID, environmentID, instanceID string, planDAG *PlanDAG, instanceData *openapiclientfleet.ResourceInstance, result map[string]*ResourceDebugInfo) {
 	debugResult, err := dataaccess.DebugResourceInstance(ctx, token, serviceID, environmentID, instanceID)
 	if err != nil || debugResult.ResourcesDebug == nil {
 		return
@@ -289,6 +289,70 @@ func collectHelmDebugInfo(ctx context.Context, token, serviceID, environmentID, 
 		// Check if it's a helm resource (has chart metadata)
 		if _, hasChart := actualDebugData["chartRepoName"]; hasChart {
 			info.Helm = parseHelmData(actualDebugData)
+
+			// Find the node ID for this resource to fetch input/output params
+			var nodeID string
+			if planDAG != nil {
+				for _, node := range planDAG.Nodes {
+					nodeKey := node.Key
+					if nodeKey == "" {
+						nodeKey = node.ID
+					}
+					if nodeKey == resourceKey {
+						nodeID = node.ID
+						break
+					}
+				}
+			}
+
+			if nodeID != "" && instanceData != nil {
+				// Fetch input parameters
+				inputParamsResult, inputErr := dataaccess.ListInputParameters(
+					ctx, token, serviceID, nodeID,
+					instanceData.ProductTierId, instanceData.TierVersion,
+				)
+				if inputErr == nil && inputParamsResult != nil {
+					for _, ip := range inputParamsResult.InputParameters {
+						param := OperatorInputParam{
+							Key:         ip.Key,
+							DisplayName: ip.Name,
+							Description: ip.Description,
+							Type:        ip.Type,
+							Required:    ip.Required,
+							Modifiable:  ip.Modifiable,
+						}
+						if ip.DefaultValue != nil {
+							param.DefaultValue = *ip.DefaultValue
+						}
+						info.Helm.InputParams = append(info.Helm.InputParams, param)
+					}
+				}
+
+				// Fetch output parameters
+				outputParamsResult, outputErr := dataaccess.ListOutputParameters(
+					ctx, token, serviceID, nodeID,
+					instanceData.ProductTierId, instanceData.TierVersion,
+				)
+				if outputErr == nil && outputParamsResult != nil {
+					for _, op := range outputParamsResult.OutputParameters {
+						param := OperatorOutputParam{
+							Key:         op.Key,
+							DisplayName: op.Name,
+							Description: op.Description,
+						}
+						if op.Value != nil {
+							param.Value = *op.Value
+						}
+						if op.ValueRef != nil {
+							param.ValueRef = *op.ValueRef
+						}
+						if op.ValueType != nil {
+							param.Type = *op.ValueType
+						}
+						info.Helm.OutputParams = append(info.Helm.OutputParams, param)
+					}
+				}
+			}
 		}
 	}
 }

--- a/cmd/instance/debug.go
+++ b/cmd/instance/debug.go
@@ -498,12 +498,18 @@ func collectOperatorDebugInfo(ctx context.Context, token, serviceID string, plan
 		if descErr == nil && resourceResult != nil {
 			crdConfig, ok := resourceResult.GetOperatorCRDConfigurationOk()
 			if ok && crdConfig != nil {
-				outputParams := crdConfig.GetOutputParameters()
-				for k, v := range outputParams {
-					opData.CRDOutputParams = append(opData.CRDOutputParams, OperatorCRDOutputParam{
+				crdOutputParams := crdConfig.GetOutputParameters()
+				for k, v := range crdOutputParams {
+					crdParam := OperatorCRDOutputParam{
 						Key:   k,
 						Value: v,
-					})
+					}
+					if resultParams != nil {
+						if rv, ok := resultParams[k]; ok {
+							crdParam.ResolvedValue = fmt.Sprintf("%v", rv)
+						}
+					}
+					opData.CRDOutputParams = append(opData.CRDOutputParams, crdParam)
 				}
 			}
 		}

--- a/cmd/instance/debug.go
+++ b/cmd/instance/debug.go
@@ -36,6 +36,7 @@ type DebugData struct {
 	TierVersion       string                        `json:"tierVersion,omitempty"`
 	Token             string                        `json:"-"`
 	ResultParams      map[string]interface{}         `json:"-"`
+	InputParams       map[string]interface{}         `json:"-"`
 	ResourceDebugInfo map[string]*ResourceDebugInfo `json:"resourceDebugInfo,omitempty"`
 }
 
@@ -119,6 +120,14 @@ func fetchDebugData(instanceID, token string) tea.Cmd {
 			}
 		}
 
+		// Extract input_params (resolved input values) from instance
+		var inputParams map[string]interface{}
+		if ip := instanceData.GetInputParams(); ip != nil {
+			if ipMap, ok := ip.(map[string]interface{}); ok {
+				inputParams = ipMap
+			}
+		}
+
 		return debugDataMsg{
 			data: DebugData{
 				InstanceID:    instanceID,
@@ -129,6 +138,7 @@ func fetchDebugData(instanceID, token string) tea.Cmd {
 				TierVersion:   instanceData.TierVersion,
 				Token:         token,
 				ResultParams:  resultParams,
+				InputParams:   inputParams,
 			},
 		}
 	}
@@ -214,6 +224,14 @@ func runDebugJSON(instanceID, token string) error {
 		}
 	}
 
+	// Extract input_params (resolved input values) from instance
+	var inputParams map[string]interface{}
+	if ip := instanceData.GetInputParams(); ip != nil {
+		if ipMap, ok := ip.(map[string]interface{}); ok {
+			inputParams = ipMap
+		}
+	}
+
 	data := DebugData{
 		InstanceID:    instanceID,
 		ServiceID:     serviceID,
@@ -222,6 +240,7 @@ func runDebugJSON(instanceID, token string) error {
 		TierVersion:   instanceData.TierVersion,
 		PlanDAG:       planDAG,
 		ResultParams:  resultParams,
+		InputParams:   inputParams,
 	}
 
 	// Collect per-resource debug info (helm data, terraform progress/files/logs)
@@ -270,14 +289,22 @@ func collectResourceDebugInfo(ctx context.Context, token, serviceID, environment
 		}
 	}
 
+	// Extract input_params for resolving input parameter values
+	var inputParams map[string]interface{}
+	if ip := instanceData.GetInputParams(); ip != nil {
+		if ipMap, ok := ip.(map[string]interface{}); ok {
+			inputParams = ipMap
+		}
+	}
+
 	// Collect helm debug data from the DebugResourceInstance API
-	collectHelmDebugInfo(ctx, token, serviceID, environmentID, instanceID, planDAG, instanceData, resultParams, result)
+	collectHelmDebugInfo(ctx, token, serviceID, environmentID, instanceID, planDAG, instanceData, inputParams, resultParams, result)
 
 	// Collect terraform debug data from k8s ConfigMaps
 	collectTerraformDebugInfo(ctx, token, instanceData, instanceID, planDAG, result)
 
 	// Collect operator debug data (input/output parameters) for non-helm, non-terraform resources
-	collectOperatorDebugInfo(ctx, token, serviceID, planDAG, instanceData, resultParams, result)
+	collectOperatorDebugInfo(ctx, token, serviceID, planDAG, instanceData, inputParams, resultParams, result)
 
 	// Remove entries that have no debug data
 	for key, info := range result {
@@ -290,7 +317,7 @@ func collectResourceDebugInfo(ctx context.Context, token, serviceID, environment
 }
 
 // collectHelmDebugInfo fetches helm debug data (logs, chart values) and input/output parameters for all helm resources.
-func collectHelmDebugInfo(ctx context.Context, token, serviceID, environmentID, instanceID string, planDAG *PlanDAG, instanceData *openapiclientfleet.ResourceInstance, resultParams map[string]interface{}, result map[string]*ResourceDebugInfo) {
+func collectHelmDebugInfo(ctx context.Context, token, serviceID, environmentID, instanceID string, planDAG *PlanDAG, instanceData *openapiclientfleet.ResourceInstance, inputParams map[string]interface{}, resultParams map[string]interface{}, result map[string]*ResourceDebugInfo) {
 	debugResult, err := dataaccess.DebugResourceInstance(ctx, token, serviceID, environmentID, instanceID)
 	if err != nil || debugResult.ResourcesDebug == nil {
 		return
@@ -337,11 +364,12 @@ func collectHelmDebugInfo(ctx context.Context, token, serviceID, environmentID, 
 
 			if nodeID != "" && instanceData != nil {
 				// Fetch input parameters
-				inputParams, _ := fetchInputParams(
+				fetchedInputParams, _ := fetchInputParams(
 					ctx, token, serviceID, nodeID,
 					instanceData.ProductTierId, instanceData.TierVersion,
+					inputParams,
 				)
-				info.Helm.InputParams = inputParams
+				info.Helm.InputParams = fetchedInputParams
 
 				// Fetch output parameters
 				outputParams, _ := fetchOutputParams(
@@ -424,7 +452,7 @@ func collectTerraformDebugInfo(ctx context.Context, token string, instanceData *
 
 // collectOperatorDebugInfo fetches operator debug data (input/output parameters, CRD outputs)
 // for operator-type resources.
-func collectOperatorDebugInfo(ctx context.Context, token, serviceID string, planDAG *PlanDAG, instanceData *openapiclientfleet.ResourceInstance, resultParams map[string]interface{}, result map[string]*ResourceDebugInfo) {
+func collectOperatorDebugInfo(ctx context.Context, token, serviceID string, planDAG *PlanDAG, instanceData *openapiclientfleet.ResourceInstance, inputParams map[string]interface{}, resultParams map[string]interface{}, result map[string]*ResourceDebugInfo) {
 	for _, node := range planDAG.Nodes {
 		lower := strings.ToLower(node.Type)
 		if !strings.Contains(lower, "operator") {
@@ -443,12 +471,13 @@ func collectOperatorDebugInfo(ctx context.Context, token, serviceID string, plan
 		opData := &OperatorData{}
 
 		// Fetch all input parameters
-		inputParams, inputErr := fetchInputParams(
+		fetchedInputParams, inputErr := fetchInputParams(
 			ctx, token, serviceID, node.ID,
 			instanceData.ProductTierId, instanceData.TierVersion,
+			inputParams,
 		)
 		if inputErr == nil {
-			opData.InputParams = inputParams
+			opData.InputParams = fetchedInputParams
 		}
 
 		// Fetch exported output parameters

--- a/cmd/instance/debug_helm_detail_tui.go
+++ b/cmd/instance/debug_helm_detail_tui.go
@@ -152,6 +152,7 @@ func (m helmDetailModel) fetchHelmData() tea.Cmd {
 				ctx, m.debugData.Token,
 				m.debugData.ServiceID, m.node.ID,
 				m.debugData.ProductTierID, m.debugData.TierVersion,
+				m.debugData.ResultParams,
 			)
 			helmData.OutputParams = outputParams
 

--- a/cmd/instance/debug_helm_detail_tui.go
+++ b/cmd/instance/debug_helm_detail_tui.go
@@ -139,54 +139,21 @@ func (m helmDetailModel) fetchHelmData() tea.Cmd {
 
 			helmData := parseHelmData(actualDebugData)
 
-			// Fetch input parameters from ListInputParameter V1 API
-			inputParamsResult, inputErr := dataaccess.ListInputParameters(
+			// Fetch input parameters
+			inputParams, _ := fetchInputParams(
 				ctx, m.debugData.Token,
 				m.debugData.ServiceID, m.node.ID,
 				m.debugData.ProductTierID, m.debugData.TierVersion,
 			)
-			if inputErr == nil && inputParamsResult != nil {
-				for _, ip := range inputParamsResult.InputParameters {
-					param := OperatorInputParam{
-						Key:         ip.Key,
-						DisplayName: ip.Name,
-						Description: ip.Description,
-						Type:        ip.Type,
-						Required:    ip.Required,
-						Modifiable:  ip.Modifiable,
-					}
-					if ip.DefaultValue != nil {
-						param.DefaultValue = *ip.DefaultValue
-					}
-					helmData.InputParams = append(helmData.InputParams, param)
-				}
-			}
+			helmData.InputParams = inputParams
 
-			// Fetch output parameters from ListOutputParameter V1 API
-			outputParamsResult, outputErr := dataaccess.ListOutputParameters(
+			// Fetch output parameters
+			outputParams, _ := fetchOutputParams(
 				ctx, m.debugData.Token,
 				m.debugData.ServiceID, m.node.ID,
 				m.debugData.ProductTierID, m.debugData.TierVersion,
 			)
-			if outputErr == nil && outputParamsResult != nil {
-				for _, op := range outputParamsResult.OutputParameters {
-					param := OperatorOutputParam{
-						Key:         op.Key,
-						DisplayName: op.Name,
-						Description: op.Description,
-					}
-					if op.Value != nil {
-						param.Value = *op.Value
-					}
-					if op.ValueRef != nil {
-						param.ValueRef = *op.ValueRef
-					}
-					if op.ValueType != nil {
-						param.Type = *op.ValueType
-					}
-					helmData.OutputParams = append(helmData.OutputParams, param)
-				}
-			}
+			helmData.OutputParams = outputParams
 
 			return helmDataMsg{helmData: helmData}
 		}

--- a/cmd/instance/debug_helm_detail_tui.go
+++ b/cmd/instance/debug_helm_detail_tui.go
@@ -15,13 +15,21 @@ import (
 )
 
 const (
-	helmTabLogs     = 0
-	helmTabValues   = 1
-	helmTabWfErrors = 2
-	helmNumTabs     = 3
+	helmTabLogs       = 0
+	helmTabValues     = 1
+	helmTabInputVars  = 2
+	helmTabOutputVars = 3
+	helmTabWfErrors   = 4
+	helmNumTabs       = 5
 )
 
-var helmTabNames = []string{"Helm Logs", "Chart Values", "Workflow Events"}
+var helmTabNames = []string{"Helm Logs", "Chart Values", "Input Parameters", "Output Parameters", "Workflow Events"}
+
+func init() {
+	if len(helmTabNames) != helmNumTabs {
+		panic(fmt.Sprintf("helmTabNames length %d does not match helmNumTabs %d", len(helmTabNames), helmNumTabs))
+	}
+}
 
 // helmDataMsg is sent when helm debug data has been fetched
 type helmDataMsg struct {
@@ -58,6 +66,16 @@ type helmDetailModel struct {
 	valuesTree   []outputNode
 	valuesCursor int
 	valuesScroll int
+
+	// Input Parameters tab (tree explorer)
+	inputTree   []outputNode
+	inputCursor int
+	inputScroll int
+
+	// Output Parameters tab (tree explorer)
+	outputTree   []outputNode
+	outputCursor int
+	outputScroll int
 
 	// Workflow Errors tab
 	wfErrors *workflowErrorsState
@@ -120,6 +138,56 @@ func (m helmDetailModel) fetchHelmData() tea.Cmd {
 			}
 
 			helmData := parseHelmData(actualDebugData)
+
+			// Fetch input parameters from ListInputParameter V1 API
+			inputParamsResult, inputErr := dataaccess.ListInputParameters(
+				ctx, m.debugData.Token,
+				m.debugData.ServiceID, m.node.ID,
+				m.debugData.ProductTierID, m.debugData.TierVersion,
+			)
+			if inputErr == nil && inputParamsResult != nil {
+				for _, ip := range inputParamsResult.InputParameters {
+					param := OperatorInputParam{
+						Key:         ip.Key,
+						DisplayName: ip.Name,
+						Description: ip.Description,
+						Type:        ip.Type,
+						Required:    ip.Required,
+						Modifiable:  ip.Modifiable,
+					}
+					if ip.DefaultValue != nil {
+						param.DefaultValue = *ip.DefaultValue
+					}
+					helmData.InputParams = append(helmData.InputParams, param)
+				}
+			}
+
+			// Fetch output parameters from ListOutputParameter V1 API
+			outputParamsResult, outputErr := dataaccess.ListOutputParameters(
+				ctx, m.debugData.Token,
+				m.debugData.ServiceID, m.node.ID,
+				m.debugData.ProductTierID, m.debugData.TierVersion,
+			)
+			if outputErr == nil && outputParamsResult != nil {
+				for _, op := range outputParamsResult.OutputParameters {
+					param := OperatorOutputParam{
+						Key:         op.Key,
+						DisplayName: op.Name,
+						Description: op.Description,
+					}
+					if op.Value != nil {
+						param.Value = *op.Value
+					}
+					if op.ValueRef != nil {
+						param.ValueRef = *op.ValueRef
+					}
+					if op.ValueType != nil {
+						param.Type = *op.ValueType
+					}
+					helmData.OutputParams = append(helmData.OutputParams, param)
+				}
+			}
+
 			return helmDataMsg{helmData: helmData}
 		}
 
@@ -249,6 +317,9 @@ func (m helmDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.valuesTree = buildHelmValuesTree(m.helmData.ChartValues, string(raw))
 				}
 			}
+			// Build input/output param trees
+			m.inputTree = buildOperatorParamTree(m.helmData.InputParams)
+			m.outputTree = buildOperatorOutputParamTree(m.helmData.OutputParams)
 			// Start log polling
 			ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // cancel stored in m.logCancel for later use
 			m.logCancel = cancel
@@ -382,6 +453,28 @@ func (m helmDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					len(visibleNodes),
 					m.helmValuesVisibleRows(),
 				)
+			} else if m.activeTab == helmTabInputVars && len(m.inputTree) > 0 {
+				visibleNodes := flattenOutputTree(m.inputTree)
+				if m.inputCursor > 0 {
+					m.inputCursor--
+				}
+				m.inputCursor, m.inputScroll = normalizeViewport(
+					m.inputCursor,
+					m.inputScroll,
+					len(visibleNodes),
+					m.helmValuesVisibleRows(),
+				)
+			} else if m.activeTab == helmTabOutputVars && len(m.outputTree) > 0 {
+				visibleNodes := flattenOutputTree(m.outputTree)
+				if m.outputCursor > 0 {
+					m.outputCursor--
+				}
+				m.outputCursor, m.outputScroll = normalizeViewport(
+					m.outputCursor,
+					m.outputScroll,
+					len(visibleNodes),
+					m.helmValuesVisibleRows(),
+				)
 			} else if m.activeTab == helmTabWfErrors {
 				items := flattenWfEventItems(m.getWfEvents())
 				if m.wfErrors.cursor > 0 {
@@ -412,6 +505,28 @@ func (m helmDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.valuesCursor, m.valuesScroll = normalizeViewport(
 					m.valuesCursor,
 					m.valuesScroll,
+					len(visibleNodes),
+					m.helmValuesVisibleRows(),
+				)
+			} else if m.activeTab == helmTabInputVars && len(m.inputTree) > 0 {
+				visibleNodes := flattenOutputTree(m.inputTree)
+				if m.inputCursor < len(visibleNodes)-1 {
+					m.inputCursor++
+				}
+				m.inputCursor, m.inputScroll = normalizeViewport(
+					m.inputCursor,
+					m.inputScroll,
+					len(visibleNodes),
+					m.helmValuesVisibleRows(),
+				)
+			} else if m.activeTab == helmTabOutputVars && len(m.outputTree) > 0 {
+				visibleNodes := flattenOutputTree(m.outputTree)
+				if m.outputCursor < len(visibleNodes)-1 {
+					m.outputCursor++
+				}
+				m.outputCursor, m.outputScroll = normalizeViewport(
+					m.outputCursor,
+					m.outputScroll,
 					len(visibleNodes),
 					m.helmValuesVisibleRows(),
 				)
@@ -516,6 +631,30 @@ func (m helmDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.helmValuesVisibleRows(),
 					)
 				}
+			} else if m.activeTab == helmTabInputVars && len(m.inputTree) > 0 {
+				visibleNodes := flattenOutputTree(m.inputTree)
+				if m.inputCursor >= 0 && m.inputCursor < len(visibleNodes) {
+					toggleOutputNode(visibleNodes[m.inputCursor])
+					visibleNodes = flattenOutputTree(m.inputTree)
+					m.inputCursor, m.inputScroll = normalizeViewport(
+						m.inputCursor,
+						m.inputScroll,
+						len(visibleNodes),
+						m.helmValuesVisibleRows(),
+					)
+				}
+			} else if m.activeTab == helmTabOutputVars && len(m.outputTree) > 0 {
+				visibleNodes := flattenOutputTree(m.outputTree)
+				if m.outputCursor >= 0 && m.outputCursor < len(visibleNodes) {
+					toggleOutputNode(visibleNodes[m.outputCursor])
+					visibleNodes = flattenOutputTree(m.outputTree)
+					m.outputCursor, m.outputScroll = normalizeViewport(
+						m.outputCursor,
+						m.outputScroll,
+						len(visibleNodes),
+						m.helmValuesVisibleRows(),
+					)
+				}
 			}
 		case "right", "l":
 			if m.activeTab == helmTabValues && len(m.valuesTree) > 0 {
@@ -533,6 +672,36 @@ func (m helmDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						)
 					}
 				}
+			} else if m.activeTab == helmTabInputVars && len(m.inputTree) > 0 {
+				visibleNodes := flattenOutputTree(m.inputTree)
+				if m.inputCursor >= 0 && m.inputCursor < len(visibleNodes) {
+					node := visibleNodes[m.inputCursor]
+					if node.expandable && !node.expanded {
+						node.expanded = true
+						visibleNodes = flattenOutputTree(m.inputTree)
+						m.inputCursor, m.inputScroll = normalizeViewport(
+							m.inputCursor,
+							m.inputScroll,
+							len(visibleNodes),
+							m.helmValuesVisibleRows(),
+						)
+					}
+				}
+			} else if m.activeTab == helmTabOutputVars && len(m.outputTree) > 0 {
+				visibleNodes := flattenOutputTree(m.outputTree)
+				if m.outputCursor >= 0 && m.outputCursor < len(visibleNodes) {
+					node := visibleNodes[m.outputCursor]
+					if node.expandable && !node.expanded {
+						node.expanded = true
+						visibleNodes = flattenOutputTree(m.outputTree)
+						m.outputCursor, m.outputScroll = normalizeViewport(
+							m.outputCursor,
+							m.outputScroll,
+							len(visibleNodes),
+							m.helmValuesVisibleRows(),
+						)
+					}
+				}
 			}
 		case "left", "h":
 			if m.activeTab == helmTabValues && len(m.valuesTree) > 0 {
@@ -545,6 +714,36 @@ func (m helmDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.valuesCursor, m.valuesScroll = normalizeViewport(
 							m.valuesCursor,
 							m.valuesScroll,
+							len(visibleNodes),
+							m.helmValuesVisibleRows(),
+						)
+					}
+				}
+			} else if m.activeTab == helmTabInputVars && len(m.inputTree) > 0 {
+				visibleNodes := flattenOutputTree(m.inputTree)
+				if m.inputCursor >= 0 && m.inputCursor < len(visibleNodes) {
+					node := visibleNodes[m.inputCursor]
+					if node.expandable && node.expanded {
+						node.expanded = false
+						visibleNodes = flattenOutputTree(m.inputTree)
+						m.inputCursor, m.inputScroll = normalizeViewport(
+							m.inputCursor,
+							m.inputScroll,
+							len(visibleNodes),
+							m.helmValuesVisibleRows(),
+						)
+					}
+				}
+			} else if m.activeTab == helmTabOutputVars && len(m.outputTree) > 0 {
+				visibleNodes := flattenOutputTree(m.outputTree)
+				if m.outputCursor >= 0 && m.outputCursor < len(visibleNodes) {
+					node := visibleNodes[m.outputCursor]
+					if node.expandable && node.expanded {
+						node.expanded = false
+						visibleNodes = flattenOutputTree(m.outputTree)
+						m.outputCursor, m.outputScroll = normalizeViewport(
+							m.outputCursor,
+							m.outputScroll,
 							len(visibleNodes),
 							m.helmValuesVisibleRows(),
 						)
@@ -697,6 +896,10 @@ func (m helmDetailModel) getHelmTabContent() string {
 		return m.renderHelmLogsTab()
 	case helmTabValues:
 		return m.renderHelmValuesTab()
+	case helmTabInputVars:
+		return m.renderHelmParamTreeTab("Input Parameters", m.inputTree, m.inputCursor, m.inputScroll)
+	case helmTabOutputVars:
+		return m.renderHelmParamTreeTab("Output Parameters", m.outputTree, m.outputCursor, m.outputScroll)
 	case helmTabWfErrors:
 		return m.renderHelmWfErrorsTab()
 	}
@@ -933,6 +1136,10 @@ func (m helmDetailModel) renderHelmFooter() string {
 		text = fmt.Sprintf("↑↓/pgup/pgdn: scroll  %s  y: copy  tab/shift+tab: switch tabs  esc: back  q: quit", followHint)
 	} else if m.activeTab == helmTabValues && len(m.valuesTree) > 0 {
 		text = "↑↓: navigate  ←→/enter: expand/collapse  y: copy  tab/shift+tab: switch tabs  esc: back  q: quit"
+	} else if m.activeTab == helmTabInputVars && len(m.inputTree) > 0 {
+		text = "↑↓: navigate  ←→/enter: expand/collapse  y: copy  tab/shift+tab: switch tabs  esc: back  q: quit"
+	} else if m.activeTab == helmTabOutputVars && len(m.outputTree) > 0 {
+		text = "↑↓: navigate  ←→/enter: expand/collapse  y: copy  tab/shift+tab: switch tabs  esc: back  q: quit"
 	} else if m.activeTab == helmTabWfErrors {
 		text = "↑↓/pgup/pgdn: scroll  y: copy  tab/shift+tab: switch tabs  esc: back  q: quit"
 	} else {
@@ -955,6 +1162,20 @@ func (m helmDetailModel) helmCopyableContent() string {
 	case helmTabValues:
 		if m.helmData != nil && len(m.helmData.ChartValues) > 0 {
 			raw, err := json.Marshal(m.helmData.ChartValues)
+			if err == nil {
+				return string(raw)
+			}
+		}
+	case helmTabInputVars:
+		if m.helmData != nil && len(m.helmData.InputParams) > 0 {
+			raw, err := json.Marshal(m.helmData.InputParams)
+			if err == nil {
+				return string(raw)
+			}
+		}
+	case helmTabOutputVars:
+		if m.helmData != nil && len(m.helmData.OutputParams) > 0 {
+			raw, err := json.Marshal(m.helmData.OutputParams)
 			if err == nil {
 				return string(raw)
 			}
@@ -1020,6 +1241,118 @@ func (m helmDetailModel) renderHelmWfErrorsTab() string {
 	enrichBootstrapSteps(steps, m.node.Key, m.debugData.PlanDAG)
 	isLive := isWorkflowInProgress(steps)
 	return renderWorkflowEventsTab(steps, m.wfErrors, m.helmBodyHeight(), m.helmContentWidth(), loading, m.spinner.View(), isLive)
+}
+
+// renderHelmParamTreeTab renders a generic parameter tree tab (used for Input/Output Parameters).
+func (m helmDetailModel) renderHelmParamTreeTab(title string, tree []outputNode, cursor, scroll int) string {
+	if m.loading {
+		return fmt.Sprintf("\n  %s Fetching %s...", m.spinner.View(), strings.ToLower(title))
+	}
+	if m.loadErr != nil {
+		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
+		return fmt.Sprintf("\n  %s\n", errStyle.Render(fmt.Sprintf("Error: %v", m.loadErr)))
+	}
+	if len(tree) == 0 {
+		subtleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+		return fmt.Sprintf("\n  %s\n", subtleStyle.Render(fmt.Sprintf("No %s available for this resource.", strings.ToLower(title))))
+	}
+
+	var b strings.Builder
+
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
+	fmt.Fprintf(&b, "  %s\n\n", headerStyle.Render(title))
+
+	visibleNodes := flattenOutputTree(tree)
+
+	visibleRows := m.helmValuesVisibleRows()
+	totalEntries := len(visibleNodes)
+	cursorIndex, scrollOffset := normalizeViewport(cursor, scroll, totalEntries, visibleRows)
+
+	end := scrollOffset + visibleRows
+	if end > totalEntries {
+		end = totalEntries
+	}
+
+	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("117"))
+	strStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("114"))
+	numStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("178"))
+	boolStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("178"))
+	nullStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	braceStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	selectedBg := lipgloss.NewStyle().Background(lipgloss.Color("236"))
+	maxLineWidth := m.helmContentWidth() - 4
+	if maxLineWidth < 1 {
+		maxLineWidth = 1
+	}
+	rowStyle := lipgloss.NewStyle().MaxWidth(maxLineWidth)
+	selectedRowStyle := selectedBg.MaxWidth(maxLineWidth)
+
+	for idx := scrollOffset; idx < end; idx++ {
+		node := visibleNodes[idx]
+		indent := strings.Repeat("  ", node.depth)
+
+		cursorMarker := "  "
+		if idx == cursorIndex {
+			cursorMarker = "▶ "
+		}
+
+		var line string
+		if node.expandable {
+			arrow := "▸"
+			if node.expanded {
+				arrow = "▾"
+			}
+			childCount := len(node.children)
+			typeMark := braceStyle.Render("{}")
+			if node.nodeType == "array" {
+				typeMark = braceStyle.Render("[]")
+			}
+			countStr := lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render(fmt.Sprintf("  %d items", childCount))
+			line = fmt.Sprintf("%s%s %s %s%s", indent, arrow, keyStyle.Render(node.key), typeMark, countStr)
+		} else {
+			var styledVal string
+			switch node.nodeType {
+			case "string":
+				styledVal = strStyle.Render(fmt.Sprintf("%q", node.value))
+			case "number":
+				styledVal = numStyle.Render(node.value)
+			case "bool":
+				styledVal = boolStyle.Render(node.value)
+			case "null":
+				styledVal = nullStyle.Render("null")
+			default:
+				styledVal = lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Render(node.value)
+			}
+			line = fmt.Sprintf("%s  %s: %s", indent, keyStyle.Render(node.key), styledVal)
+		}
+
+		if idx == cursorIndex {
+			line = selectedRowStyle.Render(line)
+		} else {
+			line = rowStyle.Render(line)
+		}
+
+		fmt.Fprintf(&b, "  %s%s\n", cursorMarker, line)
+	}
+
+	// Scroll indicator
+	if totalEntries > visibleRows {
+		dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+		pos := ""
+		if scrollOffset == 0 {
+			pos = "top"
+		} else if end >= totalEntries {
+			pos = "end"
+		} else {
+			pct := (scrollOffset * 100) / (totalEntries - visibleRows)
+			pos = fmt.Sprintf("%d%%", pct)
+		}
+		fmt.Fprintf(&b, "\n  %s\n", dimStyle.Render(fmt.Sprintf("↑↓: navigate  enter: expand/collapse  [%d/%d %s]", cursorIndex+1, totalEntries, pos)))
+	} else {
+		fmt.Fprintf(&b, "\n  %s\n", lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render("↑↓: navigate  enter: expand/collapse"))
+	}
+
+	return b.String()
 }
 
 // buildHelmValuesTree builds a tree of outputNodes from helm chart values (a plain map).

--- a/cmd/instance/debug_helm_detail_tui.go
+++ b/cmd/instance/debug_helm_detail_tui.go
@@ -144,6 +144,7 @@ func (m helmDetailModel) fetchHelmData() tea.Cmd {
 				ctx, m.debugData.Token,
 				m.debugData.ServiceID, m.node.ID,
 				m.debugData.ProductTierID, m.debugData.TierVersion,
+				m.debugData.InputParams,
 			)
 			helmData.InputParams = inputParams
 

--- a/cmd/instance/debug_helm_detail_tui_test.go
+++ b/cmd/instance/debug_helm_detail_tui_test.go
@@ -1,11 +1,13 @@
 package instance
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHelmValuesEnterTogglesSelectedNode(t *testing.T) {
@@ -137,4 +139,287 @@ func TestHelmValuesUpFromBottomKeepsViewportFixed(t *testing.T) {
 	if updated.valuesScroll != 3 {
 		t.Fatalf("expected viewport to stay anchored at scroll 3, got %d", updated.valuesScroll)
 	}
+}
+
+func TestHelmTabConstants(t *testing.T) {
+	require := require.New(t)
+
+	require.Equal(0, helmTabLogs)
+	require.Equal(1, helmTabValues)
+	require.Equal(2, helmTabInputVars)
+	require.Equal(3, helmTabOutputVars)
+	require.Equal(4, helmTabWfErrors)
+	require.Equal(5, helmNumTabs)
+	require.Len(helmTabNames, helmNumTabs)
+	require.Equal("Input Parameters", helmTabNames[helmTabInputVars])
+	require.Equal("Output Parameters", helmTabNames[helmTabOutputVars])
+}
+
+func TestHelmInputParamTreeBuildsFromOperatorInputParam(t *testing.T) {
+	params := []OperatorInputParam{
+		{Key: "db_port", DisplayName: "Database Port", Description: "Port for DB", Type: "String", Required: true, Modifiable: false, DefaultValue: "5432"},
+		{Key: "app_name", DisplayName: "App Name", Description: "Application name", Type: "String", Required: false},
+	}
+
+	tree := buildOperatorParamTree(params)
+	require.NotNil(t, tree)
+	require.Len(t, tree, 2)
+
+	// Params are sorted by key
+	require.Equal(t, "app_name (App Name)", tree[0].key)
+	require.Equal(t, "db_port (Database Port)", tree[1].key)
+	require.True(t, tree[0].expandable)
+	require.True(t, tree[1].expandable)
+}
+
+func TestHelmOutputParamTreeBuildsFromOperatorOutputParam(t *testing.T) {
+	params := []OperatorOutputParam{
+		{Key: "endpoint", DisplayName: "Endpoint URL", Description: "Service endpoint", Value: "https://example.com", Type: "String"},
+		{Key: "status", DisplayName: "Status", Description: "Current status", ValueRef: "$.status"},
+	}
+
+	tree := buildOperatorOutputParamTree(params)
+	require.NotNil(t, tree)
+	require.Len(t, tree, 2)
+
+	// Params are sorted by key
+	require.Equal(t, "endpoint (Endpoint URL)", tree[0].key)
+	require.Equal(t, "status (Status)", tree[1].key)
+}
+
+func TestHelmInputTabEnterTogglesNode(t *testing.T) {
+	params := []OperatorInputParam{
+		{Key: "port", DisplayName: "Port", Description: "Port number", Type: "String", Required: true},
+	}
+
+	model := helmDetailModel{
+		activeTab: helmTabInputVars,
+		inputTree: buildOperatorParamTree(params),
+		wfErrors:  &workflowErrorsState{},
+	}
+
+	visibleNodes := flattenOutputTree(model.inputTree)
+	require.Len(t, visibleNodes, len(params[0].Key)+1) // root + children
+	require.True(t, visibleNodes[0].expandable)
+	require.True(t, visibleNodes[0].expanded)
+
+	// Collapse
+	updatedAny, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated := updatedAny.(helmDetailModel)
+
+	visibleNodes = flattenOutputTree(updated.inputTree)
+	require.Len(t, visibleNodes, 1)
+	require.False(t, visibleNodes[0].expanded)
+
+	// Re-expand
+	updatedAny, _ = updated.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	updated = updatedAny.(helmDetailModel)
+
+	visibleNodes = flattenOutputTree(updated.inputTree)
+	require.True(t, visibleNodes[0].expanded)
+}
+
+func TestHelmOutputTabNavigationUpDown(t *testing.T) {
+	params := []OperatorOutputParam{
+		{Key: "a", DisplayName: "A", Description: "Param A"},
+		{Key: "b", DisplayName: "B", Description: "Param B"},
+	}
+
+	model := helmDetailModel{
+		activeTab:    helmTabOutputVars,
+		width:        80,
+		height:       20,
+		outputTree:   buildOperatorOutputParamTree(params),
+		outputCursor: 0,
+		wfErrors:     &workflowErrorsState{},
+	}
+
+	// Move down
+	updatedAny, _ := model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	updated := updatedAny.(helmDetailModel)
+	require.Equal(t, 1, updated.outputCursor)
+
+	// Move up
+	updatedAny, _ = updated.Update(tea.KeyMsg{Type: tea.KeyUp})
+	updated = updatedAny.(helmDetailModel)
+	require.Equal(t, 0, updated.outputCursor)
+}
+
+func TestHelmInputTabExpandCollapseLeftRight(t *testing.T) {
+	params := []OperatorInputParam{
+		{Key: "config", DisplayName: "Config", Description: "Configuration", Type: "String"},
+	}
+
+	model := helmDetailModel{
+		activeTab: helmTabInputVars,
+		width:     80,
+		height:    20,
+		inputTree: buildOperatorParamTree(params),
+		wfErrors:  &workflowErrorsState{},
+	}
+
+	// Collapse with left
+	updatedAny, _ := model.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	updated := updatedAny.(helmDetailModel)
+	visibleNodes := flattenOutputTree(updated.inputTree)
+	require.Len(t, visibleNodes, 1)
+	require.False(t, visibleNodes[0].expanded)
+
+	// Expand with right
+	updatedAny, _ = updated.Update(tea.KeyMsg{Type: tea.KeyRight})
+	updated = updatedAny.(helmDetailModel)
+	visibleNodes = flattenOutputTree(updated.inputTree)
+	require.True(t, visibleNodes[0].expanded)
+}
+
+func TestHelmRenderParamTreeTabShowsTitle(t *testing.T) {
+	params := []OperatorInputParam{
+		{Key: "name", DisplayName: "Name", Description: "Resource name", Type: "String"},
+	}
+
+	model := helmDetailModel{
+		activeTab: helmTabInputVars,
+		width:     80,
+		height:    20,
+		inputTree: buildOperatorParamTree(params),
+		helmData:  &HelmData{InputParams: params},
+		wfErrors:  &workflowErrorsState{},
+	}
+
+	rendered := model.renderHelmParamTreeTab("Input Parameters", model.inputTree, model.inputCursor, model.inputScroll)
+	require.Contains(t, rendered, "Input Parameters")
+}
+
+func TestHelmRenderParamTreeTabEmptyShowsNoDataMessage(t *testing.T) {
+	model := helmDetailModel{
+		activeTab: helmTabInputVars,
+		width:     80,
+		height:    20,
+		inputTree: nil,
+		wfErrors:  &workflowErrorsState{},
+	}
+
+	rendered := model.renderHelmParamTreeTab("Input Parameters", model.inputTree, 0, 0)
+	require.Contains(t, rendered, "No input parameters available")
+}
+
+func TestHelmCopyableContentInputOutputTabs(t *testing.T) {
+	inputParams := []OperatorInputParam{
+		{Key: "port", DisplayName: "Port", Type: "String"},
+	}
+	outputParams := []OperatorOutputParam{
+		{Key: "endpoint", DisplayName: "Endpoint", Value: "https://example.com"},
+	}
+
+	model := helmDetailModel{
+		helmData: &HelmData{
+			InputParams:  inputParams,
+			OutputParams: outputParams,
+		},
+		wfErrors: &workflowErrorsState{},
+	}
+
+	// Input params copy
+	model.activeTab = helmTabInputVars
+	text := model.helmCopyableContent()
+	require.NotEmpty(t, text)
+	var decoded []OperatorInputParam
+	require.NoError(t, json.Unmarshal([]byte(text), &decoded))
+	require.Len(t, decoded, 1)
+	require.Equal(t, "port", decoded[0].Key)
+
+	// Output params copy
+	model.activeTab = helmTabOutputVars
+	text = model.helmCopyableContent()
+	require.NotEmpty(t, text)
+	var decodedOut []OperatorOutputParam
+	require.NoError(t, json.Unmarshal([]byte(text), &decodedOut))
+	require.Len(t, decodedOut, 1)
+	require.Equal(t, "endpoint", decodedOut[0].Key)
+}
+
+func TestHelmTabCyclesAllFiveTabs(t *testing.T) {
+	model := helmDetailModel{
+		activeTab: helmTabLogs,
+		wfErrors:  &workflowErrorsState{},
+	}
+
+	for i := 0; i < helmNumTabs; i++ {
+		require.Equal(t, i, model.activeTab)
+		updatedAny, _ := model.Update(tea.KeyMsg{Type: tea.KeyTab})
+		model = updatedAny.(helmDetailModel)
+	}
+	// Should wrap to 0
+	require.Equal(t, helmTabLogs, model.activeTab)
+}
+
+func TestHelmDataJSONIncludesInputOutputParams(t *testing.T) {
+	require := require.New(t)
+
+	helmData := &HelmData{
+		ChartRepoName: "test-repo",
+		ChartVersion:  "1.0.0",
+		InputParams: []OperatorInputParam{
+			{Key: "port", DisplayName: "Port", Type: "String", Required: true},
+		},
+		OutputParams: []OperatorOutputParam{
+			{Key: "endpoint", DisplayName: "Endpoint", Value: "https://example.com"},
+		},
+	}
+
+	jsonBytes, err := json.Marshal(helmData)
+	require.NoError(err)
+
+	var decoded map[string]interface{}
+	require.NoError(json.Unmarshal(jsonBytes, &decoded))
+
+	require.Contains(decoded, "inputParams")
+	require.Contains(decoded, "outputParams")
+
+	inputArr, ok := decoded["inputParams"].([]interface{})
+	require.True(ok)
+	require.Len(inputArr, 1)
+
+	outputArr, ok := decoded["outputParams"].([]interface{})
+	require.True(ok)
+	require.Len(outputArr, 1)
+}
+
+func TestHelmDataJSONOmitsEmptyInputOutputParams(t *testing.T) {
+	require := require.New(t)
+
+	helmData := &HelmData{
+		ChartRepoName: "test-repo",
+	}
+
+	jsonBytes, err := json.Marshal(helmData)
+	require.NoError(err)
+
+	var decoded map[string]interface{}
+	require.NoError(json.Unmarshal(jsonBytes, &decoded))
+
+	require.NotContains(decoded, "inputParams")
+	require.NotContains(decoded, "outputParams")
+}
+
+func TestHelmFooterShowsTreeNavForInputOutputTabs(t *testing.T) {
+	model := helmDetailModel{
+		width:    80,
+		height:   20,
+		wfErrors: &workflowErrorsState{},
+		inputTree: buildOperatorParamTree([]OperatorInputParam{
+			{Key: "x", DisplayName: "X", Description: "test"},
+		}),
+		outputTree: buildOperatorOutputParamTree([]OperatorOutputParam{
+			{Key: "y", DisplayName: "Y", Description: "test"},
+		}),
+	}
+
+	model.activeTab = helmTabInputVars
+	footer := model.renderHelmFooter()
+	require.Contains(t, footer, "expand/collapse")
+
+	model.activeTab = helmTabOutputVars
+	footer = model.renderHelmFooter()
+	require.Contains(t, footer, "expand/collapse")
 }

--- a/cmd/instance/debug_json_test.go
+++ b/cmd/instance/debug_json_test.go
@@ -425,7 +425,7 @@ func TestResourceDebugInfoOperatorJSON(t *testing.T) {
 				{Key: "storage", DisplayName: "Storage Size", Description: "Storage in GB", Type: "string", Required: true},
 			},
 			OutputParams: []OperatorOutputParam{
-				{Key: "endpoint", DisplayName: "Endpoint", Description: "Connection endpoint", Type: "string", ValueRef: "$var.endpoint"},
+				{Key: "endpoint", DisplayName: "Endpoint", Description: "Connection endpoint", Type: "string", ValueRef: "$var.endpoint", ResolvedValue: "db.example.com:5432"},
 			},
 			CRDOutputParams: []OperatorCRDOutputParam{
 				{Key: "status", Value: ".status.conditions"},
@@ -467,7 +467,7 @@ func TestResourceDebugInfoOperatorJSON(t *testing.T) {
 	require.True(ok)
 	require.Equal("endpoint", out0["key"])
 	require.Equal("$var.endpoint", out0["valueRef"])
-
+	require.Equal("db.example.com:5432", out0["resolvedValue"])
 	crdOutputParams, ok := op["crdOutputParams"].([]interface{})
 	require.True(ok, "crdOutputParams should be an array")
 	require.Len(crdOutputParams, 1)

--- a/cmd/instance/debug_json_test.go
+++ b/cmd/instance/debug_json_test.go
@@ -428,7 +428,7 @@ func TestResourceDebugInfoOperatorJSON(t *testing.T) {
 				{Key: "endpoint", DisplayName: "Endpoint", Description: "Connection endpoint", Type: "string", ValueRef: "$var.endpoint", ResolvedValue: "db.example.com:5432"},
 			},
 			CRDOutputParams: []OperatorCRDOutputParam{
-				{Key: "status", Value: ".status.conditions"},
+				{Key: "status", Value: ".status.conditions", ResolvedValue: "Ready"},
 			},
 		},
 	}
@@ -476,6 +476,7 @@ func TestResourceDebugInfoOperatorJSON(t *testing.T) {
 	require.True(ok)
 	require.Equal("status", crd0["key"])
 	require.Equal(".status.conditions", crd0["value"])
+	require.Equal("Ready", crd0["resolvedValue"])
 
 	// Verify helm and terraform fields are omitted
 	require.NotContains(decoded, "helm")

--- a/cmd/instance/debug_json_test.go
+++ b/cmd/instance/debug_json_test.go
@@ -421,7 +421,7 @@ func TestResourceDebugInfoOperatorJSON(t *testing.T) {
 		ResourceType: "OperatorCRD",
 		Operator: &OperatorData{
 			InputParams: []OperatorInputParam{
-				{Key: "replicas", DisplayName: "Replicas", Description: "Number of replicas", Type: "int", Required: true, Modifiable: true, DefaultValue: "3"},
+				{Key: "replicas", DisplayName: "Replicas", Description: "Number of replicas", Type: "int", Required: true, Modifiable: true, DefaultValue: "3", ResolvedValue: "5"},
 				{Key: "storage", DisplayName: "Storage Size", Description: "Storage in GB", Type: "string", Required: true},
 			},
 			OutputParams: []OperatorOutputParam{
@@ -459,6 +459,7 @@ func TestResourceDebugInfoOperatorJSON(t *testing.T) {
 	require.Equal(true, param0["required"])
 	require.Equal(true, param0["modifiable"])
 	require.Equal("3", param0["defaultValue"])
+	require.Equal("5", param0["resolvedValue"])
 
 	outputParams, ok := op["outputParams"].([]interface{})
 	require.True(ok, "outputParams should be an array")

--- a/cmd/instance/debug_operator_detail_tui.go
+++ b/cmd/instance/debug_operator_detail_tui.go
@@ -110,6 +110,7 @@ func (m operatorDetailModel) fetchOperatorData() tea.Cmd {
 			ctx, m.debugData.Token,
 			m.debugData.ServiceID, m.node.ID,
 			m.debugData.ProductTierID, m.debugData.TierVersion,
+			m.debugData.ResultParams,
 		)
 		if listErr == nil {
 			opData.OutputParams = outputParams
@@ -812,7 +813,9 @@ func buildOperatorOutputParamTree(params []OperatorOutputParam) []outputNode {
 		if p.Type != "" {
 			details["type"] = p.Type
 		}
-		if p.Value != "" {
+		if p.ResolvedValue != "" {
+			details["value"] = p.ResolvedValue
+		} else if p.Value != "" {
 			details["value"] = p.Value
 		}
 		if p.ValueRef != "" {

--- a/cmd/instance/debug_operator_detail_tui.go
+++ b/cmd/instance/debug_operator_detail_tui.go
@@ -95,53 +95,24 @@ func (m operatorDetailModel) fetchOperatorData() tea.Cmd {
 
 		opData := &OperatorData{}
 
-		// Fetch all input parameters from ListInputParameter V1 API
-		inputParamsResult, err := dataaccess.ListInputParameters(
+		// Fetch all input parameters
+		inputParams, err := fetchInputParams(
 			ctx, m.debugData.Token,
 			m.debugData.ServiceID, m.node.ID,
 			m.debugData.ProductTierID, m.debugData.TierVersion,
 		)
-		if err == nil && inputParamsResult != nil {
-			for _, ip := range inputParamsResult.InputParameters {
-				param := OperatorInputParam{
-					Key:         ip.Key,
-					DisplayName: ip.Name,
-					Description: ip.Description,
-					Type:        ip.Type,
-					Required:    ip.Required,
-					Modifiable:  ip.Modifiable,
-				}
-				if ip.DefaultValue != nil {
-					param.DefaultValue = *ip.DefaultValue
-				}
-				opData.InputParams = append(opData.InputParams, param)
-			}
+		if err == nil {
+			opData.InputParams = inputParams
 		}
 
-		// Fetch exported output parameters from ListOutputParameter V1 API
-		outputParamsResult, listErr := dataaccess.ListOutputParameters(
+		// Fetch exported output parameters
+		outputParams, listErr := fetchOutputParams(
 			ctx, m.debugData.Token,
 			m.debugData.ServiceID, m.node.ID,
 			m.debugData.ProductTierID, m.debugData.TierVersion,
 		)
-		if listErr == nil && outputParamsResult != nil {
-			for _, op := range outputParamsResult.OutputParameters {
-				param := OperatorOutputParam{
-					Key:         op.Key,
-					DisplayName: op.Name,
-					Description: op.Description,
-				}
-				if op.Value != nil {
-					param.Value = *op.Value
-				}
-				if op.ValueRef != nil {
-					param.ValueRef = *op.ValueRef
-				}
-				if op.ValueType != nil {
-					param.Type = *op.ValueType
-				}
-				opData.OutputParams = append(opData.OutputParams, param)
-			}
+		if listErr == nil {
+			opData.OutputParams = outputParams
 		}
 
 		// Fetch CRD output parameters from DescribeResource (operatorCRDConfiguration.outputParameters)

--- a/cmd/instance/debug_operator_detail_tui.go
+++ b/cmd/instance/debug_operator_detail_tui.go
@@ -100,6 +100,7 @@ func (m operatorDetailModel) fetchOperatorData() tea.Cmd {
 			ctx, m.debugData.Token,
 			m.debugData.ServiceID, m.node.ID,
 			m.debugData.ProductTierID, m.debugData.TierVersion,
+			m.debugData.InputParams,
 		)
 		if err == nil {
 			opData.InputParams = inputParams
@@ -780,7 +781,9 @@ func buildOperatorParamTree(params []OperatorInputParam) []outputNode {
 			"required":    p.Required,
 			"modifiable":  p.Modifiable,
 		}
-		if p.DefaultValue != "" {
+		if p.ResolvedValue != "" {
+			details["value"] = p.ResolvedValue
+		} else if p.DefaultValue != "" {
 			details["defaultValue"] = p.DefaultValue
 		}
 

--- a/cmd/instance/debug_operator_detail_tui.go
+++ b/cmd/instance/debug_operator_detail_tui.go
@@ -128,10 +128,16 @@ func (m operatorDetailModel) fetchOperatorData() tea.Cmd {
 			if ok && crdConfig != nil {
 				outputParams := crdConfig.GetOutputParameters()
 				for k, v := range outputParams {
-					opData.CRDOutputParams = append(opData.CRDOutputParams, OperatorCRDOutputParam{
+					crdParam := OperatorCRDOutputParam{
 						Key:   k,
 						Value: v,
-					})
+					}
+					if m.debugData.ResultParams != nil {
+						if rv, ok := m.debugData.ResultParams[k]; ok {
+							crdParam.ResolvedValue = fmt.Sprintf("%v", rv)
+						}
+					}
+					opData.CRDOutputParams = append(opData.CRDOutputParams, crdParam)
 				}
 			}
 		}
@@ -849,7 +855,10 @@ func buildOperatorCRDOutputParamTree(params []OperatorCRDOutputParam) []outputNo
 	var roots []outputNode
 	for _, p := range params {
 		details := map[string]interface{}{
-			"value": p.Value,
+			"jsonPath": p.Value,
+		}
+		if p.ResolvedValue != "" {
+			details["value"] = p.ResolvedValue
 		}
 
 		node := buildJSONNode(p.Key, details, 0)

--- a/cmd/instance/debug_operator_detail_tui_test.go
+++ b/cmd/instance/debug_operator_detail_tui_test.go
@@ -207,6 +207,37 @@ func TestBuildOperatorCRDOutputParamTree(t *testing.T) {
 		require.Contains(t, result[0].key, "image")
 		require.Contains(t, result[1].key, "topology")
 	})
+
+	t.Run("resolved value shown", func(t *testing.T) {
+		params := []OperatorCRDOutputParam{
+			{Key: "endpoint", Value: ".status.endpoint", ResolvedValue: "db.example.com:5432"},
+		}
+		result := buildOperatorCRDOutputParamTree(params)
+		require.Len(t, result, 1)
+		foundJsonPath := false
+		foundValue := false
+		for _, child := range result[0].children {
+			if child.key == "jsonPath" && child.value == ".status.endpoint" {
+				foundJsonPath = true
+			}
+			if child.key == "value" && child.value == "db.example.com:5432" {
+				foundValue = true
+			}
+		}
+		require.True(t, foundJsonPath, "expected jsonPath in children")
+		require.True(t, foundValue, "expected resolved value in children")
+	})
+
+	t.Run("no resolved value", func(t *testing.T) {
+		params := []OperatorCRDOutputParam{
+			{Key: "endpoint", Value: ".status.endpoint"},
+		}
+		result := buildOperatorCRDOutputParamTree(params)
+		require.Len(t, result, 1)
+		for _, child := range result[0].children {
+			require.NotEqual(t, "value", child.key, "value should not appear without resolved value")
+		}
+	})
 }
 
 func TestOperatorCopyableContent(t *testing.T) {

--- a/cmd/instance/debug_operator_detail_tui_test.go
+++ b/cmd/instance/debug_operator_detail_tui_test.go
@@ -75,6 +75,40 @@ func TestBuildOperatorParamTree(t *testing.T) {
 		require.Len(t, result, 1)
 		require.Equal(t, "replicas", result[0].key)
 	})
+
+	t.Run("resolved value shown", func(t *testing.T) {
+		params := []OperatorInputParam{
+			{Key: "instanceType", DisplayName: "Instance Type", Description: "Instance Type", Type: "String", DefaultValue: "t3.medium", ResolvedValue: "t3.large"},
+		}
+		result := buildOperatorParamTree(params)
+		require.Len(t, result, 1)
+		found := false
+		for _, child := range result[0].children {
+			if child.key == "value" && child.value == "t3.large" {
+				found = true
+			}
+		}
+		require.True(t, found, "expected resolved value in children")
+		// defaultValue should NOT appear when resolvedValue is set
+		for _, child := range result[0].children {
+			require.NotEqual(t, "defaultValue", child.key, "defaultValue should not appear when resolved value is present")
+		}
+	})
+
+	t.Run("fallback to defaultValue when no resolved value", func(t *testing.T) {
+		params := []OperatorInputParam{
+			{Key: "replicas", Description: "Replicas", Type: "int", DefaultValue: "3"},
+		}
+		result := buildOperatorParamTree(params)
+		require.Len(t, result, 1)
+		found := false
+		for _, child := range result[0].children {
+			if child.key == "defaultValue" && child.value == "3" {
+				found = true
+			}
+		}
+		require.True(t, found, "expected defaultValue in children when no resolved value")
+	})
 }
 
 func TestBuildOperatorOutputParamTree(t *testing.T) {

--- a/cmd/instance/debug_operator_detail_tui_test.go
+++ b/cmd/instance/debug_operator_detail_tui_test.go
@@ -108,6 +108,38 @@ func TestBuildOperatorOutputParamTree(t *testing.T) {
 		require.Contains(t, result[0].key, "image")
 		require.Contains(t, result[1].key, "topology")
 	})
+
+	t.Run("resolved value shown", func(t *testing.T) {
+		params := []OperatorOutputParam{
+			{Key: "endpoint", DisplayName: "Endpoint", Description: "Connection endpoint", ValueRef: "$var.endpoint", ResolvedValue: "db.example.com:5432"},
+		}
+		result := buildOperatorOutputParamTree(params)
+		require.Len(t, result, 1)
+		require.True(t, result[0].expandable)
+		// Expand to check children contain "value" with resolved value
+		found := false
+		for _, child := range result[0].children {
+			if child.key == "value" && child.value == "db.example.com:5432" {
+				found = true
+			}
+		}
+		require.True(t, found, "expected resolved value in children")
+	})
+
+	t.Run("fallback to static value when no resolved value", func(t *testing.T) {
+		params := []OperatorOutputParam{
+			{Key: "endpoint", Description: "Connection endpoint", Value: "static-val"},
+		}
+		result := buildOperatorOutputParamTree(params)
+		require.Len(t, result, 1)
+		found := false
+		for _, child := range result[0].children {
+			if child.key == "value" && child.value == "static-val" {
+				found = true
+			}
+		}
+		require.True(t, found, "expected static value in children when no resolved value")
+	})
 }
 
 func TestBuildOperatorCRDOutputParamTree(t *testing.T) {

--- a/cmd/instance/debug_shared.go
+++ b/cmd/instance/debug_shared.go
@@ -10,6 +10,8 @@ type HelmData struct {
 	InstallLog    string                 `json:"installLog"`
 	Namespace     string                 `json:"namespace"`
 	ReleaseName   string                 `json:"releaseName"`
+	InputParams   []OperatorInputParam   `json:"inputParams,omitempty"`
+	OutputParams  []OperatorOutputParam  `json:"outputParams,omitempty"`
 }
 
 type TerraformData struct {

--- a/cmd/instance/debug_shared.go
+++ b/cmd/instance/debug_shared.go
@@ -28,13 +28,14 @@ type TerraformData struct {
 // OperatorInputParam describes a single input parameter for an operator resource.
 // These are fetched from the ListInputParameter V1 API.
 type OperatorInputParam struct {
-	Key          string `json:"key"`
-	DisplayName  string `json:"displayName"`
-	Description  string `json:"description"`
-	Type         string `json:"type"`
-	Required     bool   `json:"required"`
-	Modifiable   bool   `json:"modifiable"`
-	DefaultValue string `json:"defaultValue,omitempty"`
+	Key           string `json:"key"`
+	DisplayName   string `json:"displayName"`
+	Description   string `json:"description"`
+	Type          string `json:"type"`
+	Required      bool   `json:"required"`
+	Modifiable    bool   `json:"modifiable"`
+	DefaultValue  string `json:"defaultValue,omitempty"`
+	ResolvedValue string `json:"resolvedValue,omitempty"`
 }
 
 // OperatorOutputParam describes a single output parameter for a resource.
@@ -126,8 +127,9 @@ func parseHelmData(debugData map[string]interface{}) *HelmData {
 }
 
 // fetchInputParams fetches input parameters from the ListInputParameter V1 API
-// and converts them to OperatorInputParam structs. Used by both helm and operator TUIs.
-func fetchInputParams(ctx context.Context, token, serviceID, resourceID, productTierID, tierVersion string) ([]OperatorInputParam, error) {
+// and converts them to OperatorInputParam structs. If inputParams is provided,
+// resolved values are looked up by key and populated. Used by both helm and operator TUIs.
+func fetchInputParams(ctx context.Context, token, serviceID, resourceID, productTierID, tierVersion string, inputParams map[string]interface{}) ([]OperatorInputParam, error) {
 	result, err := dataaccess.ListInputParameters(ctx, token, serviceID, resourceID, productTierID, tierVersion)
 	if err != nil {
 		return nil, err
@@ -148,6 +150,12 @@ func fetchInputParams(ctx context.Context, token, serviceID, resourceID, product
 		}
 		if ip.DefaultValue != nil {
 			param.DefaultValue = *ip.DefaultValue
+		}
+		// Resolve value from instance input_params
+		if inputParams != nil {
+			if v, ok := inputParams[ip.Key]; ok {
+				param.ResolvedValue = fmt.Sprintf("%v", v)
+			}
 		}
 		params = append(params, param)
 	}

--- a/cmd/instance/debug_shared.go
+++ b/cmd/instance/debug_shared.go
@@ -1,6 +1,11 @@
 package instance
 
-import "encoding/json"
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+)
 
 type HelmData struct {
 	ChartRepoName string                 `json:"chartRepoName"`
@@ -116,4 +121,65 @@ func parseHelmData(debugData map[string]interface{}) *HelmData {
 	}
 
 	return helmData
+}
+
+// fetchInputParams fetches input parameters from the ListInputParameter V1 API
+// and converts them to OperatorInputParam structs. Used by both helm and operator TUIs.
+func fetchInputParams(ctx context.Context, token, serviceID, resourceID, productTierID, tierVersion string) ([]OperatorInputParam, error) {
+	result, err := dataaccess.ListInputParameters(ctx, token, serviceID, resourceID, productTierID, tierVersion)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, nil
+	}
+
+	var params []OperatorInputParam
+	for _, ip := range result.InputParameters {
+		param := OperatorInputParam{
+			Key:         ip.Key,
+			DisplayName: ip.Name,
+			Description: ip.Description,
+			Type:        ip.Type,
+			Required:    ip.Required,
+			Modifiable:  ip.Modifiable,
+		}
+		if ip.DefaultValue != nil {
+			param.DefaultValue = *ip.DefaultValue
+		}
+		params = append(params, param)
+	}
+	return params, nil
+}
+
+// fetchOutputParams fetches output parameters from the ListOutputParameter V1 API
+// and converts them to OperatorOutputParam structs. Used by both helm and operator TUIs.
+func fetchOutputParams(ctx context.Context, token, serviceID, resourceID, productTierID, tierVersion string) ([]OperatorOutputParam, error) {
+	result, err := dataaccess.ListOutputParameters(ctx, token, serviceID, resourceID, productTierID, tierVersion)
+	if err != nil {
+		return nil, err
+	}
+	if result == nil {
+		return nil, nil
+	}
+
+	var params []OperatorOutputParam
+	for _, op := range result.OutputParameters {
+		param := OperatorOutputParam{
+			Key:         op.Key,
+			DisplayName: op.Name,
+			Description: op.Description,
+		}
+		if op.Value != nil {
+			param.Value = *op.Value
+		}
+		if op.ValueRef != nil {
+			param.ValueRef = *op.ValueRef
+		}
+		if op.ValueType != nil {
+			param.Type = *op.ValueType
+		}
+		params = append(params, param)
+	}
+	return params, nil
 }

--- a/cmd/instance/debug_shared.go
+++ b/cmd/instance/debug_shared.go
@@ -52,8 +52,9 @@ type OperatorOutputParam struct {
 
 // OperatorCRDOutputParam describes a single output parameter from operatorCRDConfiguration.
 type OperatorCRDOutputParam struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key           string `json:"key"`
+	Value         string `json:"value"`
+	ResolvedValue string `json:"resolvedValue,omitempty"`
 }
 
 // OperatorData holds debug information specific to operator-type resources.

--- a/cmd/instance/debug_shared.go
+++ b/cmd/instance/debug_shared.go
@@ -3,6 +3,7 @@ package instance
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
 )
@@ -36,15 +37,16 @@ type OperatorInputParam struct {
 	DefaultValue string `json:"defaultValue,omitempty"`
 }
 
-// OperatorOutputParam describes a single output parameter for an operator resource.
+// OperatorOutputParam describes a single output parameter for a resource.
 // These are API parameters with export: true, fetched from the ListOutputParameter V1 API.
 type OperatorOutputParam struct {
-	Key         string `json:"key"`
-	DisplayName string `json:"displayName"`
-	Description string `json:"description"`
-	Value       string `json:"value,omitempty"`
-	ValueRef    string `json:"valueRef,omitempty"`
-	Type        string `json:"type,omitempty"`
+	Key           string `json:"key"`
+	DisplayName   string `json:"displayName"`
+	Description   string `json:"description"`
+	Value         string `json:"value,omitempty"`
+	ValueRef      string `json:"valueRef,omitempty"`
+	Type          string `json:"type,omitempty"`
+	ResolvedValue string `json:"resolvedValue,omitempty"`
 }
 
 // OperatorCRDOutputParam describes a single output parameter from operatorCRDConfiguration.
@@ -153,8 +155,9 @@ func fetchInputParams(ctx context.Context, token, serviceID, resourceID, product
 }
 
 // fetchOutputParams fetches output parameters from the ListOutputParameter V1 API
-// and converts them to OperatorOutputParam structs. Used by both helm and operator TUIs.
-func fetchOutputParams(ctx context.Context, token, serviceID, resourceID, productTierID, tierVersion string) ([]OperatorOutputParam, error) {
+// and converts them to OperatorOutputParam structs. If resultParams is provided,
+// resolved values are looked up by key and populated. Used by both helm and operator TUIs.
+func fetchOutputParams(ctx context.Context, token, serviceID, resourceID, productTierID, tierVersion string, resultParams map[string]interface{}) ([]OperatorOutputParam, error) {
 	result, err := dataaccess.ListOutputParameters(ctx, token, serviceID, resourceID, productTierID, tierVersion)
 	if err != nil {
 		return nil, err
@@ -178,6 +181,12 @@ func fetchOutputParams(ctx context.Context, token, serviceID, resourceID, produc
 		}
 		if op.ValueType != nil {
 			param.Type = *op.ValueType
+		}
+		// Resolve value from instance result_params
+		if resultParams != nil {
+			if v, ok := resultParams[op.Key]; ok {
+				param.ResolvedValue = fmt.Sprintf("%v", v)
+			}
 		}
 		params = append(params, param)
 	}


### PR DESCRIPTION
- Add 2 new tabs to Helm detail TUI: Input Parameters, Output Parameters (5 tabs total: Helm Logs, Chart Values, Input Parameters, Output Parameters, Workflow Events)
- Fetch input params via ListInputParameters V1 API in fetchHelmData
- Fetch output params via ListOutputParameters V1 API in fetchHelmData
- Add InputParams/OutputParams fields to HelmData struct for JSON output
- Update collectHelmDebugInfo to populate input/output params in JSON path
- Add renderHelmParamTreeTab for reusable tree rendering
- Add all key handlers (up/down/enter/left/right) for new tabs
- Add copy support and footer hints for new tabs
- Add 15 new unit tests covering tab constants, tree building, navigation, expand/collapse, rendering, copy content, tab cycling, and JSON serialization