### PR TITLE
Add Service Plan TUI for highlighting distribution semantics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ PROJECT_NAME=omnistrate-ctl
 DOCKER_PLATFORM=linux/arm64 
 TESTCOVERAGE_THRESHOLD=0
 REPO_ROOT=$(shell git rev-parse --show-toplevel)
+UNIT_TEST_PACKAGES=$(shell go list ./... | grep -v '/test/')
+SMOKE_TEST_PACKAGES=$(shell go list ./test/smoke_test/...)
+INTEGRATION_TEST_PACKAGES=$(shell go list ./test/integration_test/...)
 
 # Build info
 BUILD_INFO_PKG=github.com/omnistrate-oss/omnistrate-ctl/internal/config
@@ -46,7 +49,7 @@ download:
 .PHONY: unit-test
 unit-test:
 	@echo "Running unit tests for service"
-	go test ./... -skip ./test/... $(ARGS) -cover -coverprofile coverage.out -covermode count
+	go test $(UNIT_TEST_PACKAGES) $(ARGS) -cover -coverprofile coverage.out -covermode count
 	go tool cover -func=coverage.out | grep total | awk '{print $$3}' | sed 's/[%]//g' | awk 'current=$$1; {if (current < ${TESTCOVERAGE_THRESHOLD}) {print "\033[31mTest coverage is " current " which is below threshold\033[0m"; exit 1} else {print "\033[32mTest coverage is above threshold\033[0m"}}'
 
 .PHONY: smoke-test
@@ -58,7 +61,7 @@ smoke-test:
 	export OMNISTRATE_LOG_LEVEL=debug && \
 	export OMNISTRATE_LOG_FORMAT=pretty && \
 	go clean -testcache && \
-	go test ./... -skip ./test/smoke_test/... $(ARGS) 
+	go test $(SMOKE_TEST_PACKAGES) $(ARGS)
 
 .PHONY: integration-test
 integration-test:
@@ -69,7 +72,7 @@ integration-test:
 	export OMNISTRATE_LOG_LEVEL=debug && \
 	export OMNISTRATE_LOG_FORMAT=pretty && \
 	go clean -testcache && \
-	go test ./... -skip ./test/integration_test/... $(ARGS) 
+	go test $(INTEGRATION_TEST_PACKAGES) $(ARGS)
 
 .PHONY: build
 build:
@@ -112,7 +115,7 @@ ctl: ctl-linux-amd64 ctl-linux-arm64 ctl-darwin-amd64 ctl-darwin-arm64 ctl-windo
 
 .PHONY: test-coverage-report
 test-coverage-report:
-	go test ./... -skip ./test/... -cover -coverprofile coverage.out -covermode count
+	go test $(UNIT_TEST_PACKAGES) -cover -coverprofile coverage.out -covermode count
 	go tool cover -html=coverage.out
 
 lint-install:

--- a/cmd/auth/login/login_test.go
+++ b/cmd/auth/login/login_test.go
@@ -148,8 +148,8 @@ func TestAPIKeyLoginEmptyKeyErrorMessageBySource(t *testing.T) {
 // signinCapture records the fields from the most recent captured signin
 // request body.
 type signinCapture struct {
-	Email    string
-	Password string
+	email   string
+	payload string
 }
 
 // newFakeSigninServer starts an httptest.Server that:
@@ -168,17 +168,14 @@ func newFakeSigninServer(t *testing.T) (*httptest.Server, *signinCapture) {
 			http.Error(w, "read error", http.StatusInternalServerError)
 			return
 		}
-		var req struct {
-			Email    string `json:"email"`
-			Password string `json:"password"`
-		}
+		var req map[string]string
 		if err = json.Unmarshal(body, &req); err != nil {
 			http.Error(w, "bad JSON", http.StatusBadRequest)
 			t.Errorf("newFakeSigninServer: failed to unmarshal request body: %v", err)
 			return
 		}
-		captured.Email = req.Email
-		captured.Password = req.Password
+		captured.email = req["email"]
+		captured.payload = req["password"]
 
 		w.Header().Set("Content-Type", "application/json")
 		if _, err = io.WriteString(w, `{"jwtToken":"fake-jwt-for-testing"}`); err != nil {
@@ -220,9 +217,9 @@ func TestRunLoginPicksUpEnvVar(t *testing.T) {
 
 	err := RunLogin(LoginCmd, nil)
 	require.NoError(t, err)
-	require.Equal(t, dataaccess.APIKeySigninEmail, captured.Email,
+	require.Equal(t, dataaccess.APIKeySigninEmail, captured.email,
 		"env-var login must use the API-key sentinel email")
-	require.Equal(t, "om_test_env_key", captured.Password,
+	require.Equal(t, "om_test_env_key", captured.payload,
 		"env var value must be forwarded as the request password")
 }
 
@@ -239,7 +236,7 @@ func TestRunLoginFlagTakesPrecedenceOverEnv(t *testing.T) {
 
 	err := RunLogin(LoginCmd, nil)
 	require.NoError(t, err)
-	require.Equal(t, "om_flag_value", captured.Password,
+	require.Equal(t, "om_flag_value", captured.payload,
 		"--api-key flag value must take precedence over the env var")
 }
 
@@ -258,8 +255,8 @@ func TestRunLoginEnvVarNotUsedWhenOtherFlagsSet(t *testing.T) {
 
 	err := RunLogin(LoginCmd, nil)
 	require.NoError(t, err)
-	require.Equal(t, "test@example.com", captured.Email,
+	require.Equal(t, "test@example.com", captured.email,
 		"email/password path must send the user's email, not the API-key sentinel")
-	require.Equal(t, "fake_password", captured.Password,
+	require.Equal(t, "fake_password", captured.payload,
 		"email/password path must send the password flag, not the env var API key")
 }

--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -529,7 +529,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	var spinner1 *utils.Spinner
 	if output != "json" {
 		sm1 = utils.NewSpinnerManager()
-		spinner1 = sm1.AddSpinner("Building service...")
+		spinner1 = sm1.AddSpinner("Rendering spec file")
 		sm1.Start()
 	}
 
@@ -546,24 +546,16 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		utils.HandleSpinnerError(spinner1, sm1, err)
 		return err
 	}
+	if spinner1 != nil {
+		spinner1.Complete()
+		spinner1 = nil
+	}
 
+	var hierarchyResult *ServiceHierarchyResult
+	extendDistribution := false
 	if specType == ServicePlanSpecType {
-		// Extract plan name from YAML for display purposes
-		if spinner1 != nil {
-			var yamlContent map[string]interface{}
-			if parseErr := yaml.Unmarshal(fileData, &yamlContent); parseErr == nil {
-				if planName, ok := yamlContent["name"].(string); ok && planName != "" {
-					spinner1.UpdateMessage(fmt.Sprintf("Building service '%s' with plan '%s'...", name, planName))
-				}
-			}
-		}
-
-		// Step 1: Prepare service build - find or create service hierarchy and get upload tasks
-		if spinner1 != nil {
-			spinner1.UpdateMessage("Preparing service build...")
-		}
-
-		hierarchyResult, hierarchyErr := FindOrCreateServiceHierarchy(
+		var hierarchyErr error
+		hierarchyResult, hierarchyErr = FindOrCreateServiceHierarchy(
 			cmd.Context(),
 			token,
 			name,
@@ -572,7 +564,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			environmentTypePtr,
 		)
 		if hierarchyErr != nil {
-			utils.HandleSpinnerError(spinner1, sm1, hierarchyErr)
+			utils.HandleSpinnerError(nil, sm1, hierarchyErr)
 			return hierarchyErr
 		}
 
@@ -585,19 +577,26 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			release = true
 		}
 
-		if spinner1 != nil {
-			spinner1.UpdateMessage("Service build prepared successfully")
+		if shouldCheckDistributionExtension(hierarchyResult) {
+			extendsDistribution, distributionErr := serviceHasAdditionalPlans(cmd.Context(), token, hierarchyResult.ServiceID, hierarchyResult.EnvironmentID)
+			if distributionErr == nil {
+				extendDistribution = extendsDistribution
+			}
 		}
+	}
 
-		// Step 2: Upload artifacts using tasks from prepare response
+	var buildProgress *specBuildProgress
+	if output != "json" {
+		buildProgress = addSpecBuildChecklist(sm1, fileData, specType, specChecklistOptions{extendDistribution: extendDistribution})
+		if streamErr := buildProgress.StreamFeatureChecks(cmd.Context()); streamErr != nil {
+			utils.HandleSpinnerError(nil, sm1, streamErr)
+			return streamErr
+		}
+	}
+
+	if specType == ServicePlanSpecType && hierarchyResult != nil {
 		if len(hierarchyResult.ArtifactUploadingTasks) > 0 && !dryRun {
 			uniquePaths := UniqueArtifactPathsFromTasks(hierarchyResult.ArtifactUploadingTasks)
-
-			// Complete the prepare spinner before warnings and per-task spinners
-			if spinner1 != nil {
-				spinner1.UpdateMessage("Service build prepared successfully")
-				spinner1.Complete()
-			}
 
 			// Warn if any artifact path refers to the current working directory
 			if output != "json" {
@@ -611,54 +610,17 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			// Archive all unique artifact paths (gzip + tar + base64 encode)
 			artifactArchives, archiveErr := ArchiveArtifactPaths(cwd, uniquePaths)
 			if archiveErr != nil {
-				if sm1 != nil {
-					sm1.Stop()
-				}
-				utils.EnsureCursorRestoration()
-				utils.PrintError(archiveErr)
+				utils.HandleSpinnerError(spinner1, sm1, archiveErr)
 				return archiveErr
 			}
 
-			// Create per-task spinners for each upload task
-			type artifactSpinnerInfo struct {
-				spinner    *utils.Spinner
-				artifactID string
-			}
-			taskSpinners := make([]artifactSpinnerInfo, 0, len(hierarchyResult.ArtifactUploadingTasks))
-
-			for i, task := range hierarchyResult.ArtifactUploadingTasks {
-				taskLabel := fmt.Sprintf("[%d/%d] %s -> %s: Uploading...",
-					i+1, len(hierarchyResult.ArtifactUploadingTasks),
-					task.ArtifactPath, task.AccountConfigID)
-				var taskSpinner *utils.Spinner
-				if sm1 != nil {
-					taskSpinner = sm1.AddSpinner(taskLabel)
-				}
-				taskSpinners = append(taskSpinners, artifactSpinnerInfo{spinner: taskSpinner})
-			}
-
-			// Upload each artifact and track per-task progress
-			for i, task := range hierarchyResult.ArtifactUploadingTasks {
+			var uploadedArtifactIDs []string
+			for _, task := range hierarchyResult.ArtifactUploadingTasks {
 				base64Content, exists := artifactArchives[task.ArtifactPath]
 				if !exists {
 					uploadErr := fmt.Errorf("artifact archive not found for path '%s'", task.ArtifactPath)
-					if taskSpinners[i].spinner != nil {
-						taskSpinners[i].spinner.Error()
-						utils.PrintError(errors.Errorf("[%d/%d] %s -> %s: %v",
-							i+1, len(hierarchyResult.ArtifactUploadingTasks), task.ArtifactPath, task.AccountConfigID, uploadErr))
-					}
-					if sm1 != nil {
-						sm1.Stop()
-					}
-					utils.EnsureCursorRestoration()
-					utils.PrintError(uploadErr)
+					utils.HandleSpinnerError(spinner1, sm1, uploadErr)
 					return uploadErr
-				}
-
-				if taskSpinners[i].spinner != nil {
-					taskSpinners[i].spinner.UpdateMessage(fmt.Sprintf("[%d/%d] %s -> %s: Uploading...",
-						i+1, len(hierarchyResult.ArtifactUploadingTasks),
-						task.ArtifactPath, task.AccountConfigID))
 				}
 
 				uploadResult, uploadErr := dataaccess.UploadArtifact(
@@ -672,76 +634,18 @@ func runBuild(cmd *cobra.Command, args []string) error {
 					task.EnvironmentType,
 				)
 				if uploadErr != nil {
-					if taskSpinners[i].spinner != nil {
-						taskSpinners[i].spinner.Error()
-						utils.PrintError(errors.Errorf("[%d/%d] %s -> %s: Failed to upload",
-							i+1, len(hierarchyResult.ArtifactUploadingTasks),
-							task.ArtifactPath, task.AccountConfigID))
-					}
-					if sm1 != nil {
-						sm1.Stop()
-					}
-					utils.EnsureCursorRestoration()
-					utils.PrintError(fmt.Errorf("failed to upload artifact '%s': %w", task.ArtifactPath, uploadErr))
-					return uploadErr
+					err = fmt.Errorf("failed to upload artifact '%s': %w", task.ArtifactPath, uploadErr)
+					utils.HandleSpinnerError(spinner1, sm1, err)
+					return err
 				}
 
-				taskSpinners[i].artifactID = uploadResult.ArtifactID
-				if taskSpinners[i].spinner != nil {
-					taskSpinners[i].spinner.UpdateMessage(fmt.Sprintf("[%d/%d] %s -> %s: Uploaded, processing...",
-						i+1, len(hierarchyResult.ArtifactUploadingTasks),
-						task.ArtifactPath, task.AccountConfigID))
-				}
+				uploadedArtifactIDs = append(uploadedArtifactIDs, uploadResult.ArtifactID)
 			}
 
-			// Build artifact ID to spinner index map for the polling callback
-			artifactIDToIdx := make(map[string]int)
-			var uploadedArtifactIDs []string
-			for i, info := range taskSpinners {
-				if info.artifactID != "" {
-					artifactIDToIdx[info.artifactID] = i
-					uploadedArtifactIDs = append(uploadedArtifactIDs, info.artifactID)
-				}
-			}
-
-			// Wait for all artifacts to be in READY status with per-spinner updates
 			if len(uploadedArtifactIDs) > 0 {
-				waitErr := waitForArtifactsReady(cmd.Context(), token, uploadedArtifactIDs,
-					func(artifactID string, status string) {
-						idx, ok := artifactIDToIdx[artifactID]
-						if !ok || taskSpinners[idx].spinner == nil {
-							return
-						}
-						task := hierarchyResult.ArtifactUploadingTasks[idx]
-						switch status {
-						case StatusReady:
-							taskSpinners[idx].spinner.Complete()
-							utils.PrintInfo(fmt.Sprintf("[%d/%d] %s -> %s: Ready",
-								idx+1, len(hierarchyResult.ArtifactUploadingTasks),
-								task.ArtifactPath, task.AccountConfigID))
-						case StatusFailed:
-							taskSpinners[idx].spinner.Error()
-							utils.PrintError(errors.Errorf("[%d/%d] %s -> %s: Failed",
-								idx+1, len(hierarchyResult.ArtifactUploadingTasks),
-								task.ArtifactPath, task.AccountConfigID))
-						default:
-							taskSpinners[idx].spinner.UpdateMessage(fmt.Sprintf("[%d/%d] %s -> %s: %s",
-								idx+1, len(hierarchyResult.ArtifactUploadingTasks),
-								task.ArtifactPath, task.AccountConfigID, status))
-						}
-					})
+				waitErr := waitForArtifactsReady(cmd.Context(), token, uploadedArtifactIDs, nil)
 				if waitErr != nil {
-					// Mark any remaining spinners as errored
-					for _, info := range taskSpinners {
-						if info.spinner != nil {
-							info.spinner.Error()
-						}
-					}
-					if sm1 != nil {
-						sm1.Stop()
-					}
-					utils.EnsureCursorRestoration()
-					utils.PrintError(waitErr)
+					utils.HandleSpinnerError(spinner1, sm1, waitErr)
 					return waitErr
 				}
 			}
@@ -750,6 +654,9 @@ func runBuild(cmd *cobra.Command, args []string) error {
 
 	var undefinedResources map[string]string
 	var isNewVersionCreated bool
+	if buildProgress != nil {
+		spinner1 = buildProgress.StartFinalizing()
+	}
 	ServiceID, EnvironmentID, ProductTierID, undefinedResources, isNewVersionCreated, err = BuildService(
 		cmd.Context(),
 		fileData,
@@ -770,11 +677,14 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		utils.HandleSpinnerError(spinner1, sm1, err)
 		return err
 	}
+	if buildProgress != nil {
+		buildProgress.CompleteFinalizing()
+	}
 	header := "Successfully built service"
 	if dryRun {
 		header = "Simulated service build completed successfully (dry run)"
 	}
-	utils.HandleSpinnerSuccess(spinner1, sm1, header)
+	utils.HandleSpinnerSuccess(nil, sm1, header)
 
 	// Get product tier name
 	productTier, err := dataaccess.DescribeProductTier(cmd.Context(), token, ServiceID, ProductTierID)

--- a/cmd/build/spec_checklist.go
+++ b/cmd/build/spec_checklist.go
@@ -1,0 +1,1212 @@
+package build
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"math/big"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	composeSpecSchemaURL = "https://api.omnistrate.cloud/2022-09-01-00/schema/compose-spec-schema.json"
+	serviceSpecSchemaURL = "https://api.omnistrate.cloud/2022-09-01-00/schema/service-spec-schema.json"
+
+	maxChecklistDelayMillis = 500
+)
+
+var (
+	schemaDirectiveRE     = regexp.MustCompile(`(?m)^\s*#\s*(?:yaml-language-server:\s*)?\$schema\s*(?:=|:)\s*(\S+)\s*$`)
+	deploymentParameterRE = regexp.MustCompile(`\$var\.([A-Za-z_][A-Za-z0-9_]*)`)
+)
+
+type specChecklistItem struct {
+	Label string
+	Depth int
+}
+
+type specChecklistOptions struct {
+	extendDistribution bool
+}
+
+type specBuildProgress struct {
+	sm                utils.SpinnerManager
+	featureSpinners   []*utils.Spinner
+	finalizingSpinner *utils.Spinner
+}
+
+func addSpecBuildChecklist(sm utils.SpinnerManager, fileData []byte, specType string, options specChecklistOptions) *specBuildProgress {
+	progress := &specBuildProgress{sm: sm}
+	if sm == nil {
+		return progress
+	}
+
+	items, err := buildSpecChecklistWithOptions(fileData, specType, options)
+	if err == nil {
+		for _, item := range items {
+			spinner := sm.AddSpinner(indentChecklistLabel(item))
+			spinner.Pending()
+			progress.featureSpinners = append(progress.featureSpinners, spinner)
+		}
+	}
+	return progress
+}
+
+func (p *specBuildProgress) StreamFeatureChecks(ctx context.Context) error {
+	if p == nil {
+		return nil
+	}
+	for _, spinner := range p.featureSpinners {
+		if spinner == nil {
+			continue
+		}
+		spinner.Start()
+		if err := waitChecklistDelay(ctx); err != nil {
+			return err
+		}
+		spinner.Complete()
+	}
+	return nil
+}
+
+func (p *specBuildProgress) StartFinalizing() *utils.Spinner {
+	if p == nil || p.sm == nil {
+		return nil
+	}
+	if p.finalizingSpinner == nil {
+		p.finalizingSpinner = p.sm.AddSpinner("Finalizing build")
+	}
+	p.finalizingSpinner.Start()
+	return p.finalizingSpinner
+}
+
+func (p *specBuildProgress) FinalizingSpinner() *utils.Spinner {
+	if p == nil {
+		return nil
+	}
+	return p.finalizingSpinner
+}
+
+func (p *specBuildProgress) CompleteFinalizing() {
+	if p == nil || p.finalizingSpinner == nil {
+		return
+	}
+	p.finalizingSpinner.Complete()
+}
+
+func waitChecklistDelay(ctx context.Context) error {
+	delay := randomChecklistDelay()
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func randomChecklistDelay() time.Duration {
+	n, err := rand.Int(rand.Reader, big.NewInt(maxChecklistDelayMillis))
+	if err != nil {
+		return 100 * time.Millisecond
+	}
+	return time.Duration(n.Int64()+1) * time.Millisecond
+}
+
+func indentChecklistLabel(item specChecklistItem) string {
+	if item.Depth <= 0 {
+		return item.Label
+	}
+	return strings.Repeat("  ", item.Depth) + item.Label
+}
+
+func buildSpecChecklist(fileData []byte, specType string) ([]specChecklistItem, error) {
+	return buildSpecChecklistWithOptions(fileData, specType, specChecklistOptions{})
+}
+
+func buildSpecChecklistWithOptions(fileData []byte, specType string, options specChecklistOptions) ([]specChecklistItem, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(fileData, &root); err != nil {
+		return nil, err
+	}
+	if len(root.Content) == 0 {
+		return nil, nil
+	}
+
+	schemaURL := schemaURLFromSpec(fileData)
+	if schemaURL == "" {
+		schemaURL = defaultSchemaURLForSpecType(specType)
+	}
+	if !isAllowedSpecSchemaURL(schemaURL) {
+		schemaURL = defaultSchemaURLForSpecType(specType)
+	}
+	if specType == "" {
+		if schemaURL == serviceSpecSchemaURL {
+			specType = ServicePlanSpecType
+		} else {
+			specType = DockerComposeSpecType
+		}
+	}
+
+	if specType == ServicePlanSpecType {
+		return servicePlanSpecChecklist(root.Content[0], options), nil
+	}
+	return composeSpecChecklist(root.Content[0], options), nil
+}
+
+func schemaURLFromSpec(fileData []byte) string {
+	matches := schemaDirectiveRE.FindSubmatch(fileData)
+	if len(matches) < 2 {
+		return ""
+	}
+	return strings.TrimSpace(string(matches[1]))
+}
+
+func defaultSchemaURLForSpecType(specType string) string {
+	if specType == ServicePlanSpecType {
+		return serviceSpecSchemaURL
+	}
+	return composeSpecSchemaURL
+}
+
+func isAllowedSpecSchemaURL(schemaURL string) bool {
+	return schemaURL == composeSpecSchemaURL || schemaURL == serviceSpecSchemaURL
+}
+
+func composeSpecChecklist(root *yaml.Node, options specChecklistOptions) []specChecklistItem {
+	var items []specChecklistItem
+
+	if plan := mappingValue(root, "x-omnistrate-service-plan"); plan != nil {
+		addPlanChecklist(plan, &items, options)
+	}
+	if lb := mappingValue(root, "x-omnistrate-load-balancer"); lb != nil {
+		addLoadBalancerChecklist(lb, &items, 0)
+	}
+	addTopLevelComposeCollections(root, &items)
+
+	services := mappingValue(root, "services")
+	if services != nil && services.Kind == yaml.MappingNode {
+		for _, entry := range mappingEntries(services) {
+			name := entry.key
+			if name == "" {
+				name = "unnamed"
+			}
+			addResourceChecklist(name, entry.value, DockerComposeSpecType, &items)
+		}
+	}
+
+	return dedupeSpecChecklistItems(items)
+}
+
+func servicePlanSpecChecklist(root *yaml.Node, options specChecklistOptions) []specChecklistItem {
+	var items []specChecklistItem
+
+	addPlanChecklist(root, &items, options)
+	if lb := mappingValue(root, "loadBalancers"); lb != nil {
+		addLoadBalancerChecklist(lb, &items, 0)
+	}
+	if sharedFileSystems := mappingValue(root, "sharedFileSystems"); sharedFileSystems != nil {
+		addSharedFileSystemsChecklist(sharedFileSystems, &items, 0)
+	}
+	addWorkflowChecklist(root, &items, 0)
+
+	services := mappingValue(root, "services")
+	if services != nil && services.Kind == yaml.SequenceNode {
+		for i, service := range services.Content {
+			name := mappingScalar(service, "name")
+			if name == "" {
+				name = fmt.Sprintf("resource %d", i+1)
+			}
+			addResourceChecklist(name, service, ServicePlanSpecType, &items)
+		}
+	}
+
+	return dedupeSpecChecklistItems(items)
+}
+
+func addPlanChecklist(plan *yaml.Node, items *[]specChecklistItem, options specChecklistOptions) {
+	deployment := mappingValue(plan, "deployment")
+	if options.extendDistribution {
+		appendChecklist(items, 0, "Extending distribution to %s deployment model", deploymentModelLabel(deployment))
+		addDeploymentCloudAccountsChecklist(deployment, items, 1)
+	}
+	if name := mappingScalar(plan, "name"); name != "" {
+		appendChecklist(items, 0, "Resolving plan %s", name)
+	}
+	if tenancy := mappingScalar(plan, "tenancyType"); tenancy != "" {
+		appendChecklist(items, 0, "Setting tenancy to %s", humanizeIdentifier(tenancy))
+	}
+	if deployment != nil && !options.extendDistribution {
+		addDeploymentChecklist(deployment, items, 0)
+	}
+	if features := mappingValue(plan, "features"); features != nil {
+		addFeatureChecklist(features, items, 0)
+	}
+	if pricing := mappingValue(plan, "pricing"); pricing != nil {
+		addPricingChecklist(pricing, items, 0)
+	}
+	if metering := mappingValue(plan, "metering"); metering != nil {
+		addMeteringChecklist(metering, items, 0)
+	}
+	if providers := mappingValue(plan, "billingProviders"); providers != nil {
+		addBillingProvidersChecklist(providers, items, 0)
+	}
+	if limit := mappingScalar(plan, "maxNumberOfInstancesAllowed"); limit != "" {
+		appendChecklist(items, 0, "Limiting plan to %s instance(s)", limit)
+	}
+	if boolValue(plan, "validPaymentMethodRequired") {
+		appendChecklist(items, 0, "Requiring a valid payment method")
+	}
+	if boolValue(plan, "enableDeletionProtection") {
+		appendChecklist(items, 0, "Enabling deletion protection")
+	}
+	if billingProductID := mappingScalar(plan, "billingProductID"); billingProductID != "" {
+		appendChecklist(items, 0, "Linking billing product %s", billingProductID)
+	}
+}
+
+func addDeploymentChecklist(deployment *yaml.Node, items *[]specChecklistItem, depth int) {
+	for _, deploymentType := range deploymentChecklistTypes() {
+		config := mappingValue(deployment, deploymentType.key)
+		if config == nil {
+			continue
+		}
+		appendChecklist(items, depth, "Configuring %s deployment", deploymentType.label)
+		addCloudAccountChecklist(config, items, depth+1)
+	}
+}
+
+func addDeploymentCloudAccountsChecklist(deployment *yaml.Node, items *[]specChecklistItem, depth int) {
+	if deployment == nil {
+		return
+	}
+	for _, deploymentType := range deploymentChecklistTypes() {
+		config := mappingValue(deployment, deploymentType.key)
+		if config == nil {
+			continue
+		}
+		addCloudAccountChecklist(config, items, depth)
+	}
+}
+
+func deploymentModelLabel(deployment *yaml.Node) string {
+	for _, deploymentType := range deploymentChecklistTypes() {
+		if mappingValue(deployment, deploymentType.key) != nil {
+			return deploymentType.label
+		}
+	}
+	return "unknown"
+}
+
+func deploymentChecklistTypes() []struct {
+	key   string
+	label string
+} {
+	return []struct {
+		key   string
+		label string
+	}{
+		{"hostedDeployment", "hosted"},
+		{"byoaDeployment", "BYOA"},
+		{"onPremDeployment", "on-prem"},
+		{"onPremCopilotDeployment", "on-prem copilot"},
+	}
+}
+
+func addCloudAccountChecklist(config *yaml.Node, items *[]specChecklistItem, depth int) {
+	if awsAccountID := mappingScalar(config, "AwsAccountId"); awsAccountID != "" {
+		appendChecklist(items, depth, "Connecting AWS account %s", awsAccountID)
+	}
+	if roleArn := mappingScalar(config, "AWSBootstrapRoleAccountArn"); roleArn != "" {
+		appendChecklist(items, depth, "Using AWS bootstrap role %s", roleArn)
+	}
+
+	gcpProjectID := mappingScalar(config, "GcpProjectId")
+	gcpProjectNumber := mappingScalar(config, "GcpProjectNumber")
+	switch {
+	case gcpProjectID != "" && gcpProjectNumber != "":
+		appendChecklist(items, depth, "Connecting GCP project %s (%s)", gcpProjectID, gcpProjectNumber)
+	case gcpProjectID != "":
+		appendChecklist(items, depth, "Connecting GCP project %s", gcpProjectID)
+	case gcpProjectNumber != "":
+		appendChecklist(items, depth, "Connecting GCP project number %s", gcpProjectNumber)
+	}
+	if serviceAccount := mappingScalar(config, "GcpServiceAccountEmail"); serviceAccount != "" {
+		appendChecklist(items, depth, "Using GCP service account %s", serviceAccount)
+	}
+
+	azureSubscriptionID := mappingScalar(config, "AzureSubscriptionId")
+	azureTenantID := mappingScalar(config, "AzureTenantId")
+	switch {
+	case azureSubscriptionID != "" && azureTenantID != "":
+		appendChecklist(items, depth, "Connecting Azure subscription %s (tenant %s)", azureSubscriptionID, azureTenantID)
+	case azureSubscriptionID != "":
+		appendChecklist(items, depth, "Connecting Azure subscription %s", azureSubscriptionID)
+	case azureTenantID != "":
+		appendChecklist(items, depth, "Using Azure tenant %s", azureTenantID)
+	}
+
+	if nebiusTenantID := mappingScalar(config, "NebiusTenantId"); nebiusTenantID != "" {
+		appendChecklist(items, depth, "Connecting Nebius tenant %s", nebiusTenantID)
+	}
+	if ociTenancyID := mappingScalar(config, "OCITenancyId"); ociTenancyID != "" {
+		appendChecklist(items, depth, "Connecting OCI tenancy %s", ociTenancyID)
+	}
+	if ociDomainID := mappingScalar(config, "OCIDomainId"); ociDomainID != "" {
+		appendChecklist(items, depth, "Using OCI domain %s", ociDomainID)
+	}
+}
+
+func addFeatureChecklist(features *yaml.Node, items *[]specChecklistItem, depth int) {
+	if features.Kind != yaml.MappingNode {
+		return
+	}
+	for _, entry := range mappingEntries(features) {
+		name := featureDisplayName(entry.key)
+		if name == "" {
+			continue
+		}
+		appendChecklist(items, depth, "Enabling %s feature (%s)", name, featureAudience(entry.key, entry.value))
+	}
+}
+
+func addPricingChecklist(pricing *yaml.Node, items *[]specChecklistItem, depth int) {
+	for _, node := range collectionNodes(pricing) {
+		dimension := mappingScalar(node, "dimension")
+		if dimension == "" {
+			dimension = "pricing"
+		}
+		appendChecklist(items, depth, "Configuring %s pricing", humanizeIdentifier(dimension))
+	}
+}
+
+func addMeteringChecklist(metering *yaml.Node, items *[]specChecklistItem, depth int) {
+	switch {
+	case mappingScalar(metering, "s3BucketArn") != "":
+		appendChecklist(items, depth, "Exporting metering to S3")
+	case mappingScalar(metering, "gcsBucketName") != "":
+		appendChecklist(items, depth, "Exporting metering to GCS")
+	default:
+		appendChecklist(items, depth, "Configuring metering")
+	}
+}
+
+func addBillingProvidersChecklist(providers *yaml.Node, items *[]specChecklistItem, depth int) {
+	for _, node := range collectionNodes(providers) {
+		name := mappingScalar(node, "name")
+		if name == "" {
+			name = "billing provider"
+		}
+		appendChecklist(items, depth, "Configuring %s billing", name)
+	}
+}
+
+func addLoadBalancerChecklist(loadBalancers *yaml.Node, items *[]specChecklistItem, depth int) {
+	for _, protocol := range []string{"https", "tcp"} {
+		configs := mappingValue(loadBalancers, protocol)
+		for _, node := range collectionNodes(configs) {
+			name := mappingScalar(node, "name")
+			if name == "" {
+				name = strings.ToUpper(protocol)
+			}
+			appendChecklist(items, depth, "Configuring %s load balancer %s", strings.ToUpper(protocol), name)
+			addLoadBalancerRoutesChecklist(node, items, depth+1)
+		}
+	}
+}
+
+func addLoadBalancerRoutesChecklist(node *yaml.Node, items *[]specChecklistItem, depth int) {
+	for _, port := range collectionNodes(mappingValue(node, "ports")) {
+		backendPort := mappingScalar(port, "backendPort")
+		ingressPort := mappingScalar(port, "ingressPort")
+		if backendPort != "" && ingressPort != "" {
+			appendValuesChecklist(items, depth, "load balancer port", []string{ingressPort, backendPort}, "Routing port %s to backend port %s", ingressPort, backendPort)
+		}
+	}
+	for _, path := range collectionNodes(mappingValue(node, "paths")) {
+		route := mappingScalar(path, "path")
+		backendPort := mappingScalar(path, "backendPort")
+		resource := mappingScalar(path, "associatedResourceKey")
+		if route == "" {
+			route = "/"
+		}
+		switch {
+		case resource != "" && backendPort != "":
+			appendValuesChecklist(items, depth, "load balancer route", []string{route, backendPort}, "Routing %s to %s on port %s", route, resource, backendPort)
+		case backendPort != "":
+			appendValuesChecklist(items, depth, "load balancer route", []string{route, backendPort}, "Routing %s to backend port %s", route, backendPort)
+		default:
+			appendValueChecklist(items, depth, "load balancer route", route, "Routing %s", route)
+		}
+	}
+}
+
+func addSharedFileSystemsChecklist(sharedFileSystems *yaml.Node, items *[]specChecklistItem, depth int) {
+	for _, node := range collectionNodes(sharedFileSystems) {
+		name := mappingScalar(node, "name")
+		if name == "" {
+			name = "shared file system"
+		}
+		appendChecklist(items, depth, "Configuring shared file system %s", name)
+	}
+}
+
+func addWorkflowChecklist(root *yaml.Node, items *[]specChecklistItem, depth int) {
+	if workflows := mappingValue(root, "systemWorkflows"); workflows != nil {
+		for _, key := range []string{"backup", "restore", "deleteBackup"} {
+			if mappingValue(workflows, key) != nil {
+				appendChecklist(items, depth, "Registering %s workflow", humanizeIdentifier(key))
+			}
+		}
+	}
+	if workflows := mappingValue(root, "customWorkflows"); workflows != nil {
+		for _, node := range collectionNodes(workflows) {
+			displayName := mappingScalar(node, "displayName")
+			if displayName == "" {
+				displayName = mappingScalar(node, "verb")
+			}
+			if displayName == "" {
+				displayName = "custom"
+			}
+			appendChecklist(items, depth, "Registering %s workflow", displayName)
+		}
+	}
+}
+
+func addTopLevelComposeCollections(root *yaml.Node, items *[]specChecklistItem) {
+	for _, entry := range []struct {
+		key    string
+		action string
+	}{
+		{"volumes", "Configuring shared volume"},
+		{"networks", "Configuring network"},
+		{"configs", "Configuring config"},
+		{"secrets", "Configuring secret"},
+	} {
+		node := mappingValue(root, entry.key)
+		if node == nil || node.Kind != yaml.MappingNode {
+			continue
+		}
+		for _, value := range mappingEntries(node) {
+			appendChecklist(items, 0, "%s %s", entry.action, value.key)
+		}
+	}
+}
+
+func addResourceChecklist(name string, resource *yaml.Node, specType string, items *[]specChecklistItem) {
+	appendChecklist(items, 0, "Preparing resource %s", name)
+	addResourceRuntimeChecklist(resource, specType, items, 1)
+	addComputeChecklist(resourceComputeNode(resource, specType), items, 1)
+	addStorageChecklist(resource, specType, items, 1)
+	addNetworkChecklist(resource, specType, items, 1)
+	addCapabilitiesChecklist(resourceCapabilitiesNode(resource, specType), items, 1)
+	addResourceInputsChecklist(resource, specType, items, 1)
+	addResourceConfigChecklist(resource, items, 1)
+	addResourceLifecycleChecklist(resource, specType, items, 1)
+	addResourceSecurityChecklist(resource, specType, items, 1)
+}
+
+func addResourceRuntimeChecklist(resource *yaml.Node, specType string, items *[]specChecklistItem, depth int) {
+	if image := mappingScalar(resource, "image"); image != "" {
+		appendValueChecklist(items, depth, "container image", image, "Configuring container image %s", image)
+	}
+	if build := mappingValue(resource, "build"); build != nil {
+		switch build.Kind {
+		case yaml.ScalarNode:
+			appendValueChecklist(items, depth, "container build", build.Value, "Configuring container build from %s", build.Value)
+		case yaml.MappingNode:
+			context := mappingScalar(build, "context")
+			if context == "" {
+				context = "."
+			}
+			appendValueChecklist(items, depth, "container build", context, "Configuring container build from %s", context)
+		}
+	}
+
+	if specType == ServicePlanSpecType {
+		if helm := mappingValue(resource, "helmChartConfiguration"); helm != nil {
+			chartName := mappingScalar(helm, "chartName")
+			chartVersion := mappingScalar(helm, "chartVersion")
+			if chartName == "" {
+				chartName = "Helm chart"
+			}
+			if chartVersion != "" {
+				appendValuesChecklist(items, depth, "Helm chart", []string{chartName, chartVersion}, "Configuring Helm chart %s %s", chartName, chartVersion)
+			} else {
+				appendValueChecklist(items, depth, "Helm chart", chartName, "Configuring Helm chart %s", chartName)
+			}
+		}
+		if mappingValue(resource, "operatorCRDConfiguration") != nil {
+			appendChecklist(items, depth, "Configuring operator CRD")
+		}
+		if mappingValue(resource, "terraformConfigurations") != nil {
+			appendChecklist(items, depth, "Configuring Terraform")
+		}
+		if kustomize := mappingValue(resource, "kustomizeConfiguration"); kustomize != nil {
+			path := mappingScalar(kustomize, "kustomizePath")
+			if path == "" {
+				path = "overlay"
+			}
+			appendValueChecklist(items, depth, "Kustomize", path, "Configuring Kustomize %s", path)
+		}
+		if mappingValue(resource, "agentConfiguration") != nil {
+			appendChecklist(items, depth, "Configuring agent runtime")
+		}
+		if mappingValue(resource, "containerImagesRegistryCopyConfiguration") != nil {
+			appendChecklist(items, depth, "Configuring container image registry copy")
+		}
+	}
+
+	if mappingValue(resource, "command") != nil || mappingValue(resource, "args") != nil || mappingValue(resource, "entrypoint") != nil {
+		appendChecklist(items, depth, "Configuring startup command")
+	}
+}
+
+func resourceComputeNode(resource *yaml.Node, specType string) *yaml.Node {
+	if specType == ServicePlanSpecType {
+		return mappingValue(resource, "compute")
+	}
+	return mappingValue(resource, "x-omnistrate-compute")
+}
+
+func addComputeChecklist(compute *yaml.Node, items *[]specChecklistItem, depth int) {
+	if compute == nil {
+		return
+	}
+	var section []specChecklistItem
+	if replicaCount := mappingScalar(compute, "replicaCount"); replicaCount != "" {
+		appendValueChecklist(&section, depth+1, "replica count", replicaCount, "Configuring replica count to %s", replicaCount)
+	}
+	if apiParam := mappingScalar(compute, "replicaCountAPIParam"); apiParam != "" {
+		appendChecklist(&section, depth+1, "Configuring replica count parameter %s", apiParam)
+	}
+	if architecture := mappingScalar(compute, "cpuArchitecture"); architecture != "" {
+		appendValueChecklist(&section, depth+1, "CPU architecture", architecture, "Configuring %s CPU architecture", architecture)
+	}
+	if rootVolumeSize := mappingScalar(compute, "rootVolumeSizeGi"); rootVolumeSize != "" {
+		appendValueChecklist(&section, depth+1, "root volume", rootVolumeSize, "Configuring root volume to %s GiB", rootVolumeSize)
+	}
+	addComputeUnitChecklist(mappingValue(compute, "reservations"), "reservations", &section, depth+1)
+	addComputeUnitChecklist(mappingValue(compute, "limits"), "limits", &section, depth+1)
+	addInstanceTypesChecklist(mappingValue(compute, "instanceTypes"), &section, depth+1)
+	appendChecklistSection(items, depth, "Configuring compute", section)
+}
+
+func addComputeUnitChecklist(unit *yaml.Node, label string, items *[]specChecklistItem, depth int) {
+	if unit == nil {
+		return
+	}
+	cpu := quantityValue(mappingValue(unit, "cpu"))
+	memory := quantityValue(mappingValue(unit, "memory"))
+	switch {
+	case cpu != "" && memory != "":
+		appendValuesChecklist(items, depth, "compute "+label, []string{cpu, memory}, "Configuring compute %s for %s CPU and %s memory", label, cpu, memory)
+	case cpu != "":
+		appendValueChecklist(items, depth, "compute "+label, cpu, "Configuring compute %s for %s CPU", label, cpu)
+	case memory != "":
+		appendValueChecklist(items, depth, "compute "+label, memory, "Configuring compute %s for %s memory", label, memory)
+	}
+}
+
+func addInstanceTypesChecklist(instanceTypes *yaml.Node, items *[]specChecklistItem, depth int) {
+	for _, node := range collectionNodes(instanceTypes) {
+		name := mappingScalar(node, "name")
+		apiParam := mappingScalar(node, "apiParam")
+		cloudProvider := strings.ToUpper(mappingScalar(node, "cloudProvider"))
+		platform := mappingScalar(node, "platform")
+		if name == "" && apiParam == "" {
+			continue
+		}
+		switch {
+		case apiParam != "" && cloudProvider != "":
+			appendChecklist(items, depth, "Configuring compute instance type parameter %s for %s", apiParam, cloudProvider)
+		case apiParam != "":
+			appendChecklist(items, depth, "Configuring compute instance type parameter %s", apiParam)
+		case name != "" && deploymentParameterName(name) != "":
+			appendValueChecklist(items, depth, "compute instance type", name, "Configuring compute instance type %s", name)
+		case cloudProvider != "" && platform != "":
+			appendValuesChecklist(items, depth, "compute instance type", []string{name, platform}, "Configuring compute instance type %s %s on %s", cloudProvider, name, platform)
+		case cloudProvider != "":
+			appendValueChecklist(items, depth, "compute instance type", name, "Configuring compute instance type %s %s", cloudProvider, name)
+		default:
+			appendValueChecklist(items, depth, "compute instance type", name, "Configuring compute instance type %s", name)
+		}
+	}
+}
+
+func addStorageChecklist(resource *yaml.Node, specType string, items *[]specChecklistItem, depth int) {
+	var section []specChecklistItem
+	var storage *yaml.Node
+	if specType == ServicePlanSpecType {
+		storage = mappingValue(resource, "storage")
+	} else {
+		storage = mappingValue(resource, "x-omnistrate-storage")
+	}
+	addStorageEntriesChecklist(storage, &section, depth+1)
+
+	if volumes := mappingValue(resource, "volumes"); volumes != nil {
+		for _, volume := range collectionNodes(volumes) {
+			if volume.Kind == yaml.ScalarNode {
+				appendValueChecklist(&section, depth+1, "volume mount", volume.Value, "Configuring volume mount %s", volume.Value)
+				continue
+			}
+			target := mappingScalar(volume, "target")
+			source := mappingScalar(volume, "source")
+			switch {
+			case source != "" && target != "":
+				appendValuesChecklist(&section, depth+1, "volume mount", []string{source, target}, "Configuring volume mount %s at %s", source, target)
+			case target != "":
+				appendValueChecklist(&section, depth+1, "volume mount", target, "Configuring volume mount at %s", target)
+			}
+			addStorageEntriesChecklist(mappingValue(volume, "x-omnistrate-storage"), &section, depth+2)
+		}
+	}
+	appendChecklistSection(items, depth, "Configuring storage", section)
+}
+
+func addStorageEntriesChecklist(storage *yaml.Node, items *[]specChecklistItem, depth int) {
+	if storage == nil {
+		return
+	}
+	for _, entry := range mappingEntries(storage) {
+		name := entry.key
+		if name == "" {
+			name = "storage"
+		}
+		appendChecklist(items, depth, "Configuring storage %s", name)
+		if entry.value.Kind == yaml.MappingNode {
+			addStorageParamsChecklist(entry.value, items, depth+1)
+			continue
+		}
+		for _, params := range collectionNodes(entry.value) {
+			addStorageParamsChecklist(params, items, depth+1)
+		}
+	}
+}
+
+func addStorageParamsChecklist(params *yaml.Node, items *[]specChecklistItem, depth int) {
+	if params == nil || params.Kind != yaml.MappingNode {
+		return
+	}
+	if size := mappingScalar(params, "instanceStorageSizeGi"); size != "" {
+		appendValueChecklist(items, depth, "storage size", size, "Configuring storage size to %s GiB", size)
+	}
+	if storageType := mappingScalar(params, "instanceStorageType"); storageType != "" {
+		appendValueChecklist(items, depth, "storage type", storageType, "Configuring storage type %s", storageType)
+	}
+	if storageTypeParam := mappingScalar(params, "instanceStorageTypeAPIParam"); storageTypeParam != "" {
+		appendChecklist(items, depth, "Configuring storage type parameter %s", storageTypeParam)
+	}
+	if sizeParam := mappingScalar(params, "instanceStorageSizeGiAPIParam"); sizeParam != "" {
+		appendChecklist(items, depth, "Configuring storage size parameter %s", sizeParam)
+	}
+}
+
+func addNetworkChecklist(resource *yaml.Node, specType string, items *[]specChecklistItem, depth int) {
+	var section []specChecklistItem
+	if ports := mappingValue(resource, "ports"); ports != nil {
+		for _, port := range collectionNodes(ports) {
+			if port.Kind == yaml.ScalarNode {
+				appendValueChecklist(&section, depth+1, "port", port.Value, "Configuring port %s", port.Value)
+				continue
+			}
+			target := mappingScalar(port, "target")
+			published := mappingScalar(port, "published")
+			switch {
+			case target != "" && published != "":
+				appendValuesChecklist(&section, depth+1, "port", []string{target, published}, "Configuring port %s as %s", target, published)
+			case target != "":
+				appendValueChecklist(&section, depth+1, "port", target, "Configuring port %s", target)
+			}
+		}
+	}
+
+	if specType == ServicePlanSpecType {
+		if network := mappingValue(resource, "network"); network != nil {
+			if ports := mappingValue(network, "ports"); ports != nil {
+				for _, port := range collectionNodes(ports) {
+					if port.Value != "" {
+						appendValueChecklist(&section, depth+1, "port", port.Value, "Configuring port %s", port.Value)
+					}
+				}
+			}
+		}
+		if endpoints := mappingValue(resource, "endpointConfiguration"); endpoints != nil {
+			for _, entry := range mappingEntries(endpoints) {
+				appendChecklist(&section, depth+1, "Configuring endpoint %s", entry.key)
+			}
+		}
+	} else if networks := mappingValue(resource, "networks"); networks != nil {
+		appendChecklist(&section, depth+1, "Configuring network attachments")
+	}
+	appendChecklistSection(items, depth, "Configuring networking", section)
+}
+
+func resourceCapabilitiesNode(resource *yaml.Node, specType string) *yaml.Node {
+	if specType == ServicePlanSpecType {
+		return mappingValue(resource, "capabilities")
+	}
+	return mappingValue(resource, "x-omnistrate-capabilities")
+}
+
+func addCapabilitiesChecklist(capabilities *yaml.Node, items *[]specChecklistItem, depth int) {
+	if capabilities == nil || capabilities.Kind != yaml.MappingNode {
+		return
+	}
+	var section []specChecklistItem
+	if mappingValue(capabilities, "autoscaling") != nil {
+		appendChecklist(&section, depth+1, "Enabling autoscaling")
+	}
+	if mappingValue(capabilities, "backupConfiguration") != nil {
+		appendChecklist(&section, depth+1, "Configuring backups")
+	}
+	if dns := mappingValue(capabilities, "customDNS"); dns != nil {
+		name := mappingScalar(dns, "Name")
+		if name == "" {
+			name = mappingScalar(dns, "name")
+		}
+		if name != "" {
+			appendValueChecklist(&section, depth+1, "custom DNS", name, "Configuring custom DNS %s", name)
+		} else {
+			appendChecklist(&section, depth+1, "Configuring custom DNS")
+		}
+	}
+	if proxy := mappingValue(capabilities, "httpReverseProxy"); proxy != nil {
+		if targetPort := mappingScalar(proxy, "targetPort"); targetPort != "" {
+			appendValueChecklist(&section, depth+1, "HTTP reverse proxy", targetPort, "Configuring HTTP reverse proxy to port %s", targetPort)
+		} else {
+			appendChecklist(&section, depth+1, "Configuring HTTP reverse proxy")
+		}
+	}
+	if mappingValue(capabilities, "serverlessConfiguration") != nil {
+		appendChecklist(&section, depth+1, "Enabling serverless configuration")
+	}
+	if boolValue(capabilities, "enableMultiZone") {
+		appendChecklist(&section, depth+1, "Enabling multi-zone placement")
+	}
+	if boolValue(capabilities, "enableCustomZone") {
+		appendChecklist(&section, depth+1, "Enabling custom zone placement")
+	}
+	if boolValue(capabilities, "enableEndpointPerReplica") {
+		appendChecklist(&section, depth+1, "Configuring endpoint per replica")
+	}
+	if networkType := mappingScalar(capabilities, "networkType"); networkType != "" {
+		appendValueChecklist(&section, depth+1, "network type", networkType, "Configuring network type %s", networkType)
+	}
+	if boolValue(capabilities, "enableStableEgressIP") {
+		appendChecklist(&section, depth+1, "Enabling stable egress IP")
+	}
+	if boolValue(capabilities, "enableClusterLoadBalancer") {
+		appendChecklist(&section, depth+1, "Enabling cluster load balancer")
+	}
+	if boolValue(capabilities, "enableNodeLoadBalancer") {
+		appendChecklist(&section, depth+1, "Enabling node load balancer")
+	}
+	if mappingValue(capabilities, "serviceAccountPolicies") != nil {
+		appendChecklist(&section, depth+1, "Configuring service account policies")
+	}
+	if mappingValue(capabilities, "nodeWarmPool") != nil {
+		appendChecklist(&section, depth+1, "Configuring node warm pool")
+	}
+	if mappingValue(capabilities, "sidecars") != nil {
+		appendChecklist(&section, depth+1, "Configuring sidecars")
+	}
+	appendChecklistSection(items, depth, "Configuring resource capabilities", section)
+}
+
+func addResourceInputsChecklist(resource *yaml.Node, specType string, items *[]specChecklistItem, depth int) {
+	var params *yaml.Node
+	if specType == ServicePlanSpecType {
+		params = mappingValue(resource, "apiParameters")
+	} else {
+		params = mappingValue(resource, "x-omnistrate-api-params")
+	}
+	var paramSection []specChecklistItem
+	for _, param := range collectionNodes(params) {
+		key := mappingScalar(param, "key")
+		if key == "" {
+			key = mappingScalar(param, "name")
+		}
+		if key == "" {
+			key = "input"
+		}
+		appendChecklist(&paramSection, depth+1, "Configuring deployment parameter %s", key)
+	}
+	appendChecklistSection(items, depth, "Configuring deployment parameters", paramSection)
+
+	if env := mappingValue(resource, "environment"); env != nil {
+		appendChecklist(items, depth, "Injecting %d environment variable(s)", collectionLen(env))
+	}
+	if env := mappingValue(resource, "environmentVariables"); env != nil {
+		appendChecklist(items, depth, "Injecting %d environment variable(s)", collectionLen(env))
+	}
+	if envFile := mappingValue(resource, "env_file"); envFile != nil {
+		appendChecklist(items, depth, "Loading environment file(s)")
+	}
+}
+
+func addResourceConfigChecklist(resource *yaml.Node, items *[]specChecklistItem, depth int) {
+	if configs := mappingValue(resource, "configs"); configs != nil {
+		appendChecklist(items, depth, "Configuring %d config item(s)", collectionLen(configs))
+	}
+	if secrets := mappingValue(resource, "secrets"); secrets != nil {
+		appendChecklist(items, depth, "Configuring %d secret item(s)", collectionLen(secrets))
+	}
+}
+
+func addResourceLifecycleChecklist(resource *yaml.Node, specType string, items *[]specChecklistItem, depth int) {
+	if mappingValue(resource, "healthcheck") != nil {
+		appendChecklist(items, depth, "Configuring health check")
+	}
+
+	var hooks *yaml.Node
+	if specType == ServicePlanSpecType {
+		hooks = mappingValue(resource, "actionHooks")
+	} else {
+		hooks = mappingValue(resource, "x-omnistrate-actionhooks")
+	}
+	for _, hook := range collectionNodes(hooks) {
+		hookType := mappingScalar(hook, "Type")
+		if hookType == "" {
+			hookType = "lifecycle"
+		}
+		appendChecklist(items, depth, "Registering %s action hook", humanizeIdentifier(hookType))
+	}
+
+	if specType == ServicePlanSpecType {
+		if mappingValue(resource, "jobResourceConfiguration") != nil {
+			appendChecklist(items, depth, "Configuring job execution")
+		}
+		if depends := mappingValue(resource, "dependsOn"); depends != nil {
+			appendChecklist(items, depth, "Linking resource dependencies")
+		}
+	} else {
+		if mappingValue(resource, "x-omnistrate-job-config") != nil {
+			appendChecklist(items, depth, "Configuring job execution")
+		}
+		if depends := mappingValue(resource, "depends_on"); depends != nil {
+			appendChecklist(items, depth, "Linking service dependencies")
+		}
+	}
+}
+
+func addResourceSecurityChecklist(resource *yaml.Node, specType string, items *[]specChecklistItem, depth int) {
+	if boolValue(resource, "privileged") {
+		appendChecklist(items, depth, "Configuring privileged access")
+	}
+	if specType == ServicePlanSpecType {
+		if boolValue(resource, "internal") {
+			appendChecklist(items, depth, "Marking resource as internal")
+		}
+		if proxyType := mappingScalar(resource, "proxyType"); proxyType != "" {
+			appendValueChecklist(items, depth, "proxy type", proxyType, "Configuring proxy type %s", proxyType)
+		}
+	} else {
+		if boolValue(resource, "x-omnistrate-mode-internal") {
+			appendChecklist(items, depth, "Marking resource as internal")
+		}
+		if proxyType := mappingScalar(resource, "x-omnistrate-proxy-type"); proxyType != "" {
+			appendValueChecklist(items, depth, "proxy type", proxyType, "Configuring proxy type %s", proxyType)
+		}
+	}
+}
+
+func appendChecklist(items *[]specChecklistItem, depth int, format string, args ...interface{}) {
+	label := fmt.Sprintf(format, args...)
+	label = strings.TrimSpace(label)
+	if label == "" {
+		return
+	}
+	*items = append(*items, specChecklistItem{Label: label, Depth: depth})
+}
+
+func appendValueChecklist(items *[]specChecklistItem, depth int, thing string, value string, fallbackFormat string, args ...interface{}) {
+	if parameter := deploymentParameterName(value); parameter != "" {
+		appendChecklist(items, depth, "Configuring %s with deployment parameter %s", thing, parameter)
+		return
+	}
+	appendChecklist(items, depth, "%s", fmt.Sprintf(fallbackFormat, args...))
+}
+
+func appendValuesChecklist(items *[]specChecklistItem, depth int, thing string, values []string, fallbackFormat string, args ...interface{}) {
+	for _, value := range values {
+		if parameter := deploymentParameterName(value); parameter != "" {
+			appendChecklist(items, depth, "Configuring %s with deployment parameter %s", thing, parameter)
+			return
+		}
+	}
+	appendChecklist(items, depth, "%s", fmt.Sprintf(fallbackFormat, args...))
+}
+
+func deploymentParameterName(value string) string {
+	matches := deploymentParameterRE.FindStringSubmatch(value)
+	if len(matches) < 2 {
+		return ""
+	}
+	return matches[1]
+}
+
+func appendChecklistSection(items *[]specChecklistItem, depth int, label string, section []specChecklistItem) {
+	if len(section) == 0 {
+		return
+	}
+	appendChecklist(items, depth, "%s", label)
+	*items = append(*items, section...)
+}
+
+func featureDisplayName(featureKey string) string {
+	name := strings.TrimSpace(featureKey)
+	if delimiter := strings.IndexAny(name, "#:"); delimiter >= 0 {
+		name = strings.TrimSpace(name[:delimiter])
+	}
+	name = strings.Join(trimAudienceTokens(name), " ")
+	return humanizeIdentifier(name)
+}
+
+func featureAudience(featureKey string, node *yaml.Node) string {
+	if audience := audienceFromText(featureKey); audience != "" {
+		return audience
+	}
+	if audience := audienceFromNode(node, 0); audience != "" {
+		return audience
+	}
+	return "customer-facing"
+}
+
+func audienceFromNode(node *yaml.Node, depth int) string {
+	if node == nil || depth > 2 {
+		return ""
+	}
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return audienceFromText(node.Value)
+	case yaml.SequenceNode:
+		for _, child := range node.Content {
+			if audience := audienceFromNode(child, depth+1); audience != "" {
+				return audience
+			}
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(node.Content); i += 2 {
+			key := strings.ToLower(strings.TrimSpace(node.Content[i].Value))
+			value := node.Content[i+1]
+			if key == "internal" {
+				if strings.EqualFold(scalarValue(value), "true") {
+					return "internal"
+				}
+				if strings.EqualFold(scalarValue(value), "false") {
+					return "customer-facing"
+				}
+			}
+			if key == "customerfacing" || key == "customer-facing" || key == "customer_facing" {
+				if strings.EqualFold(scalarValue(value), "true") {
+					return "customer-facing"
+				}
+				if strings.EqualFold(scalarValue(value), "false") {
+					return "internal"
+				}
+			}
+			if key == "audience" || key == "visibility" || key == "scope" || key == "access" || key == "mode" || key == "type" {
+				if audience := audienceFromText(scalarValue(value)); audience != "" {
+					return audience
+				}
+			}
+			if audience := audienceFromNode(value, depth+1); audience != "" {
+				return audience
+			}
+		}
+	}
+	return ""
+}
+
+func audienceFromText(value string) string {
+	for _, token := range audienceTokens(value) {
+		switch token {
+		case "INTERNAL", "PRIVATE":
+			return "internal"
+		case "CUSTOMER", "CUSTOMERFACING", "PUBLIC", "EXTERNAL":
+			return "customer-facing"
+		}
+	}
+	return ""
+}
+
+func trimAudienceTokens(value string) []string {
+	tokens := audienceTokens(value)
+	for len(tokens) > 0 && isFeatureAudienceToken(tokens[0]) {
+		tokens = tokens[1:]
+	}
+	for len(tokens) > 0 && isFeatureAudienceToken(tokens[len(tokens)-1]) {
+		tokens = tokens[:len(tokens)-1]
+	}
+	if len(tokens) == 0 {
+		return []string{value}
+	}
+	for i, token := range tokens {
+		tokens[i] = strings.ToLower(token)
+	}
+	return tokens
+}
+
+func audienceTokens(value string) []string {
+	normalized := strings.NewReplacer(
+		"#", " ",
+		":", " ",
+		"_", " ",
+		"-", " ",
+		".", " ",
+		"/", " ",
+	).Replace(strings.ToUpper(strings.TrimSpace(value)))
+	return strings.Fields(normalized)
+}
+
+func isFeatureAudienceToken(token string) bool {
+	switch token {
+	case "INTERNAL", "PRIVATE", "CUSTOMER", "CUSTOMERFACING", "FACING", "PUBLIC", "EXTERNAL":
+		return true
+	default:
+		return false
+	}
+}
+
+func dedupeSpecChecklistItems(items []specChecklistItem) []specChecklistItem {
+	seen := make(map[string]struct{}, len(items))
+	result := make([]specChecklistItem, 0, len(items))
+	for _, item := range items {
+		key := fmt.Sprintf("%d:%s", item.Depth, item.Label)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		result = append(result, item)
+	}
+	return result
+}
+
+func mappingEntries(node *yaml.Node) []struct {
+	key   string
+	value *yaml.Node
+} {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	entries := make([]struct {
+		key   string
+		value *yaml.Node
+	}, 0, len(node.Content)/2)
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		entries = append(entries, struct {
+			key   string
+			value *yaml.Node
+		}{key: strings.TrimSpace(node.Content[i].Value), value: node.Content[i+1]})
+	}
+	return entries
+}
+
+func mappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+func mappingScalar(node *yaml.Node, key string) string {
+	return scalarValue(mappingValue(node, key))
+}
+
+func scalarValue(node *yaml.Node) string {
+	if node == nil || node.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return strings.TrimSpace(node.Value)
+}
+
+func boolValue(node *yaml.Node, key string) bool {
+	value := strings.ToLower(mappingScalar(node, key))
+	return value == "true" || value == "yes" || value == "on"
+}
+
+func collectionNodes(node *yaml.Node) []*yaml.Node {
+	if node == nil {
+		return nil
+	}
+	switch node.Kind {
+	case yaml.SequenceNode:
+		return node.Content
+	case yaml.MappingNode:
+		nodes := make([]*yaml.Node, 0, len(node.Content)/2)
+		for i := 1; i < len(node.Content); i += 2 {
+			nodes = append(nodes, node.Content[i])
+		}
+		return nodes
+	default:
+		return nil
+	}
+}
+
+func collectionLen(node *yaml.Node) int {
+	if node == nil {
+		return 0
+	}
+	switch node.Kind {
+	case yaml.SequenceNode:
+		return len(node.Content)
+	case yaml.MappingNode:
+		return len(node.Content) / 2
+	default:
+		return 1
+	}
+}
+
+func quantityValue(node *yaml.Node) string {
+	if node == nil {
+		return ""
+	}
+	if node.Kind == yaml.ScalarNode {
+		return scalarValue(node)
+	}
+	if format := mappingScalar(node, "Format"); format != "" {
+		return format
+	}
+	return ""
+}
+
+func humanizeIdentifier(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	value = strings.ReplaceAll(value, "_", " ")
+	value = strings.ReplaceAll(value, "-", " ")
+	upper := strings.ToUpper(value)
+	switch upper {
+	case "OMNISTRATE DEDICATED TENANCY":
+		return "dedicated"
+	case "OMNISTRATE MULTI TENANCY":
+		return "multi-tenant"
+	}
+	parts := strings.Fields(strings.ToLower(value))
+	for i, part := range parts {
+		if part == "id" || part == "dns" || part == "api" || part == "http" || part == "tcp" {
+			parts[i] = strings.ToUpper(part)
+			continue
+		}
+		parts[i] = strings.ToUpper(part[:1]) + part[1:]
+	}
+	if len(parts) == 0 {
+		return value
+	}
+	return strings.Join(parts, " ")
+}

--- a/cmd/build/spec_checklist_test.go
+++ b/cmd/build/spec_checklist_test.go
@@ -1,0 +1,220 @@
+package build
+
+import (
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSchemaURLFromSpec_YAMLLanguageServerDirective(t *testing.T) {
+	spec := []byte(`# yaml-language-server: $schema=https://api.omnistrate.cloud/2022-09-01-00/schema/compose-spec-schema.json
+services:
+  api:
+    image: nginx
+`)
+
+	require.Equal(t, composeSpecSchemaURL, schemaURLFromSpec(spec))
+}
+
+func TestSchemaURLFromSpec_IntelliJDirective(t *testing.T) {
+	spec := []byte(`# $schema: https://api.omnistrate.cloud/2022-09-01-00/schema/service-spec-schema.json
+name: test
+services: []
+`)
+
+	require.Equal(t, serviceSpecSchemaURL, schemaURLFromSpec(spec))
+}
+
+func TestBuildSpecChecklist_ComposeSpecUsesPlatformActions(t *testing.T) {
+	spec := []byte(`# yaml-language-server: $schema=https://api.omnistrate.cloud/2022-09-01-00/schema/compose-spec-schema.json
+x-omnistrate-service-plan:
+  name: dev
+  tenancyType: OMNISTRATE_DEDICATED_TENANCY
+  features:
+    dashboard: {}
+    metrics#INTERNAL: {}
+services:
+  api:
+    image: nginx:latest
+    ports:
+      - "8080:80"
+    volumes:
+      - source: api-data
+        target: /data
+        x-omnistrate-storage:
+          aws:
+            instanceStorageType: AWS::EBS_GP3
+            instanceStorageSizeGi: 100
+    x-omnistrate-compute:
+      replicaCount: 2
+    x-omnistrate-capabilities:
+      autoscaling:
+        minReplicas:
+          Type: 0
+          IntVal: 1
+          StrVal: "1"
+`)
+
+	items, err := buildSpecChecklist(spec, DockerComposeSpecType)
+
+	require.NoError(t, err)
+	labels := specChecklistLabels(items)
+	require.Contains(t, labels, "Resolving plan dev")
+	require.Contains(t, labels, "Setting tenancy to dedicated")
+	require.Contains(t, labels, "Enabling Dashboard feature (customer-facing)")
+	require.Contains(t, labels, "Enabling Metrics feature (internal)")
+	require.Contains(t, labels, "Preparing resource api")
+	require.Contains(t, labels, "Configuring container image nginx:latest")
+	require.Contains(t, labels, "Configuring networking")
+	require.Contains(t, labels, "Configuring port 8080:80")
+	require.Contains(t, labels, "Configuring compute")
+	require.Contains(t, labels, "Configuring replica count to 2")
+	require.Contains(t, labels, "Configuring storage")
+	require.Contains(t, labels, "Configuring storage aws")
+	require.Contains(t, labels, "Enabling autoscaling")
+}
+
+func TestBuildSpecChecklist_ServicePlanSpecShowsDeploymentAccountsAndResources(t *testing.T) {
+	spec := []byte(`# yaml-language-server: $schema=https://api.omnistrate.cloud/2022-09-01-00/schema/service-spec-schema.json
+name: dev
+deployment:
+  hostedDeployment:
+    AwsAccountId: "123"
+features:
+  audit:
+    audience: internal
+services:
+  - name: redis
+    helmChartConfiguration:
+      chartName: redis
+      chartVersion: 1.0.0
+      chartRepoName: bitnami
+      chartRepoURL: https://charts.bitnami.com/bitnami
+    compute:
+      replicaCount: 1
+      instanceTypes:
+        - apiParam: instanceType
+          cloudProvider: aws
+    apiParameters:
+      - key: password
+        name: Password
+`)
+
+	items, err := buildSpecChecklist(spec, ServicePlanSpecType)
+
+	require.NoError(t, err)
+	labels := specChecklistLabels(items)
+	require.Contains(t, labels, "Resolving plan dev")
+	require.Contains(t, labels, "Configuring hosted deployment")
+	require.Contains(t, labels, "Connecting AWS account 123")
+	require.Contains(t, labels, "Enabling Audit feature (internal)")
+	require.Contains(t, labels, "Preparing resource redis")
+	require.Contains(t, labels, "Configuring Helm chart redis 1.0.0")
+	require.Contains(t, labels, "Configuring compute")
+	require.Contains(t, labels, "Configuring replica count to 1")
+	require.Contains(t, labels, "Configuring compute instance type parameter instanceType for AWS")
+	require.Contains(t, labels, "Configuring deployment parameters")
+	require.Contains(t, labels, "Configuring deployment parameter password")
+	requireResourceSubItems(t, items, "Preparing resource redis")
+}
+
+func TestBuildSpecChecklist_DistributionExtensionStartsChecklistAndReplacesDeploymentModel(t *testing.T) {
+	spec := []byte(`# yaml-language-server: $schema=https://api.omnistrate.cloud/2022-09-01-00/schema/service-spec-schema.json
+name: dev
+deployment:
+  byoaDeployment:
+    AwsAccountId: "123"
+services: []
+`)
+
+	items, err := buildSpecChecklistWithOptions(spec, ServicePlanSpecType, specChecklistOptions{extendDistribution: true})
+
+	require.NoError(t, err)
+	require.NotEmpty(t, items)
+	require.Equal(t, "Extending distribution to BYOA deployment model", items[0].Label)
+	labels := specChecklistLabels(items)
+	require.Contains(t, labels, "Connecting AWS account 123")
+	require.NotContains(t, labels, "Configuring BYOA deployment")
+}
+
+func TestBuildSpecChecklist_FormatsVarReferencesAsDeploymentParameters(t *testing.T) {
+	spec := []byte(`# yaml-language-server: $schema=https://api.omnistrate.cloud/2022-09-01-00/schema/service-spec-schema.json
+name: parametrized
+services:
+  - name: api
+    image: repo:$var.imageTag
+    helmChartConfiguration:
+      chartName: redis
+      chartVersion: $var.chartVersion
+    compute:
+      replicaCount: $var.replicaCount
+      rootVolumeSizeGi: $var.rootVolumeSize
+      instanceTypes:
+        - name: $var.instanceType
+          cloudProvider: aws
+    storage:
+      data:
+        instanceStorageSizeGi: $var.storageSize
+        instanceStorageType: $var.storageType
+    network:
+      ports:
+        - $var.port
+    capabilities:
+      httpReverseProxy:
+        targetPort: $var.proxyPort
+`)
+
+	items, err := buildSpecChecklist(spec, ServicePlanSpecType)
+
+	require.NoError(t, err)
+	labels := specChecklistLabels(items)
+	require.Contains(t, labels, "Configuring container image with deployment parameter imageTag")
+	require.Contains(t, labels, "Configuring Helm chart with deployment parameter chartVersion")
+	require.Contains(t, labels, "Configuring replica count with deployment parameter replicaCount")
+	require.Contains(t, labels, "Configuring root volume with deployment parameter rootVolumeSize")
+	require.Contains(t, labels, "Configuring compute instance type with deployment parameter instanceType")
+	require.Contains(t, labels, "Configuring storage size with deployment parameter storageSize")
+	require.Contains(t, labels, "Configuring storage type with deployment parameter storageType")
+	require.Contains(t, labels, "Configuring port with deployment parameter port")
+	require.Contains(t, labels, "Configuring HTTP reverse proxy with deployment parameter proxyPort")
+}
+
+func TestIsAllowedSpecSchemaURL(t *testing.T) {
+	require.True(t, isAllowedSpecSchemaURL(composeSpecSchemaURL))
+	require.True(t, isAllowedSpecSchemaURL(serviceSpecSchemaURL))
+	require.False(t, isAllowedSpecSchemaURL("https://example.com/schema.json"))
+}
+
+func TestRandomChecklistDelayDoesNotExceedMaximum(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		delay := randomChecklistDelay()
+		require.Greater(t, delay, time.Duration(0))
+		require.LessOrEqual(t, delay, time.Duration(maxChecklistDelayMillis)*time.Millisecond)
+	}
+}
+
+func specChecklistLabels(items []specChecklistItem) []string {
+	labels := make([]string, 0, len(items))
+	for _, item := range items {
+		labels = append(labels, strings.TrimSpace(item.Label))
+	}
+	sort.Strings(labels)
+	return labels
+}
+
+func requireResourceSubItems(t *testing.T, items []specChecklistItem, resourceLabel string) {
+	t.Helper()
+	resourceIndex := -1
+	for i, item := range items {
+		if item.Label == resourceLabel {
+			resourceIndex = i
+			break
+		}
+	}
+	require.NotEqual(t, -1, resourceIndex)
+	require.Greater(t, len(items), resourceIndex+1)
+	require.Greater(t, items[resourceIndex+1].Depth, items[resourceIndex].Depth)
+}

--- a/cmd/build/utils.go
+++ b/cmd/build/utils.go
@@ -332,6 +332,25 @@ type ServiceHierarchyResult struct {
 	ArtifactUploadingTasks []ArtifactUploadingTask
 }
 
+func shouldCheckDistributionExtension(result *ServiceHierarchyResult) bool {
+	return result != nil && result.IsNewProductTier && result.ServiceID != "" && result.EnvironmentID != ""
+}
+
+func shouldExtendDistributionToNewDeploymentModel(isNewProductTier bool, servicePlanCount int) bool {
+	return isNewProductTier && servicePlanCount > 1
+}
+
+func serviceHasAdditionalPlans(ctx context.Context, token, serviceID, environmentID string) (bool, error) {
+	if serviceID == "" || environmentID == "" {
+		return false, nil
+	}
+	servicePlans, err := dataaccess.ListServicePlans(ctx, token, serviceID, environmentID)
+	if err != nil {
+		return false, err
+	}
+	return shouldExtendDistributionToNewDeploymentModel(true, len(servicePlans.GetServicePlans())), nil
+}
+
 // ArtifactUploadingTask represents a single artifact upload task returned by the prepare API.
 // It contains all the server-side resolved parameters needed to call the upload artifact API.
 type ArtifactUploadingTask struct {

--- a/cmd/build/utils_test.go
+++ b/cmd/build/utils_test.go
@@ -141,6 +141,20 @@ func TestUniqueArtifactPathsFromTasks_SinglePath(t *testing.T) {
 	assert.Equal(t, "/only/path", paths[0])
 }
 
+func TestShouldCheckDistributionExtension(t *testing.T) {
+	require.False(t, shouldCheckDistributionExtension(nil))
+	require.False(t, shouldCheckDistributionExtension(&ServiceHierarchyResult{IsNewProductTier: false, ServiceID: "svc", EnvironmentID: "env"}))
+	require.False(t, shouldCheckDistributionExtension(&ServiceHierarchyResult{IsNewProductTier: true, ServiceID: "", EnvironmentID: "env"}))
+	require.False(t, shouldCheckDistributionExtension(&ServiceHierarchyResult{IsNewProductTier: true, ServiceID: "svc", EnvironmentID: ""}))
+	require.True(t, shouldCheckDistributionExtension(&ServiceHierarchyResult{IsNewProductTier: true, ServiceID: "svc", EnvironmentID: "env"}))
+}
+
+func TestShouldExtendDistributionToNewDeploymentModel(t *testing.T) {
+	require.False(t, shouldExtendDistributionToNewDeploymentModel(false, 2))
+	require.False(t, shouldExtendDistributionToNewDeploymentModel(true, 1))
+	require.True(t, shouldExtendDistributionToNewDeploymentModel(true, 2))
+}
+
 func TestArchiveArtifactPaths_CreatesBase64Archive(t *testing.T) {
 	// Create a temporary source directory with some files
 	sourceDir, err := os.MkdirTemp("", "test-source-*")

--- a/cmd/common/token_test.go
+++ b/cmd/common/token_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mitchellh/go-homedir"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
 	"github.com/stretchr/testify/assert"
 )
@@ -62,6 +63,7 @@ func TestAPIKeyEnvConst(t *testing.T) {
 // exists and OMNISTRATE_API_KEY is set, GetTokenWithLogin attempts a
 // signin-exchange rather than falling through to RunLogin (interactive).
 func TestGetTokenWithLoginUsesEnvVar(t *testing.T) {
+	isolateHome(t)
 	t.Setenv("OMNISTRATE_API_KEY", "om_test_env_key")
 	t.Setenv("OMNISTRATE_DRY_RUN", "true")
 
@@ -82,11 +84,9 @@ func TestGetTokenWithLoginUsesEnvVar(t *testing.T) {
 // no OMNISTRATE_API_KEY, and stdin is not a terminal, GetTokenWithLogin
 // returns a clear error instead of attempting an interactive login prompt.
 func TestGetTokenWithLoginNonTTY(t *testing.T) {
+	isolateHome(t)
 	// Ensure no API key is set so we fall through to the TTY check.
 	t.Setenv("OMNISTRATE_API_KEY", "")
-
-	// Point HOME to a temp dir so no existing config/token is found.
-	t.Setenv("HOME", t.TempDir())
 
 	// Swap os.Stdin with a pipe (not a terminal).
 	origStdin := os.Stdin
@@ -103,4 +103,12 @@ func TestGetTokenWithLoginNonTTY(t *testing.T) {
 	assert.Empty(t, token)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no TTY available for interactive login")
+}
+
+func isolateHome(t *testing.T) {
+	t.Helper()
+
+	t.Setenv("HOME", t.TempDir())
+	homedir.Reset()
+	t.Cleanup(homedir.Reset)
 }

--- a/cmd/customer/create.go
+++ b/cmd/customer/create.go
@@ -1,0 +1,137 @@
+package customer
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+const createExample = `# Create a customer portal user
+omnistrate-ctl customer create --email user@example.com --name "Jane Doe" --password "$PASSWORD" --legal-company-name "Example Inc"
+
+# Create a customer portal user and auto-verify the account
+omnistrate-ctl customer create --email user@example.com --name "Jane Doe" --password "$PASSWORD" --legal-company-name "Example Inc" --auto-verify
+
+# Create a customer portal user with the password read from stdin
+echo "$PASSWORD" | omnistrate-ctl customer create --email user@example.com --name "Jane Doe" --password-stdin --legal-company-name "Example Inc"`
+
+var createCmd = &cobra.Command{
+	Use:          "create [flags]",
+	Short:        "Create a customer portal user",
+	Long:         "This command creates a customer portal user.",
+	Example:      createExample,
+	RunE:         runCreate,
+	SilenceUsage: true,
+}
+
+func init() {
+	createCmd.Flags().String("email", "", "Customer user email")
+	createCmd.Flags().String("name", "", "Customer user name")
+	createCmd.Flags().String("password", "", "Customer user password")
+	createCmd.Flags().Bool("password-stdin", false, "Reads the customer user password from stdin")
+	createCmd.Flags().String("legal-company-name", "", "Customer legal company name")
+	createCmd.Flags().String("company-url", "", "Customer company URL")
+	createCmd.Flags().Bool("auto-verify", false, "Enable automatic verification for the customer user")
+	createCmd.Flags().StringArray("attribute", []string{}, "Customer user attribute in key=value format. Can be repeated or comma-separated")
+	_ = createCmd.MarkFlagRequired("email")
+	_ = createCmd.MarkFlagRequired("name")
+	_ = createCmd.MarkFlagRequired("legal-company-name")
+	createCmd.MarkFlagsMutuallyExclusive("password", "password-stdin")
+	createCmd.MarkFlagsOneRequired("password", "password-stdin")
+}
+
+func runCreate(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	email, _ := cmd.Flags().GetString("email")
+	name, _ := cmd.Flags().GetString("name")
+	password, err := customerCreatePassword(cmd, os.Stdin, customerInputIsTerminal(os.Stdin))
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+	legalCompanyName, _ := cmd.Flags().GetString("legal-company-name")
+	companyURL, _ := cmd.Flags().GetString("company-url")
+	autoVerify, _ := cmd.Flags().GetBool("auto-verify")
+	attributeValues, _ := cmd.Flags().GetStringArray("attribute")
+
+	attributes, err := parseAttributes(attributeValues)
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+	if err = utils.ValidateEmail(strings.TrimSpace(email)); err != nil {
+		err = fmt.Errorf("invalid --email value: %w", err)
+		utils.PrintError(err)
+		return err
+	}
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	userID, err := dataaccess.CreateCustomerUser(
+		cmd.Context(),
+		token,
+		dataaccess.NewCustomerUserCreateRequest(
+			strings.TrimSpace(email),
+			strings.TrimSpace(name),
+			password,
+			strings.TrimSpace(legalCompanyName),
+			strings.TrimSpace(companyURL),
+			autoVerify,
+			attributes,
+		),
+	)
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	fmt.Printf("Successfully created customer user %s\n", userID)
+	return nil
+}
+
+func customerCreatePassword(cmd *cobra.Command, stdin io.Reader, stdinIsTerminal bool) (string, error) {
+	password, _ := cmd.Flags().GetString("password")
+	passwordStdin, _ := cmd.Flags().GetBool("password-stdin")
+	if strings.TrimSpace(password) != "" && passwordStdin {
+		return "", fmt.Errorf("--password and --password-stdin are mutually exclusive")
+	}
+
+	if passwordStdin {
+		if stdinIsTerminal {
+			return "", fmt.Errorf("--password-stdin requires piped or redirected input; for example: printf '%%s\\n' \"$PASSWORD\" | omnistrate-ctl customer create --email user@example.com --name \"Jane Doe\" --legal-company-name \"Example Inc\" --password-stdin")
+		}
+
+		passwordFromStdin, err := io.ReadAll(stdin)
+		if err != nil {
+			return "", err
+		}
+		password = string(passwordFromStdin)
+	}
+
+	password = strings.TrimSpace(password)
+	if password == "" {
+		return "", fmt.Errorf("must provide a non-empty password via --password or --password-stdin")
+	}
+
+	return password, nil
+}
+
+func customerInputIsTerminal(file *os.File) bool {
+	info, err := file.Stat()
+	if err != nil {
+		return false
+	}
+	return (info.Mode() & os.ModeCharDevice) != 0
+}

--- a/cmd/customer/customer.go
+++ b/cmd/customer/customer.go
@@ -1,0 +1,105 @@
+package customer
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/model"
+	"github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
+	"github.com/spf13/cobra"
+)
+
+var Cmd = &cobra.Command{
+	Use:          "customer [operation] [flags]",
+	Short:        "Manage customer portal users",
+	Long:         "This command helps ISVs manage customer portal users.",
+	Run:          runCustomer,
+	SilenceUsage: true,
+}
+
+func init() {
+	Cmd.AddCommand(createCmd)
+	Cmd.AddCommand(listCmd)
+	Cmd.AddCommand(describeCmd)
+	Cmd.AddCommand(updateCmd)
+	Cmd.AddCommand(verifyCmd)
+	Cmd.AddCommand(suspendCmd)
+	Cmd.AddCommand(unsuspendCmd)
+	Cmd.AddCommand(deleteCmd)
+}
+
+func runCustomer(cmd *cobra.Command, args []string) {
+	_ = cmd.Help()
+}
+
+func parseAttributes(values []string) (map[string]string, error) {
+	attributes := make(map[string]string)
+	for _, value := range values {
+		for _, pair := range strings.Split(value, ",") {
+			pair = strings.TrimSpace(pair)
+			if pair == "" {
+				continue
+			}
+			key, val, ok := strings.Cut(pair, "=")
+			if !ok || strings.TrimSpace(key) == "" {
+				return nil, fmt.Errorf("invalid attribute %q. Attributes must use key=value format", pair)
+			}
+			attributes[strings.TrimSpace(key)] = strings.TrimSpace(val)
+		}
+	}
+	return attributes, nil
+}
+
+func formatUser(user fleet.AccessSideUser) model.CustomerUser {
+	return model.CustomerUser{
+		UserID:            stringValue(user.UserId),
+		UserName:          stringValue(user.UserName),
+		Email:             stringValue(user.Email),
+		Status:            stringValue(user.Status),
+		Enabled:           formatOptionalBool(user.Enabled),
+		OrgID:             stringValue(user.OrgId),
+		OrgName:           stringValue(user.OrgName),
+		SubscriptionCount: formatOptionalInt64(user.SubscriptionCount),
+		InstanceCount:     formatOptionalInt64(user.InstanceCount),
+		CreatedAt:         stringValue(user.CreatedAt),
+	}
+}
+
+func formatDescribeUser(user *fleet.FleetDescribeUserResult) model.CustomerUser {
+	if user == nil {
+		return model.CustomerUser{}
+	}
+
+	return model.CustomerUser{
+		UserID:    stringValue(user.UserId),
+		UserName:  stringValue(user.UserName),
+		Email:     stringValue(user.Email),
+		Status:    stringValue(user.Status),
+		Enabled:   formatOptionalBool(user.Enabled),
+		OrgID:     stringValue(user.OrgId),
+		OrgName:   stringValue(user.OrgName),
+		CreatedAt: stringValue(user.CreatedAt),
+	}
+}
+
+func stringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func formatOptionalBool(value *bool) string {
+	if value == nil {
+		return ""
+	}
+	return strconv.FormatBool(*value)
+}
+
+func formatOptionalInt64(value *int64) string {
+	if value == nil {
+		return ""
+	}
+	return strconv.FormatInt(*value, 10)
+}

--- a/cmd/customer/customer_test.go
+++ b/cmd/customer/customer_test.go
@@ -1,0 +1,207 @@
+package customer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomerCommands(t *testing.T) {
+	require.Equal(t, "customer [operation] [flags]", Cmd.Use)
+	require.Contains(t, Cmd.Short, "customer portal users")
+
+	expectedCommands := []string{"create", "list", "describe", "update", "verify", "suspend", "unsuspend", "delete"}
+	actualCommands := make([]string, 0, len(Cmd.Commands()))
+	for _, command := range Cmd.Commands() {
+		actualCommands = append(actualCommands, command.Name())
+	}
+
+	require.ElementsMatch(t, expectedCommands, actualCommands)
+}
+
+func TestCustomerCommandFlags(t *testing.T) {
+	require.NotNil(t, createCmd.Flag("email"))
+	require.NotNil(t, createCmd.Flag("name"))
+	require.NotNil(t, createCmd.Flag("password"))
+	require.NotNil(t, createCmd.Flag("password-stdin"))
+	require.NotNil(t, createCmd.Flag("legal-company-name"))
+	require.NotNil(t, createCmd.Flag("company-url"))
+	require.NotNil(t, createCmd.Flag("auto-verify"))
+	require.NotNil(t, createCmd.Flag("attribute"))
+
+	require.NotNil(t, listCmd.Flag("next-page-token"))
+	require.NotNil(t, listCmd.Flag("page-size"))
+	require.NotNil(t, listCmd.Flag("exclude-stats"))
+
+	require.NotNil(t, describeCmd.Flag("user-id"))
+	require.NotNil(t, updateCmd.Flag("user-id"))
+	require.NotNil(t, updateCmd.Flag("attribute"))
+	require.NotNil(t, verifyCmd.Flag("user-id"))
+	require.NotNil(t, suspendCmd.Flag("user-id"))
+	require.NotNil(t, unsuspendCmd.Flag("user-id"))
+	require.NotNil(t, deleteCmd.Flag("user-id"))
+}
+
+func TestCustomerCommandsDoNotAskForService(t *testing.T) {
+	for _, cmd := range []*cobra.Command{createCmd, listCmd, describeCmd, updateCmd, verifyCmd, suspendCmd, unsuspendCmd, deleteCmd} {
+		require.Nil(t, cmd.Flag("service"), cmd.Name())
+		require.NotContains(t, cmd.Example, "--service", cmd.Name())
+		require.NotContains(t, cmd.Long, "service", cmd.Name())
+	}
+}
+
+func TestCreateExamplesMentionPasswordStdinAndAutoVerify(t *testing.T) {
+	require.Contains(t, createExample, "--password-stdin")
+	require.Contains(t, createExample, "--auto-verify")
+}
+
+func TestCustomerCreatePassword(t *testing.T) {
+	tests := []struct {
+		name          string
+		password      string
+		passwordStdin bool
+		stdin         string
+		stdinTerminal bool
+		want          string
+		wantErr       string
+	}{
+		{
+			name:     "password flag",
+			password: "  secret  ",
+			want:     "secret",
+		},
+		{
+			name:          "stdin password",
+			passwordStdin: true,
+			stdin:         "  secret\n",
+			want:          "secret",
+		},
+		{
+			name:          "mutually exclusive",
+			password:      "secret",
+			passwordStdin: true,
+			stdin:         "other",
+			wantErr:       "mutually exclusive",
+		},
+		{
+			name:          "empty stdin",
+			passwordStdin: true,
+			stdin:         "\n",
+			wantErr:       "non-empty password",
+		},
+		{
+			name:          "terminal stdin",
+			passwordStdin: true,
+			stdinTerminal: true,
+			wantErr:       "requires piped or redirected input",
+		},
+		{
+			name:    "missing",
+			wantErr: "non-empty password",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newCustomerCreatePasswordTestCommand(t)
+			if tt.password != "" {
+				require.NoError(t, cmd.Flags().Set("password", tt.password))
+			}
+			if tt.passwordStdin {
+				require.NoError(t, cmd.Flags().Set("password-stdin", "true"))
+			}
+
+			got, err := customerCreatePassword(cmd, strings.NewReader(tt.stdin), tt.stdinTerminal)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func newCustomerCreatePasswordTestCommand(t *testing.T) *cobra.Command {
+	t.Helper()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("password", "", "")
+	cmd.Flags().Bool("password-stdin", false, "")
+	return cmd
+}
+
+func TestParseAttributes(t *testing.T) {
+	tests := []struct {
+		name    string
+		values  []string
+		want    map[string]string
+		wantErr string
+	}{
+		{
+			name:   "empty",
+			values: []string{},
+			want:   map[string]string{},
+		},
+		{
+			name:   "repeated and comma separated",
+			values: []string{"tier=enterprise", "region=us-west-2, owner = platform "},
+			want: map[string]string{
+				"tier":   "enterprise",
+				"region": "us-west-2",
+				"owner":  "platform",
+			},
+		},
+		{
+			name:    "invalid",
+			values:  []string{"missing-equals"},
+			wantErr: "Attributes must use key=value format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseAttributes(tt.values)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFormatUser(t *testing.T) {
+	enabled := true
+	subscriptionCount := int64(2)
+	instanceCount := int64(3)
+
+	got := formatUser(fleet.AccessSideUser{
+		UserId:            stringPointer("user-1"),
+		UserName:          stringPointer("Jane Doe"),
+		Email:             stringPointer("jane@example.com"),
+		Status:            stringPointer("ACTIVE"),
+		Enabled:           &enabled,
+		OrgId:             stringPointer("org-1"),
+		OrgName:           stringPointer("Example"),
+		SubscriptionCount: &subscriptionCount,
+		InstanceCount:     &instanceCount,
+		CreatedAt:         stringPointer("2026-01-01T00:00:00Z"),
+	})
+
+	require.Equal(t, "user-1", got.UserID)
+	require.Equal(t, "Jane Doe", got.UserName)
+	require.Equal(t, "jane@example.com", got.Email)
+	require.Equal(t, "ACTIVE", got.Status)
+	require.Equal(t, "true", got.Enabled)
+	require.Equal(t, "2", got.SubscriptionCount)
+	require.Equal(t, "3", got.InstanceCount)
+}
+
+func stringPointer(value string) *string {
+	return &value
+}

--- a/cmd/customer/delete.go
+++ b/cmd/customer/delete.go
@@ -1,0 +1,48 @@
+package customer
+
+import (
+	"fmt"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+const deleteExample = `# Delete a customer portal user
+omnistrate-ctl customer delete --user-id user-123`
+
+var deleteCmd = &cobra.Command{
+	Use:          "delete [flags]",
+	Short:        "Delete a customer portal user",
+	Long:         "This command deletes a customer portal user.",
+	Example:      deleteExample,
+	RunE:         runDelete,
+	SilenceUsage: true,
+}
+
+func init() {
+	deleteCmd.Flags().String("user-id", "", "Customer user ID")
+	_ = deleteCmd.MarkFlagRequired("user-id")
+}
+
+func runDelete(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	userID, _ := cmd.Flags().GetString("user-id")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	if err = dataaccess.DeleteCustomerUser(cmd.Context(), token, userID); err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	fmt.Printf("Successfully deleted customer user %s\n", userID)
+	return nil
+}

--- a/cmd/customer/describe.go
+++ b/cmd/customer/describe.go
@@ -1,0 +1,52 @@
+package customer
+
+import (
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+const describeExample = `# Describe a customer portal user
+omnistrate-ctl customer describe --user-id user-123`
+
+var describeCmd = &cobra.Command{
+	Use:          "describe [flags]",
+	Short:        "Describe a customer portal user",
+	Long:         "This command describes a customer portal user.",
+	Example:      describeExample,
+	RunE:         runDescribe,
+	SilenceUsage: true,
+}
+
+func init() {
+	describeCmd.Flags().String("user-id", "", "Customer user ID")
+	_ = describeCmd.MarkFlagRequired("user-id")
+}
+
+func runDescribe(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	output, _ := cmd.Flags().GetString("output")
+	userID, _ := cmd.Flags().GetString("user-id")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	result, err := dataaccess.DescribeCustomerUser(cmd.Context(), token, userID)
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	if err = utils.PrintTextTableJsonOutput(output, formatDescribeUser(result)); err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	return nil
+}

--- a/cmd/customer/list.go
+++ b/cmd/customer/list.go
@@ -1,0 +1,88 @@
+package customer
+
+import (
+	"fmt"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/model"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+const listExample = `# List customer portal users
+omnistrate-ctl customer list
+
+# List customer portal users as JSON
+omnistrate-ctl customer list --output json`
+
+var listCmd = &cobra.Command{
+	Use:          "list [flags]",
+	Short:        "List customer portal users",
+	Long:         "This command lists customer portal users.",
+	Example:      listExample,
+	RunE:         runList,
+	SilenceUsage: true,
+}
+
+func init() {
+	listCmd.Flags().String("next-page-token", "", "Token for the next page of results")
+	listCmd.Flags().Int64("page-size", 0, "Number of users to return per page")
+	listCmd.Flags().Bool("exclude-stats", false, "Exclude user statistics from the response")
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	output, _ := cmd.Flags().GetString("output")
+	nextPageToken, _ := cmd.Flags().GetString("next-page-token")
+	pageSize, _ := cmd.Flags().GetInt64("page-size")
+	excludeStats, _ := cmd.Flags().GetBool("exclude-stats")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	var sm utils.SpinnerManager
+	var spinner *utils.Spinner
+	if output != "json" {
+		sm = utils.NewSpinnerManager()
+		spinner = sm.AddSpinner("Listing customer users...")
+		sm.Start()
+	}
+
+	result, err := dataaccess.ListCustomerUsers(cmd.Context(), token, dataaccess.CustomerUserListOptions{
+		NextPageToken: nextPageToken,
+		PageSize:      pageSize,
+		ExcludeStats:  excludeStats,
+	})
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+
+	users := make([]model.CustomerUser, 0, len(result.Users))
+	for _, user := range result.Users {
+		users = append(users, formatUser(user))
+	}
+
+	if len(users) == 0 {
+		utils.HandleSpinnerSuccess(spinner, sm, "No customer users found")
+	} else {
+		utils.HandleSpinnerSuccess(spinner, sm, fmt.Sprintf("Found %d customer user(s)", len(users)))
+	}
+
+	if err = utils.PrintTextTableJsonArrayOutput(output, users); err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	if result.NextPageToken != nil && *result.NextPageToken != "" && output != "json" {
+		fmt.Printf("Next page token: %s\n", *result.NextPageToken)
+	}
+
+	return nil
+}

--- a/cmd/customer/suspend.go
+++ b/cmd/customer/suspend.go
@@ -1,0 +1,48 @@
+package customer
+
+import (
+	"fmt"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+const suspendExample = `# Suspend a customer portal user
+omnistrate-ctl customer suspend --user-id user-123`
+
+var suspendCmd = &cobra.Command{
+	Use:          "suspend [flags]",
+	Short:        "Suspend a customer portal user",
+	Long:         "This command suspends a customer portal user.",
+	Example:      suspendExample,
+	RunE:         runSuspend,
+	SilenceUsage: true,
+}
+
+func init() {
+	suspendCmd.Flags().String("user-id", "", "Customer user ID")
+	_ = suspendCmd.MarkFlagRequired("user-id")
+}
+
+func runSuspend(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	userID, _ := cmd.Flags().GetString("user-id")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	if err = dataaccess.SuspendCustomerUser(cmd.Context(), token, userID); err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	fmt.Printf("Successfully suspended customer user %s\n", userID)
+	return nil
+}

--- a/cmd/customer/unsuspend.go
+++ b/cmd/customer/unsuspend.go
@@ -1,0 +1,48 @@
+package customer
+
+import (
+	"fmt"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+const unsuspendExample = `# Unsuspend a customer portal user
+omnistrate-ctl customer unsuspend --user-id user-123`
+
+var unsuspendCmd = &cobra.Command{
+	Use:          "unsuspend [flags]",
+	Short:        "Unsuspend a customer portal user",
+	Long:         "This command unsuspends a customer portal user.",
+	Example:      unsuspendExample,
+	RunE:         runUnsuspend,
+	SilenceUsage: true,
+}
+
+func init() {
+	unsuspendCmd.Flags().String("user-id", "", "Customer user ID")
+	_ = unsuspendCmd.MarkFlagRequired("user-id")
+}
+
+func runUnsuspend(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	userID, _ := cmd.Flags().GetString("user-id")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	if err = dataaccess.UnsuspendCustomerUser(cmd.Context(), token, userID); err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	fmt.Printf("Successfully unsuspended customer user %s\n", userID)
+	return nil
+}

--- a/cmd/customer/update.go
+++ b/cmd/customer/update.go
@@ -1,0 +1,61 @@
+package customer
+
+import (
+	"fmt"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+const updateExample = `# Update attributes on a customer portal user
+omnistrate-ctl customer update --user-id user-123 --attribute plan=enterprise --attribute region=us-west-2`
+
+var updateCmd = &cobra.Command{
+	Use:          "update [flags]",
+	Short:        "Update a customer portal user",
+	Long:         "This command updates customer portal user attributes.",
+	Example:      updateExample,
+	RunE:         runUpdate,
+	SilenceUsage: true,
+}
+
+func init() {
+	updateCmd.Flags().String("user-id", "", "Customer user ID")
+	updateCmd.Flags().StringArray("attribute", []string{}, "Customer user attribute in key=value format. Can be repeated or comma-separated")
+	_ = updateCmd.MarkFlagRequired("user-id")
+}
+
+func runUpdate(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	userID, _ := cmd.Flags().GetString("user-id")
+	attributeValues, _ := cmd.Flags().GetStringArray("attribute")
+
+	attributes, err := parseAttributes(attributeValues)
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+	if len(attributes) == 0 {
+		err = fmt.Errorf("at least one --attribute is required")
+		utils.PrintError(err)
+		return err
+	}
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	if err = dataaccess.UpdateCustomerUser(cmd.Context(), token, userID, dataaccess.CustomerUserUpdateRequest{Attributes: attributes}); err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	fmt.Printf("Successfully updated customer user %s\n", userID)
+	return nil
+}

--- a/cmd/customer/verify.go
+++ b/cmd/customer/verify.go
@@ -1,0 +1,48 @@
+package customer
+
+import (
+	"fmt"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+const verifyExample = `# Send a verification email to a customer portal user
+omnistrate-ctl customer verify --user-id user-123`
+
+var verifyCmd = &cobra.Command{
+	Use:          "verify [flags]",
+	Short:        "Send a customer portal user verification email",
+	Long:         "This command sends a verification email to a customer portal user.",
+	Example:      verifyExample,
+	RunE:         runVerify,
+	SilenceUsage: true,
+}
+
+func init() {
+	verifyCmd.Flags().String("user-id", "", "Customer user ID")
+	_ = verifyCmd.MarkFlagRequired("user-id")
+}
+
+func runVerify(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	userID, _ := cmd.Flags().GetString("user-id")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	if err = dataaccess.SendCustomerUserVerificationEmail(cmd.Context(), token, userID); err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	fmt.Printf("Successfully sent verification email to customer user %s\n", userID)
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ import (
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/auth/revoke"
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/build"
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/cost"
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/customer"
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/customnetwork"
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/deploy"
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/deploymentcell"
@@ -145,6 +146,7 @@ func init() {
 	RootCmd.AddCommand(secret.Cmd)
 	RootCmd.AddCommand(workflow.Cmd)
 	RootCmd.AddCommand(cost.Cmd)
+	RootCmd.AddCommand(customer.Cmd)
 	RootCmd.AddCommand(operations.Cmd)
 	RootCmd.AddCommand(audit.Cmd)
 	RootCmd.AddCommand(mcp.Cmd)

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/serviceplan"
 	"github.com/spf13/cobra"
 )
 
@@ -17,6 +18,7 @@ func init() {
 	Cmd.AddCommand(describeCmd)
 	Cmd.AddCommand(deleteCmd)
 	Cmd.AddCommand(listCmd)
+	Cmd.AddCommand(serviceplan.NewNestedCommand())
 }
 
 func run(cmd *cobra.Command, args []string) {

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestServicePlanNestedCommandRegistered(t *testing.T) {
+	planCmd, _, err := Cmd.Find([]string{"plan"})
+
+	require.NoError(t, err)
+	require.NotNil(t, planCmd)
+	require.Equal(t, "plan", planCmd.Name())
+
+	expected := []string{
+		"delete",
+		"describe",
+		"describe-version",
+		"disable-feature",
+		"enable-feature",
+		"list",
+		"list-versions",
+		"release",
+		"set-default",
+		"update",
+	}
+	actual := make([]string, 0, len(planCmd.Commands()))
+	for _, command := range planCmd.Commands() {
+		actual = append(actual, command.Name())
+	}
+	require.ElementsMatch(t, expected, actual)
+}

--- a/cmd/serviceplan/browser.go
+++ b/cmd/serviceplan/browser.go
@@ -2,15 +2,18 @@ package serviceplan
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"unicode"
 
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -27,7 +30,7 @@ const (
 	servicePlanBrowserListMinWidth       = 34
 	servicePlanBrowserListPreferredWidth = 42
 	servicePlanBrowserHelpHeight         = 2
-	servicePlanBrowserHeaderHeight       = 5
+	servicePlanBrowserHeaderHeight       = 1
 	servicePlanBrowserTabsHeight         = 3
 
 	servicePlanBrowserFocusLeft servicePlanBrowserFocus = iota
@@ -36,6 +39,10 @@ const (
 	servicePlanBrowserModalDeployments   servicePlanBrowserModalKind = "deployments"
 	servicePlanBrowserModalSubscriptions servicePlanBrowserModalKind = "subscriptions"
 	servicePlanBrowserModalUsers         servicePlanBrowserModalKind = "users"
+	servicePlanBrowserModalCloudAccounts servicePlanBrowserModalKind = "cloud-accounts"
+
+	servicePlanCustomerAccountConfigIDParamKey = "cloud_provider_account_config_id"
+	servicePlanCustomerAccountResourcePrefix   = "r-injectedaccountconfig"
 )
 
 type servicePlanBrowserFocus int
@@ -76,17 +83,19 @@ type servicePlanBrowserEnvironment struct {
 }
 
 type servicePlanEnvironmentDetails struct {
-	DeploymentModel          string
-	EnabledFeatures          []string
-	Clouds                   []string
-	Regions                  []string
-	Deployments              []servicePlanDeploymentRow
-	Subscriptions            []servicePlanSubscriptionRow
-	Users                    []servicePlanUserRow
-	DeploymentsCount         int
-	ActiveSubscriptionsCount int
-	UniqueUsersCount         int
-	Err                      string
+	DeploymentModel            string
+	EnabledFeatures            []string
+	Clouds                     []string
+	Regions                    []string
+	Deployments                []servicePlanDeploymentRow
+	Subscriptions              []servicePlanSubscriptionRow
+	Users                      []servicePlanUserRow
+	CustomerCloudAccounts      []servicePlanCustomerCloudAccountRow
+	DeploymentsCount           int
+	ActiveSubscriptionsCount   int
+	UniqueUsersCount           int
+	CustomerCloudAccountsCount int
+	Err                        string
 }
 
 type servicePlanDeploymentRow struct {
@@ -102,6 +111,7 @@ type servicePlanSubscriptionRow struct {
 	ID            string
 	Status        string
 	RootUserEmail string
+	RootUserID    string
 	RootUserName  string
 	InstanceCount int64
 }
@@ -114,8 +124,23 @@ type servicePlanUserRow struct {
 	OrgName string
 }
 
+type servicePlanCustomerCloudAccountRow struct {
+	InstanceID     string
+	CloudProvider  string
+	Status         string
+	SubscriptionID string
+	CustomerEmail  string
+	Resource       string
+	Region         string
+}
+
 type servicePlanBrowserLoader interface {
 	LoadEnvironmentDetails(context.Context, string, servicePlanBrowserEnvironment) (servicePlanEnvironmentDetails, error)
+}
+
+type servicePlanBrowserDeploymentLauncher interface {
+	LoadDeploymentForm(context.Context, string, servicePlanBrowserEnvironment) (servicePlanDeploymentForm, error)
+	LaunchDeployment(context.Context, string, servicePlanDeploymentLaunchRequest) (string, error)
 }
 
 type productionServicePlanBrowserLoader struct{}
@@ -143,6 +168,10 @@ type servicePlanBrowserModel struct {
 	detailPanelWidth       int
 	statusMessage          string
 	modal                  *servicePlanBrowserModal
+	loadingDeploymentForm  bool
+	deploymentForm         *servicePlanDeploymentFormState
+	loadDeploymentForm     func(servicePlanBrowserEnvironment) (servicePlanDeploymentForm, error)
+	launchDeployment       func(servicePlanDeploymentLaunchRequest) (string, error)
 }
 
 type servicePlanBrowserLeftItem struct {
@@ -154,6 +183,7 @@ type servicePlanBrowserLeftItem struct {
 	expandable   bool
 	expanded     bool
 	isService    bool
+	isLastChild  bool
 	hostingBadge servicePlanHostingBadge
 	serviceIndex int
 	planIndex    int
@@ -193,9 +223,136 @@ type servicePlanBrowserDetailsLoadedMsg struct {
 	detail   servicePlanEnvironmentDetails
 }
 
+type servicePlanDeploymentFormLoadedMsg struct {
+	form servicePlanDeploymentForm
+	err  error
+}
+
+type servicePlanDeploymentLaunchedMsg struct {
+	instanceID string
+	err        error
+}
+
+type servicePlanDeploymentForm struct {
+	Environment              servicePlanBrowserEnvironment
+	Version                  string
+	ServiceProviderID        string
+	ServiceURLKey            string
+	ServiceAPIVersion        string
+	ServiceEnvironmentURLKey string
+	ServiceModelURLKey       string
+	ProductTierURLKey        string
+	Resources                []servicePlanDeploymentResource
+	CloudProviders           []string
+	RegionsByCloud           map[string][]string
+	Parameters               []servicePlanDeploymentParameter
+	ParametersByResource     map[string][]servicePlanDeploymentParameter
+	CustomerCloudAccounts    []servicePlanCustomerCloudAccountRow
+	Customers                []servicePlanDeploymentCustomer
+	Subscriptions            []servicePlanSubscriptionRow
+	RequiresCustomerAccount  bool
+}
+
+type servicePlanDeploymentResource struct {
+	ID     string
+	Name   string
+	URLKey string
+}
+
+type servicePlanDeploymentParameter struct {
+	Key          string
+	DisplayName  string
+	Description  string
+	Type         string
+	Required     bool
+	IsList       bool
+	Custom       bool
+	DefaultValue string
+	Options      []string
+}
+
+type servicePlanDeploymentCustomer struct {
+	UserID  string
+	Email   string
+	Name    string
+	OrgName string
+	Self    bool
+}
+
+type servicePlanDeploymentLaunchRequest struct {
+	Form              servicePlanDeploymentForm
+	Customer          servicePlanDeploymentCustomer
+	ResourceName      string
+	CloudProvider     string
+	Region            string
+	CustomerAccountID string
+	SubscriptionID    string
+	Params            map[string]any
+}
+
+type servicePlanDeploymentFieldKind int
+
+const (
+	servicePlanDeploymentFieldParameter servicePlanDeploymentFieldKind = iota
+)
+
+type servicePlanDeploymentFormField struct {
+	Kind        servicePlanDeploymentFieldKind
+	Key         string
+	Label       string
+	Required    bool
+	Type        string
+	IsList      bool
+	Description string
+	Options     []string
+	Input       textinput.Model
+}
+
+type servicePlanDeploymentFormState struct {
+	Form                servicePlanDeploymentForm
+	Steps               []servicePlanDeploymentWizardStep
+	StepIndex           int
+	SelectionCursor     int
+	ParamFields         []servicePlanDeploymentFormField
+	ParamCursor         int
+	SelectedCustomer    servicePlanDeploymentCustomer
+	ResourceName        string
+	CloudProvider       string
+	Region              string
+	CustomerAccountID   string
+	ParameterResourceID string
+	ParamValues         map[string]string
+	Launching           bool
+	InstanceID          string
+	Result              string
+	Err                 string
+}
+
+type servicePlanDeploymentWizardStep string
+
+const (
+	servicePlanDeploymentStepCustomer     servicePlanDeploymentWizardStep = "customer"
+	servicePlanDeploymentStepResource     servicePlanDeploymentWizardStep = "resource"
+	servicePlanDeploymentStepCloud        servicePlanDeploymentWizardStep = "cloud"
+	servicePlanDeploymentStepCloudAccount servicePlanDeploymentWizardStep = "cloud-account"
+	servicePlanDeploymentStepRegion       servicePlanDeploymentWizardStep = "region"
+	servicePlanDeploymentStepCustomParams servicePlanDeploymentWizardStep = "custom-params"
+	servicePlanDeploymentStepSystemParams servicePlanDeploymentWizardStep = "system-params"
+	servicePlanDeploymentStepReview       servicePlanDeploymentWizardStep = "review"
+	servicePlanDeploymentStepComplete     servicePlanDeploymentWizardStep = "complete"
+)
+
+type servicePlanDeploymentWizardOption struct {
+	Label       string
+	Description string
+	Value       string
+	Customer    servicePlanDeploymentCustomer
+	Account     servicePlanCustomerCloudAccountRow
+}
+
 func newServicePlanBrowserDelegate() servicePlanBrowserDelegate {
 	delegate := servicePlanBrowserDelegate{DefaultDelegate: list.NewDefaultDelegate()}
-	delegate.SetHeight(2)
+	delegate.SetHeight(1)
 	delegate.SetSpacing(0)
 	return delegate
 }
@@ -209,35 +366,36 @@ func (d servicePlanBrowserDelegate) Render(writer io.Writer, model list.Model, i
 
 	isSelected := index == model.Index()
 	titleStyle := lipgloss.NewStyle().Padding(0, 0, 0, 1)
-	descriptionStyle := lipgloss.NewStyle().Padding(0, 0, 0, 1).Foreground(lipgloss.Color("245"))
 	if isSelected {
 		titleStyle = titleStyle.Bold(true).Foreground(lipgloss.Color("230")).Background(lipgloss.Color("62"))
-		descriptionStyle = descriptionStyle.Foreground(lipgloss.Color("252"))
 	}
 
-	indent := strings.Repeat("  ", browserItem.level)
-	titlePrefix := ""
-	switch {
-	case browserItem.expandable && browserItem.expanded:
-		titlePrefix = "▾ "
-	case browserItem.expandable:
-		titlePrefix = "▸ "
-	case browserItem.level > 0:
-		titlePrefix = "• "
-	}
-
-	title := indent + titlePrefix + browserItem.title
-	description := browserItem.description
-	if description != "" {
-		description = indent + "  " + description
-	}
+	title := servicePlanBrowserLeftItemTreePrefix(browserItem) + browserItem.title
 
 	renderedTitle := titleStyle.Render(title)
 	if browserItem.hostingBadge.Label != "" {
 		renderedTitle = lipgloss.JoinHorizontal(lipgloss.Center, renderedTitle, " ", renderServicePlanHostingBadge(browserItem.hostingBadge))
 	}
 
-	fmt.Fprintf(writer, "%s\n%s", renderedTitle, descriptionStyle.Render(description))
+	fmt.Fprint(writer, renderedTitle)
+}
+
+func servicePlanBrowserLeftItemTreePrefix(item servicePlanBrowserLeftItem) string {
+	if item.isService {
+		if item.expanded {
+			return "- "
+		}
+		return "+ "
+	}
+
+	if item.level > 0 {
+		if item.isLastChild {
+			return "  └─ "
+		}
+		return "  ├─ "
+	}
+
+	return ""
 }
 
 func buildServicePlanBrowserCatalog(services []openapiclient.DescribeServiceResult, filterMaps []map[string]string) servicePlanBrowserCatalog {
@@ -345,6 +503,14 @@ func newServicePlanBrowserModel(ctx context.Context, token string, catalog servi
 		model.loadEnvironmentDetails = func(env servicePlanBrowserEnvironment) (servicePlanEnvironmentDetails, error) {
 			return loader.LoadEnvironmentDetails(ctx, token, env)
 		}
+		if launcher, ok := loader.(servicePlanBrowserDeploymentLauncher); ok {
+			model.loadDeploymentForm = func(env servicePlanBrowserEnvironment) (servicePlanDeploymentForm, error) {
+				return launcher.LoadDeploymentForm(ctx, token, env)
+			}
+			model.launchDeployment = func(request servicePlanDeploymentLaunchRequest) (string, error) {
+				return launcher.LaunchDeployment(ctx, token, request)
+			}
+		}
 	}
 	model.setSize(defaultServicePlanBrowserWidth, defaultServicePlanBrowserHeight)
 	model.ensureActiveEnvironmentExpanded()
@@ -365,7 +531,7 @@ func (m servicePlanBrowserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.setSize(msg.Width, msg.Height)
 		return m, nil
 	case spinner.TickMsg:
-		if !m.hasLoadingDetails() {
+		if !m.hasLoadingDetails() && !m.loadingDeploymentForm {
 			return m, nil
 		}
 		var cmd tea.Cmd
@@ -375,9 +541,48 @@ func (m servicePlanBrowserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case servicePlanBrowserDetailsLoadedMsg:
 		delete(m.loadingDetails, msg.cacheKey)
 		m.detailCache[msg.cacheKey] = msg.detail
+		if m.statusMessage == "Refreshing plan details..." {
+			m.statusMessage = "Plan details refreshed"
+		}
 		m.syncViewportContent()
 		return m, nil
+	case servicePlanDeploymentFormLoadedMsg:
+		if !m.loadingDeploymentForm {
+			return m, nil
+		}
+		m.loadingDeploymentForm = false
+		if msg.err != nil {
+			m.statusMessage = "Failed to load deployment form: " + msg.err.Error()
+			return m, nil
+		}
+		formState := newServicePlanDeploymentFormState(msg.form, spMax(m.detailPanelWidth-8, 40))
+		m.deploymentForm = &formState
+		return m, nil
+	case servicePlanDeploymentLaunchedMsg:
+		if m.deploymentForm == nil {
+			return m, nil
+		}
+		m.deploymentForm.Launching = false
+		if msg.err != nil {
+			m.deploymentForm.Err = msg.err.Error()
+			return m, nil
+		}
+		m.deploymentForm.Err = ""
+		m.deploymentForm.InstanceID = strings.TrimSpace(msg.instanceID)
+		m.deploymentForm.Result = "Deployment launched: " + emptyValue(msg.instanceID)
+		m.deploymentForm.StepIndex = len(m.deploymentForm.Steps)
+		m.deploymentForm.Steps = append(m.deploymentForm.Steps, servicePlanDeploymentStepComplete)
+		m.statusMessage = m.deploymentForm.Result
+		return m, m.refreshSelectedDetails()
 	case tea.KeyMsg:
+		if m.deploymentForm != nil {
+			return m.updateDeploymentForm(msg)
+		}
+		if m.loadingDeploymentForm && msg.String() == "esc" {
+			m.loadingDeploymentForm = false
+			m.statusMessage = ""
+			return m, nil
+		}
 		if m.modal != nil {
 			return m.updateModal(msg), nil
 		}
@@ -385,6 +590,10 @@ func (m servicePlanBrowserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "ctrl+c", "q":
 			return m, tea.Quit
+		case "d":
+			return m, m.openDeploymentForm()
+		case "r":
+			return m, m.refreshSelectedDetails()
 		case "tab":
 			return m, m.moveEnvironmentTab(1)
 		case "shift+tab":
@@ -397,6 +606,9 @@ func (m servicePlanBrowserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		switch msg.String() {
 		case "enter":
+			if m.toggleSelectedService() {
+				return m, nil
+			}
 			_, loadCmd := m.enterDetailsPane()
 			return m, loadCmd
 		case " ", "right":
@@ -484,6 +696,12 @@ func (m servicePlanBrowserModel) updateModal(msg tea.KeyMsg) servicePlanBrowserM
 }
 
 func (m servicePlanBrowserModel) View() string {
+	if m.deploymentForm != nil {
+		return m.renderDeploymentForm()
+	}
+	if m.loadingDeploymentForm {
+		return m.renderDeploymentFormLoading()
+	}
 	if m.modal != nil {
 		return m.renderModal()
 	}
@@ -550,16 +768,16 @@ func (m servicePlanBrowserModel) statusLine() string {
 		return m.statusMessage
 	}
 	if m.focus == servicePlanBrowserFocusDetails {
-		return "Use tab or shift+tab to switch environments. Use esc or left to return to the plan list."
+		return "Use d to launch a deployment, r to refresh. Use tab or shift+tab to switch environments. Use esc or left to return to the plan list."
 	}
-	return "Use tab or shift+tab to switch environments. Plan details update as the selector moves."
+	return "Use d to launch a deployment, r to refresh. Plan details update as the selector moves."
 }
 
 func (m servicePlanBrowserModel) helpLine() string {
 	if m.focus == servicePlanBrowserFocusDetails {
-		return "tab/shift+tab: environment  ↑/↓: detail rows  enter: open row  esc/←: focus plans  q: quit"
+		return "d: deploy  r: refresh  tab/shift+tab: environment  ↑/↓: detail rows  enter: open row  esc/←: focus plans  q: quit"
 	}
-	return "tab/shift+tab: environment  ↑/↓: navigate plans  enter/→: details/open  ←/→: expand/collapse services  q: quit"
+	return "d: deploy  r: refresh  tab/shift+tab: environment  ↑/↓: navigate plans  enter/→: details/open  ←/→: expand/collapse services  q: quit"
 }
 
 func (m *servicePlanBrowserModel) rebuildVisibleItems(selectedKey string) {
@@ -589,9 +807,6 @@ func (m *servicePlanBrowserModel) rebuildVisibleItems(selectedKey string) {
 		m.list.Select(selectedIndex)
 	}
 	m.list.Title = "Service Plans"
-	if env := m.activeEnvironmentName(); env != "" {
-		m.list.Title = "Service Plans · " + env
-	}
 	m.syncSelectionFromList()
 	m.syncViewportContent()
 }
@@ -951,37 +1166,8 @@ func isServicePlanSoftBreak(r rune) bool {
 	return unicode.IsSpace(r) || strings.ContainsRune("/:?&=_-.,", r)
 }
 
-func renderServicePlanBrowserHeader(catalog servicePlanBrowserCatalog) string {
-	serviceCount := len(catalog.Services)
-	planCount := 0
-	envCount := 0
-	for _, service := range catalog.Services {
-		planCount += len(service.Plans)
-		for _, plan := range service.Plans {
-			envCount += len(plan.Environments)
-		}
-	}
-
-	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230")).Render("Service Plan Browser")
-	metadata := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render(
-		fmt.Sprintf("%d service(s)  |  %d plan name(s)  |  %d environment variant(s)", serviceCount, planCount, envCount),
-	)
-	checks := []string{
-		renderServicePlanBrowserCheck("Service catalog loaded", serviceCount > 0),
-		renderServicePlanBrowserCheck("Plan details available", planCount > 0),
-	}
-
-	return lipgloss.JoinVertical(lipgloss.Left, title, metadata, strings.Join(checks, "  "))
-}
-
-func renderServicePlanBrowserCheck(label string, ok bool) string {
-	icon := "○"
-	style := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-	if ok {
-		icon = "✓"
-		style = lipgloss.NewStyle().Foreground(lipgloss.Color("82")).Bold(true)
-	}
-	return style.Render(fmt.Sprintf("%s %s", icon, label))
+func renderServicePlanBrowserHeader(_ servicePlanBrowserCatalog) string {
+	return lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230")).Render("Service Plan Browser")
 }
 
 func (m servicePlanBrowserModel) renderEnvironmentTabs(width int) string {
@@ -996,7 +1182,8 @@ func (m servicePlanBrowserModel) renderEnvironmentTabs(width int) string {
 	inactiveTabStyle := lipgloss.NewStyle().
 		Border(inactiveTabBorder, true).
 		BorderForeground(highlightColor).
-		Padding(0, 1)
+		Padding(0, 1).
+		Bold(true)
 	activeTabStyle := lipgloss.NewStyle().
 		Border(activeTabBorder, true).
 		BorderForeground(highlightColor).
@@ -1082,7 +1269,7 @@ func (m servicePlanBrowserModel) detailRows() []servicePlanBrowserDetailRow {
 		return []servicePlanBrowserDetailRow{{Label: "Error", Value: detail.Err}}
 	}
 
-	return []servicePlanBrowserDetailRow{
+	rows := []servicePlanBrowserDetailRow{
 		{Label: "Deployment model", Value: emptyValue(detail.DeploymentModel)},
 		{Label: "Enabled features", Value: joinOrNone(detail.EnabledFeatures)},
 		{Label: "Clouds", Value: joinOrNone(detail.Clouds)},
@@ -1091,6 +1278,14 @@ func (m servicePlanBrowserModel) detailRows() []servicePlanBrowserDetailRow {
 		{Label: "Subscriptions", Value: fmt.Sprintf("%d", detail.ActiveSubscriptionsCount), ModalKind: servicePlanBrowserModalSubscriptions},
 		{Label: "Users", Value: fmt.Sprintf("%d", detail.UniqueUsersCount), ModalKind: servicePlanBrowserModalUsers},
 	}
+	if servicePlanEnvironmentRequiresCustomerAccount(*env) || detail.CustomerCloudAccountsCount > 0 {
+		rows = append(rows, servicePlanBrowserDetailRow{
+			Label:     "Cloud accounts",
+			Value:     fmt.Sprintf("%d connected", detail.CustomerCloudAccountsCount),
+			ModalKind: servicePlanBrowserModalCloudAccounts,
+		})
+	}
+	return rows
 }
 
 func (m servicePlanBrowserModel) renderModal() string {
@@ -1232,6 +1427,17 @@ func (m *servicePlanBrowserModel) expandSelectedService() bool {
 	return true
 }
 
+func (m *servicePlanBrowserModel) toggleSelectedService() bool {
+	selected := m.selectedLeftItem()
+	if selected == nil || !selected.expandable {
+		return false
+	}
+
+	m.expanded[selected.serviceIndex] = !selected.expanded
+	m.rebuildVisibleItems(selected.key)
+	return true
+}
+
 func (m *servicePlanBrowserModel) collapseSelectedItem() bool {
 	selected := m.selectedLeftItem()
 	if selected == nil {
@@ -1287,6 +1493,19 @@ func (m *servicePlanBrowserModel) openSelectedModal() {
 			text := fmt.Sprintf("%s | %s | %s | %s | %s", emptyValue(user.ID), emptyValue(user.Email), emptyValue(user.Name), emptyValue(user.Status), emptyValue(user.OrgName))
 			modalRows = append(modalRows, servicePlanBrowserModalRow{Text: text, Search: strings.ToLower(text)})
 		}
+	case servicePlanBrowserModalCloudAccounts:
+		for _, account := range detail.CustomerCloudAccounts {
+			text := fmt.Sprintf(
+				"%s | %s | %s | %s | %s | %s",
+				emptyValue(account.InstanceID),
+				emptyValue(account.CloudProvider),
+				emptyValue(account.Status),
+				emptyValue(account.Region),
+				emptyValue(account.CustomerEmail),
+				emptyValue(account.SubscriptionID),
+			)
+			modalRows = append(modalRows, servicePlanBrowserModalRow{Text: text, Search: strings.ToLower(text)})
+		}
 	}
 
 	m.modal = &servicePlanBrowserModal{
@@ -1316,6 +1535,9 @@ func (m servicePlanBrowserModel) leftItems() []servicePlanBrowserLeftItem {
 				planIndex:    planIndex,
 			})
 		}
+		for index := range planItems {
+			planItems[index].isLastChild = index == len(planItems)-1
+		}
 		if len(planItems) == 0 {
 			continue
 		}
@@ -1323,7 +1545,6 @@ func (m servicePlanBrowserModel) leftItems() []servicePlanBrowserLeftItem {
 		items = append(items, servicePlanBrowserLeftItem{
 			key:          serviceKey,
 			title:        service.Name,
-			description:  fmt.Sprintf("%d plan name(s)", len(planItems)),
 			expandable:   true,
 			expanded:     m.expanded[serviceIndex],
 			isService:    true,
@@ -1444,6 +1665,21 @@ func (m *servicePlanBrowserModel) requestSelectedDetailsLoad() tea.Cmd {
 	return tea.Batch(m.spinner.Tick, m.loadDetailsCmd(*env))
 }
 
+func (m *servicePlanBrowserModel) refreshSelectedDetails() tea.Cmd {
+	env := m.selectedEnvironment()
+	if env == nil {
+		m.statusMessage = "No environment selected to refresh"
+		return nil
+	}
+	key := env.cacheKey()
+	delete(m.detailCache, key)
+	delete(m.loadingDetails, key)
+	m.statusMessage = "Refreshing plan details..."
+	cmd := m.requestSelectedDetailsLoad()
+	m.syncViewportContent()
+	return cmd
+}
+
 func (m servicePlanBrowserModel) selectedDetailsLoadCmd() tea.Cmd {
 	env := m.selectedEnvironment()
 	if env == nil {
@@ -1453,6 +1689,1009 @@ func (m servicePlanBrowserModel) selectedDetailsLoadCmd() tea.Cmd {
 		return nil
 	}
 	return m.loadDetailsCmd(*env)
+}
+
+func (m *servicePlanBrowserModel) openDeploymentForm() tea.Cmd {
+	selected := m.selectedLeftItem()
+	if selected == nil || selected.isService {
+		m.statusMessage = "Select a plan before launching a deployment"
+		return nil
+	}
+	env := m.selectedEnvironment()
+	if env == nil {
+		m.statusMessage = "No environment is selected for this plan"
+		return nil
+	}
+	if m.loadDeploymentForm == nil {
+		m.statusMessage = "Deployment launch is not available in this view"
+		return nil
+	}
+
+	m.loadingDeploymentForm = true
+	m.statusMessage = "Loading deployment form..."
+	return tea.Batch(m.spinner.Tick, m.loadDeploymentFormCmd(*env))
+}
+
+func (m servicePlanBrowserModel) loadDeploymentFormCmd(env servicePlanBrowserEnvironment) tea.Cmd {
+	if m.loadDeploymentForm == nil {
+		return nil
+	}
+
+	return func() tea.Msg {
+		form, err := m.loadDeploymentForm(env)
+		return servicePlanDeploymentFormLoadedMsg{form: form, err: err}
+	}
+}
+
+func (m servicePlanBrowserModel) launchDeploymentCmd(request servicePlanDeploymentLaunchRequest) tea.Cmd {
+	if m.launchDeployment == nil {
+		return nil
+	}
+
+	return func() tea.Msg {
+		instanceID, err := m.launchDeployment(request)
+		return servicePlanDeploymentLaunchedMsg{instanceID: instanceID, err: err}
+	}
+}
+
+func (m servicePlanBrowserModel) updateDeploymentForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.deploymentForm == nil {
+		return m, nil
+	}
+
+	switch msg.String() {
+	case "ctrl+c":
+		return m, tea.Quit
+	case "esc":
+		m.deploymentForm = nil
+		m.statusMessage = ""
+		return m, nil
+	case "left", "backspace":
+		m.deploymentForm.previousStep(spMax(m.detailPanelWidth-8, 40))
+		return m, nil
+	case "up":
+		if m.deploymentForm.currentStepIsParameters() && m.deploymentForm.moveCurrentParameterOption(-1) {
+			return m, nil
+		}
+		m.deploymentForm.moveWizardCursor(-1)
+		return m, nil
+	case "down":
+		if m.deploymentForm.currentStepIsParameters() && m.deploymentForm.moveCurrentParameterOption(1) {
+			return m, nil
+		}
+		m.deploymentForm.moveWizardCursor(1)
+		return m, nil
+	case "tab":
+		if m.deploymentForm.currentStepIsParameters() {
+			m.deploymentForm.moveWizardCursor(1)
+			return m, nil
+		}
+	case "shift+tab":
+		if m.deploymentForm.currentStepIsParameters() {
+			m.deploymentForm.moveWizardCursor(-1)
+			return m, nil
+		}
+	case "right", "enter":
+		return m.advanceDeploymentWizard()
+	}
+
+	if m.deploymentForm.Launching || !m.deploymentForm.currentStepIsParameters() || len(m.deploymentForm.ParamFields) == 0 {
+		return m, nil
+	}
+
+	field := &m.deploymentForm.ParamFields[m.deploymentForm.ParamCursor]
+	if len(field.Options) > 0 {
+		return m, nil
+	}
+	updated, cmd := field.Input.Update(msg)
+	field.Input = updated
+	m.deploymentForm.Err = ""
+	return m, cmd
+}
+
+func (m servicePlanBrowserModel) advanceDeploymentWizard() (tea.Model, tea.Cmd) {
+	if m.deploymentForm == nil {
+		return m, nil
+	}
+	if m.deploymentForm.currentStep() == servicePlanDeploymentStepComplete {
+		m.deploymentForm = nil
+		m.statusMessage = ""
+		return m, nil
+	}
+	if m.deploymentForm.currentStep() == servicePlanDeploymentStepReview {
+		request, err := m.deploymentForm.launchRequest()
+		if err != nil {
+			m.deploymentForm.Err = err.Error()
+			return m, nil
+		}
+		if m.launchDeployment == nil {
+			m.deploymentForm.Err = "deployment launch is not available"
+			return m, nil
+		}
+		m.deploymentForm.Err = ""
+		m.deploymentForm.Result = ""
+		m.deploymentForm.Launching = true
+		return m, m.launchDeploymentCmd(request)
+	}
+
+	if err := m.deploymentForm.advanceStep(spMax(m.detailPanelWidth-8, 40)); err != nil {
+		m.deploymentForm.Err = err.Error()
+		return m, nil
+	}
+	return m, nil
+}
+
+func newServicePlanDeploymentFormState(form servicePlanDeploymentForm, width int) servicePlanDeploymentFormState {
+	customers := servicePlanDeploymentCustomerOptions(form)
+	resourceName := firstString(servicePlanDeploymentResourceOptions(form.Resources))
+	cloudProvider := firstString(form.CloudProviders)
+	state := servicePlanDeploymentFormState{
+		Form:             form,
+		SelectedCustomer: firstServicePlanDeploymentCustomer(customers),
+		ResourceName:     resourceName,
+		CloudProvider:    cloudProvider,
+		Region:           firstString(form.RegionsByCloud[cloudProvider]),
+		ParamValues:      map[string]string{},
+	}
+	state.Steps = servicePlanDeploymentWizardSteps(form)
+	state.CustomerAccountID = state.firstCloudAccountID()
+	state.prepareCurrentStep(width)
+	return state
+}
+
+func servicePlanDeploymentWizardSteps(form servicePlanDeploymentForm) []servicePlanDeploymentWizardStep {
+	steps := make([]servicePlanDeploymentWizardStep, 0, 8)
+	if servicePlanEnvironmentIsProduction(form.Environment) {
+		steps = append(steps, servicePlanDeploymentStepCustomer)
+	}
+	steps = append(steps, servicePlanDeploymentStepResource)
+	steps = append(steps, servicePlanDeploymentStepCloud)
+	if form.RequiresCustomerAccount {
+		steps = append(steps, servicePlanDeploymentStepCloudAccount)
+	}
+	steps = append(steps, servicePlanDeploymentStepRegion)
+	if servicePlanDeploymentFormHasParameters(form, true) {
+		steps = append(steps, servicePlanDeploymentStepCustomParams)
+	}
+	if servicePlanDeploymentFormHasParameters(form, false) {
+		steps = append(steps, servicePlanDeploymentStepSystemParams)
+	}
+	steps = append(steps, servicePlanDeploymentStepReview)
+	return steps
+}
+
+func servicePlanDeploymentFormHasParameters(form servicePlanDeploymentForm, custom bool) bool {
+	for _, resource := range form.Resources {
+		resourceName := strings.TrimSpace(resource.Name)
+		if resourceName == "" {
+			resourceName = strings.TrimSpace(resource.ID)
+		}
+		if len(servicePlanDeploymentParametersByCustomFlag(form, resourceName, custom)) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *servicePlanDeploymentFormState) prepareCurrentStep(width int) {
+	s.Err = ""
+	s.SelectionCursor = s.selectedOptionIndex()
+	if s.currentStepIsParameters() {
+		_, s.ParameterResourceID = servicePlanDeploymentParametersForResource(s.Form, s.ResourceName)
+		s.ParamFields = s.buildParameterFields(s.currentStep(), width)
+		s.ParamCursor = spClamp(s.ParamCursor, spMax(0, len(s.ParamFields)-1))
+		s.syncFocus()
+		return
+	}
+	s.ParameterResourceID = ""
+	s.ParamFields = nil
+	s.ParamCursor = 0
+}
+
+func (s servicePlanDeploymentFormState) buildParameterFields(step servicePlanDeploymentWizardStep, width int) []servicePlanDeploymentFormField {
+	custom := step == servicePlanDeploymentStepCustomParams
+	parameters := servicePlanDeploymentParametersByCustomFlag(s.Form, s.ResourceName, custom)
+	fields := make([]servicePlanDeploymentFormField, 0, len(parameters))
+	fieldWidth := spMin(spMax(width-28, 24), 64)
+	for _, parameter := range parameters {
+		if strings.EqualFold(parameter.Key, servicePlanCustomerAccountConfigIDParamKey) {
+			continue
+		}
+		label := strings.TrimSpace(parameter.DisplayName)
+		if label == "" {
+			label = parameter.Key
+		}
+		value := parameter.DefaultValue
+		if s.ParamValues != nil {
+			if existing, ok := s.ParamValues[parameter.Key]; ok {
+				value = existing
+			}
+		}
+		input := textinput.New()
+		input.CharLimit = 0
+		input.Width = fieldWidth
+		input.Prompt = ""
+		input.SetValue(value)
+		fields = append(fields, servicePlanDeploymentFormField{
+			Kind:        servicePlanDeploymentFieldParameter,
+			Key:         parameter.Key,
+			Label:       label,
+			Required:    parameter.Required,
+			Type:        parameter.Type,
+			IsList:      parameter.IsList,
+			Description: parameter.Description,
+			Options:     parameter.Options,
+			Input:       input,
+		})
+	}
+	return fields
+}
+
+func (s *servicePlanDeploymentFormState) advanceStep(width int) error {
+	if s.Launching {
+		return nil
+	}
+	if s.currentStepIsParameters() {
+		if err := s.storeCurrentParameterValues(); err != nil {
+			return err
+		}
+	} else if err := s.applySelectedOption(); err != nil {
+		return err
+	}
+
+	if s.StepIndex < len(s.Steps)-1 {
+		s.StepIndex++
+		s.prepareCurrentStep(width)
+	}
+	return nil
+}
+
+func (s *servicePlanDeploymentFormState) previousStep(width int) {
+	if s.Launching {
+		return
+	}
+	if s.currentStepIsParameters() {
+		_ = s.storeCurrentParameterValues()
+	}
+	if s.StepIndex > 0 {
+		s.StepIndex--
+		s.prepareCurrentStep(width)
+	}
+}
+
+func (s *servicePlanDeploymentFormState) moveWizardCursor(delta int) {
+	if s.currentStepIsParameters() {
+		if len(s.ParamFields) == 0 {
+			s.ParamCursor = 0
+			return
+		}
+		s.ParamCursor = (s.ParamCursor + delta + len(s.ParamFields)) % len(s.ParamFields)
+		s.syncFocus()
+		return
+	}
+
+	options := s.currentOptions()
+	if len(options) == 0 {
+		s.SelectionCursor = 0
+		return
+	}
+	s.SelectionCursor = (s.SelectionCursor + delta + len(options)) % len(options)
+}
+
+func (s *servicePlanDeploymentFormState) moveCurrentParameterOption(delta int) bool {
+	if !s.currentStepIsParameters() || len(s.ParamFields) == 0 {
+		return false
+	}
+	field := &s.ParamFields[s.ParamCursor]
+	if len(field.Options) == 0 {
+		return false
+	}
+
+	current := strings.TrimSpace(field.Input.Value())
+	index := -1
+	for i, option := range field.Options {
+		if strings.EqualFold(strings.TrimSpace(option), current) {
+			index = i
+			break
+		}
+	}
+	next := 0
+	if index >= 0 {
+		next = (index + delta + len(field.Options)) % len(field.Options)
+	} else if delta < 0 {
+		next = len(field.Options) - 1
+	}
+	field.Input.SetValue(field.Options[next])
+	s.Err = ""
+	return true
+}
+
+func (s servicePlanDeploymentFormState) currentStep() servicePlanDeploymentWizardStep {
+	if s.StepIndex < 0 || s.StepIndex >= len(s.Steps) {
+		return servicePlanDeploymentStepReview
+	}
+	return s.Steps[s.StepIndex]
+}
+
+func (s servicePlanDeploymentFormState) currentStepIsParameters() bool {
+	step := s.currentStep()
+	return step == servicePlanDeploymentStepCustomParams || step == servicePlanDeploymentStepSystemParams
+}
+
+func (s servicePlanDeploymentFormState) currentStepNumber() int {
+	return spMin(s.StepIndex+1, len(s.Steps))
+}
+
+func (s *servicePlanDeploymentFormState) syncFocus() {
+	for i := range s.ParamFields {
+		if i == s.ParamCursor {
+			s.ParamFields[i].Input.Focus()
+		} else {
+			s.ParamFields[i].Input.Blur()
+		}
+	}
+}
+
+func (s *servicePlanDeploymentFormState) storeCurrentParameterValues() error {
+	if s.ParamValues == nil {
+		s.ParamValues = map[string]string{}
+	}
+	for _, field := range s.ParamFields {
+		value := strings.TrimSpace(field.Input.Value())
+		if field.Required && value == "" {
+			return fmt.Errorf("%s is required", field.Label)
+		}
+		s.ParamValues[field.Key] = value
+	}
+	return nil
+}
+
+func (s *servicePlanDeploymentFormState) applySelectedOption() error {
+	options := s.currentOptions()
+	if len(options) == 0 {
+		if s.currentStep() == servicePlanDeploymentStepCloudAccount {
+			return fmt.Errorf("no connected cloud accounts for %s. Run: omnistrate-ctl account customer create --help", emptyValue(s.CloudProvider))
+		}
+		return nil
+	}
+	option := options[spClamp(s.SelectionCursor, len(options)-1)]
+	switch s.currentStep() {
+	case servicePlanDeploymentStepCustomer:
+		s.SelectedCustomer = option.Customer
+		s.CustomerAccountID = s.firstCloudAccountID()
+	case servicePlanDeploymentStepResource:
+		s.ResourceName = option.Value
+		s.ParamFields = nil
+	case servicePlanDeploymentStepCloud:
+		s.CloudProvider = option.Value
+		s.Region = firstString(s.Form.RegionsByCloud[s.CloudProvider])
+		s.CustomerAccountID = s.firstCloudAccountID()
+	case servicePlanDeploymentStepCloudAccount:
+		s.CustomerAccountID = option.Value
+	case servicePlanDeploymentStepRegion:
+		s.Region = option.Value
+	}
+	s.SelectionCursor = 0
+	return nil
+}
+
+func (s servicePlanDeploymentFormState) launchRequest() (servicePlanDeploymentLaunchRequest, error) {
+	request := servicePlanDeploymentLaunchRequest{
+		Form:              s.Form,
+		Customer:          s.SelectedCustomer,
+		ResourceName:      s.ResourceName,
+		CloudProvider:     s.CloudProvider,
+		Region:            s.Region,
+		CustomerAccountID: s.CustomerAccountID,
+		Params:            map[string]any{},
+	}
+
+	if s.currentStepIsParameters() {
+		copyState := s
+		if err := copyState.storeCurrentParameterValues(); err != nil {
+			return request, err
+		}
+	}
+	request.SubscriptionID = servicePlanSubscriptionIDForCustomer(s.Form.Subscriptions, s.SelectedCustomer)
+
+	if _, ok := servicePlanDeploymentResourceByName(s.Form, request.ResourceName); !ok {
+		return request, fmt.Errorf("resource %q is not available for this plan", request.ResourceName)
+	}
+	if request.CloudProvider != "" && !servicePlanContainsFold(s.Form.CloudProviders, request.CloudProvider) {
+		return request, fmt.Errorf("cloud provider %q is not available for this plan", request.CloudProvider)
+	}
+	if request.Region != "" {
+		regions := s.Form.RegionsByCloud[request.CloudProvider]
+		if len(regions) > 0 && !servicePlanContainsFold(regions, request.Region) {
+			return request, fmt.Errorf("region %q is not available for cloud provider %q", request.Region, request.CloudProvider)
+		}
+	}
+	if s.Form.RequiresCustomerAccount {
+		if request.CustomerAccountID == "" {
+			return request, fmt.Errorf("customer cloud account is required for BYOC plans. Run: omnistrate-ctl account customer create --help")
+		}
+		if !servicePlanCustomerCloudAccountExists(s.filteredCloudAccounts(), request.CustomerAccountID) {
+			return request, fmt.Errorf("customer cloud account %q is not connected to this plan", request.CustomerAccountID)
+		}
+	}
+
+	for _, parameter := range servicePlanDeploymentParametersForSelectedResource(s.Form, request.ResourceName) {
+		if strings.EqualFold(parameter.Key, servicePlanCustomerAccountConfigIDParamKey) {
+			continue
+		}
+		value := strings.TrimSpace(s.ParamValues[parameter.Key])
+		if value == "" {
+			value = strings.TrimSpace(parameter.DefaultValue)
+		}
+		if value == "" && !parameter.Required {
+			continue
+		}
+		if value == "" {
+			return request, fmt.Errorf("%s is required", servicePlanDeploymentParameterLabel(parameter))
+		}
+		parsed, err := parseServicePlanDeploymentParamValue(value, parameter.Type, parameter.IsList)
+		if err != nil {
+			return request, fmt.Errorf("%s: %w", servicePlanDeploymentParameterLabel(parameter), err)
+		}
+		request.Params[parameter.Key] = parsed
+	}
+
+	return request, nil
+}
+
+func parseServicePlanDeploymentParamValue(value, valueType string, isList bool) (any, error) {
+	value = strings.TrimSpace(value)
+	if isList {
+		if strings.HasPrefix(value, "[") {
+			var parsed any
+			if err := json.Unmarshal([]byte(value), &parsed); err != nil {
+				return nil, err
+			}
+			return parsed, nil
+		}
+		if value == "" {
+			return []string{}, nil
+		}
+		parts := strings.Split(value, ",")
+		values := make([]string, 0, len(parts))
+		for _, part := range parts {
+			part = strings.TrimSpace(part)
+			if part != "" {
+				values = append(values, part)
+			}
+		}
+		return values, nil
+	}
+
+	switch strings.ToLower(strings.TrimSpace(valueType)) {
+	case "bool", "boolean":
+		return strconv.ParseBool(value)
+	case "int", "int32", "int64", "integer":
+		return strconv.ParseInt(value, 10, 64)
+	case "float", "float32", "float64", "double", "number":
+		return strconv.ParseFloat(value, 64)
+	case "object", "json", "map":
+		var parsed any
+		if err := json.Unmarshal([]byte(value), &parsed); err != nil {
+			return nil, err
+		}
+		return parsed, nil
+	default:
+		return value, nil
+	}
+}
+
+func (m servicePlanBrowserModel) renderDeploymentFormLoading() string {
+	env := m.selectedEnvironment()
+	title := "Launch Deployment"
+	if plan := m.selectedPlan(); plan != nil && env != nil {
+		title = plan.ServiceName + " / " + plan.Name + " / " + env.Name
+	}
+	content := lipgloss.JoinVertical(
+		lipgloss.Left,
+		lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230")).Render(title),
+		"",
+		m.spinner.View()+" Loading deployment form...",
+		"",
+		lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render("esc: cancel"),
+	)
+	return servicePlanBrowserPanelStyle(lipgloss.Color("117")).Width(spMax(m.width-4, 80)).Render(content)
+}
+
+func (m servicePlanBrowserModel) renderDeploymentForm() string {
+	form := m.deploymentForm
+	if form == nil {
+		return ""
+	}
+
+	width := spMax(m.width-4, 80)
+	height := spMax(m.height-6, 16)
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230"))
+	metaStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("111"))
+	selectedLabelStyle := labelStyle.Foreground(lipgloss.Color("230")).Background(lipgloss.Color("62"))
+	valueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+
+	lines := []string{
+		titleStyle.Render("Launch Deployment"),
+		metaStyle.Render(fmt.Sprintf("%s / %s / %s", form.Form.Environment.ServiceName, form.Form.Environment.PlanName, form.Form.Environment.Name)),
+		metaStyle.Render(fmt.Sprintf("Step %d/%d: %s", form.currentStepNumber(), len(form.Steps), servicePlanDeploymentStepTitle(form.currentStep()))),
+		metaStyle.Render("Version: " + emptyValue(form.Form.Version)),
+		"",
+	}
+
+	switch {
+	case form.currentStep() == servicePlanDeploymentStepComplete:
+		lines = append(lines, form.renderDeploymentCompleteLines(valueStyle)...)
+	case form.currentStep() == servicePlanDeploymentStepReview:
+		lines = append(lines, form.renderDeploymentReviewLines(labelStyle, valueStyle)...)
+	case form.currentStepIsParameters():
+		lines = append(lines, form.renderDeploymentParameterLines(height, labelStyle, selectedLabelStyle, metaStyle)...)
+	default:
+		lines = append(lines, form.renderDeploymentOptionLines(height, selectedLabelStyle, valueStyle, metaStyle)...)
+	}
+
+	if form.Err != "" {
+		lines = append(lines, "", lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render("Error: "+form.Err))
+	}
+	if form.Launching {
+		lines = append(lines, "", lipgloss.NewStyle().Foreground(lipgloss.Color("111")).Render("Launching deployment..."))
+	}
+
+	help := "enter/→: next  ↑/↓: select  ←: back  esc: close"
+	if form.currentStepIsParameters() {
+		help = "enter/→: next  tab/shift+tab: fields  ↑/↓: select option or move fields  ←: back  esc: close"
+	}
+	if form.currentStep() == servicePlanDeploymentStepReview {
+		help = "enter: launch  ←: back  esc: close"
+	}
+	if form.currentStep() == servicePlanDeploymentStepComplete {
+		help = "enter/esc: close"
+	}
+	lines = append(lines, "", metaStyle.Render(help))
+
+	return servicePlanBrowserPanelStyle(lipgloss.Color("117")).
+		Width(width).
+		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
+}
+
+func (s servicePlanDeploymentFormState) renderDeploymentOptionLines(height int, selectedStyle, valueStyle, metaStyle lipgloss.Style) []string {
+	options := s.currentOptions()
+	if len(options) == 0 {
+		if s.currentStep() == servicePlanDeploymentStepCloudAccount {
+			return []string{
+				"No connected cloud accounts match this selection.",
+				"",
+				metaStyle.Render("Run: omnistrate-ctl account customer create --help"),
+			}
+		}
+		return []string{"No options available."}
+	}
+
+	visibleRows := spMax(height-10, 4)
+	start := 0
+	if s.SelectionCursor >= visibleRows {
+		start = s.SelectionCursor - visibleRows + 1
+	}
+	end := spMin(len(options), start+visibleRows)
+	lines := make([]string, 0, visibleRows+1)
+	for i := start; i < end; i++ {
+		option := options[i]
+		prefix := "  "
+		style := valueStyle
+		if i == s.SelectionCursor {
+			prefix = "▸ "
+			style = selectedStyle
+		}
+		lines = append(lines, style.Render(prefix+option.Label))
+		if option.Description != "" {
+			lines = append(lines, metaStyle.Render("    "+option.Description))
+		}
+	}
+	return lines
+}
+
+func (s servicePlanDeploymentFormState) renderDeploymentParameterLines(height int, labelStyle, selectedLabelStyle, metaStyle lipgloss.Style) []string {
+	if len(s.ParamFields) == 0 {
+		return []string{"No parameters required for this step."}
+	}
+
+	visibleFields := spMax(height-10, 4)
+	start := 0
+	if s.ParamCursor >= visibleFields {
+		start = s.ParamCursor - visibleFields + 1
+	}
+	end := spMin(len(s.ParamFields), start+visibleFields)
+	lines := make([]string, 0, visibleFields+1)
+	for i := start; i < end; i++ {
+		field := s.ParamFields[i]
+		prefix := "  "
+		style := labelStyle
+		if i == s.ParamCursor {
+			prefix = "▸ "
+			style = selectedLabelStyle
+		}
+		required := ""
+		if field.Required {
+			required = " *"
+		}
+		lines = append(lines, style.Render(prefix+field.Label+required+": ")+field.Input.View())
+		if len(field.Options) > 0 {
+			lines = append(lines, metaStyle.Render("    "+servicePlanDeploymentParameterOptionsLine(field)))
+		} else if field.Description != "" {
+			lines = append(lines, metaStyle.Render("    "+field.Description))
+		}
+	}
+	return lines
+}
+
+func servicePlanDeploymentParameterOptionsLine(field servicePlanDeploymentFormField) string {
+	current := strings.TrimSpace(field.Input.Value())
+	parts := make([]string, 0, len(field.Options))
+	for _, option := range field.Options {
+		option = strings.TrimSpace(option)
+		if option == "" {
+			continue
+		}
+		if strings.EqualFold(option, current) {
+			parts = append(parts, "["+option+"]")
+			continue
+		}
+		parts = append(parts, option)
+	}
+	if current == "" {
+		return "options: " + strings.Join(parts, "  ")
+	}
+	return "selected: " + strings.Join(parts, "  ")
+}
+
+func (s servicePlanDeploymentFormState) renderDeploymentReviewLines(labelStyle, valueStyle lipgloss.Style) []string {
+	lines := []string{
+		labelStyle.Render("Deploy for: ") + valueStyle.Render(servicePlanDeploymentCustomerLabel(s.SelectedCustomer)),
+		labelStyle.Render("Resource: ") + valueStyle.Render(emptyValue(s.ResourceName)),
+		labelStyle.Render("Cloud: ") + valueStyle.Render(emptyValue(s.CloudProvider)),
+		labelStyle.Render("Region: ") + valueStyle.Render(emptyValue(s.Region)),
+	}
+	if s.Form.RequiresCustomerAccount {
+		lines = append(lines, labelStyle.Render("Cloud account: ")+valueStyle.Render(emptyValue(s.CustomerAccountID)))
+	}
+	if subscriptionID := servicePlanSubscriptionIDForCustomer(s.Form.Subscriptions, s.SelectedCustomer); subscriptionID != "" {
+		lines = append(lines, labelStyle.Render("Subscription: ")+valueStyle.Render(subscriptionID))
+	} else if !s.SelectedCustomer.Self {
+		lines = append(lines, labelStyle.Render("Subscription: ")+valueStyle.Render("will be created on launch"))
+	}
+
+	params := servicePlanDeploymentParametersForSelectedResource(s.Form, s.ResourceName)
+	if len(params) > 0 {
+		lines = append(lines, "", labelStyle.Render("Parameters"))
+		for _, parameter := range params {
+			if strings.EqualFold(parameter.Key, servicePlanCustomerAccountConfigIDParamKey) {
+				continue
+			}
+			value := strings.TrimSpace(s.ParamValues[parameter.Key])
+			if value == "" {
+				value = strings.TrimSpace(parameter.DefaultValue)
+			}
+			lines = append(lines, valueStyle.Render("  "+servicePlanDeploymentParameterLabel(parameter)+": "+emptyValue(value)))
+		}
+	}
+	return lines
+}
+
+func (s servicePlanDeploymentFormState) renderDeploymentCompleteLines(valueStyle lipgloss.Style) []string {
+	instanceID := emptyValue(s.InstanceID)
+	lines := []string{
+		lipgloss.NewStyle().Foreground(lipgloss.Color("82")).Render("Deployment launched: " + instanceID),
+		"",
+		"Next commands:",
+		valueStyle.Render("  omnistrate-ctl instance describe " + instanceID),
+		valueStyle.Render("  omnistrate-ctl instance list-endpoints " + instanceID),
+		valueStyle.Render("  omnistrate-ctl instance debug " + instanceID),
+	}
+	return lines
+}
+
+func (s servicePlanDeploymentFormState) currentOptions() []servicePlanDeploymentWizardOption {
+	switch s.currentStep() {
+	case servicePlanDeploymentStepCustomer:
+		customers := servicePlanDeploymentCustomerOptions(s.Form)
+		options := make([]servicePlanDeploymentWizardOption, 0, len(customers))
+		for _, customer := range customers {
+			options = append(options, servicePlanDeploymentWizardOption{
+				Label:       servicePlanDeploymentCustomerLabel(customer),
+				Description: servicePlanDeploymentCustomerDescription(customer),
+				Value:       customer.Email,
+				Customer:    customer,
+			})
+		}
+		return options
+	case servicePlanDeploymentStepResource:
+		options := make([]servicePlanDeploymentWizardOption, 0, len(s.Form.Resources))
+		for _, resource := range s.Form.Resources {
+			label := strings.TrimSpace(resource.Name)
+			if label == "" {
+				label = resource.ID
+			}
+			options = append(options, servicePlanDeploymentWizardOption{
+				Label: label,
+				Value: label,
+			})
+		}
+		return options
+	case servicePlanDeploymentStepCloud:
+		options := make([]servicePlanDeploymentWizardOption, 0, len(s.Form.CloudProviders))
+		for _, cloud := range s.Form.CloudProviders {
+			options = append(options, servicePlanDeploymentWizardOption{Label: cloud, Value: cloud})
+		}
+		return options
+	case servicePlanDeploymentStepCloudAccount:
+		accounts := s.filteredCloudAccounts()
+		options := make([]servicePlanDeploymentWizardOption, 0, len(accounts))
+		for _, account := range accounts {
+			label := account.InstanceID
+			descriptionParts := []string{account.CloudProvider, account.Region, account.Status, account.CustomerEmail}
+			options = append(options, servicePlanDeploymentWizardOption{
+				Label:       label,
+				Description: strings.Join(nonEmptyStrings(descriptionParts), " | "),
+				Value:       account.InstanceID,
+				Account:     account,
+			})
+		}
+		return options
+	case servicePlanDeploymentStepRegion:
+		regions := s.Form.RegionsByCloud[s.CloudProvider]
+		options := make([]servicePlanDeploymentWizardOption, 0, len(regions))
+		for _, region := range regions {
+			options = append(options, servicePlanDeploymentWizardOption{Label: region, Value: region})
+		}
+		return options
+	default:
+		return nil
+	}
+}
+
+func (s servicePlanDeploymentFormState) selectedOptionIndex() int {
+	options := s.currentOptions()
+	selected := ""
+	switch s.currentStep() {
+	case servicePlanDeploymentStepCustomer:
+		selected = s.SelectedCustomer.Email
+		if s.SelectedCustomer.Self {
+			selected = "self"
+		}
+	case servicePlanDeploymentStepResource:
+		selected = s.ResourceName
+	case servicePlanDeploymentStepCloud:
+		selected = s.CloudProvider
+	case servicePlanDeploymentStepCloudAccount:
+		selected = s.CustomerAccountID
+	case servicePlanDeploymentStepRegion:
+		selected = s.Region
+	}
+	for i, option := range options {
+		if strings.EqualFold(option.Value, selected) ||
+			strings.EqualFold(option.Label, selected) ||
+			(option.Customer.Self && selected == "self") {
+			return i
+		}
+	}
+	return 0
+}
+
+func (s servicePlanDeploymentFormState) filteredCloudAccounts() []servicePlanCustomerCloudAccountRow {
+	accounts := make([]servicePlanCustomerCloudAccountRow, 0, len(s.Form.CustomerCloudAccounts))
+	selectedSubscriptionID := servicePlanSubscriptionIDForCustomer(s.Form.Subscriptions, s.SelectedCustomer)
+	for _, account := range s.Form.CustomerCloudAccounts {
+		if s.CloudProvider != "" && !strings.EqualFold(account.CloudProvider, s.CloudProvider) {
+			continue
+		}
+		if !s.SelectedCustomer.Self {
+			switch {
+			case selectedSubscriptionID != "" && account.SubscriptionID != "":
+				if !strings.EqualFold(account.SubscriptionID, selectedSubscriptionID) {
+					continue
+				}
+			case s.SelectedCustomer.Email != "":
+				if !strings.EqualFold(account.CustomerEmail, s.SelectedCustomer.Email) {
+					continue
+				}
+			default:
+				continue
+			}
+		}
+		accounts = append(accounts, account)
+	}
+	return accounts
+}
+
+func (s servicePlanDeploymentFormState) firstCloudAccountID() string {
+	for _, account := range s.filteredCloudAccounts() {
+		if strings.TrimSpace(account.InstanceID) != "" {
+			return strings.TrimSpace(account.InstanceID)
+		}
+	}
+	return ""
+}
+
+func servicePlanDeploymentCustomerOptions(form servicePlanDeploymentForm) []servicePlanDeploymentCustomer {
+	customers := []servicePlanDeploymentCustomer{{Self: true, Name: "Self"}}
+	customers = append(customers, form.Customers...)
+	return customers
+}
+
+func firstServicePlanDeploymentCustomer(customers []servicePlanDeploymentCustomer) servicePlanDeploymentCustomer {
+	if len(customers) == 0 {
+		return servicePlanDeploymentCustomer{Self: true, Name: "Self"}
+	}
+	return customers[0]
+}
+
+func servicePlanDeploymentCustomerLabel(customer servicePlanDeploymentCustomer) string {
+	if customer.Self {
+		return "Self"
+	}
+	name := strings.TrimSpace(customer.Name)
+	email := strings.TrimSpace(customer.Email)
+	if name == "" {
+		return emptyValue(email)
+	}
+	if email == "" {
+		return name
+	}
+	return fmt.Sprintf("%s <%s>", name, email)
+}
+
+func servicePlanDeploymentCustomerDescription(customer servicePlanDeploymentCustomer) string {
+	if customer.Self {
+		return "Deploy as the current service provider user"
+	}
+	parts := nonEmptyStrings([]string{customer.OrgName, customer.UserID})
+	return strings.Join(parts, " | ")
+}
+
+func servicePlanDeploymentStepTitle(step servicePlanDeploymentWizardStep) string {
+	switch step {
+	case servicePlanDeploymentStepCustomer:
+		return "Deploy on Behalf Of"
+	case servicePlanDeploymentStepResource:
+		return "Resource"
+	case servicePlanDeploymentStepCloud:
+		return "Cloud Provider"
+	case servicePlanDeploymentStepCloudAccount:
+		return "Customer Cloud Account"
+	case servicePlanDeploymentStepRegion:
+		return "Region"
+	case servicePlanDeploymentStepCustomParams:
+		return "Customer Parameters"
+	case servicePlanDeploymentStepSystemParams:
+		return "Advanced Parameters"
+	case servicePlanDeploymentStepReview:
+		return "Review"
+	case servicePlanDeploymentStepComplete:
+		return "Complete"
+	default:
+		return "Deploy"
+	}
+}
+
+func servicePlanDeploymentResourceOptions(resources []servicePlanDeploymentResource) []string {
+	options := make([]string, 0, len(resources))
+	for _, resource := range resources {
+		name := strings.TrimSpace(resource.Name)
+		if name == "" {
+			name = strings.TrimSpace(resource.ID)
+		}
+		if name != "" {
+			options = append(options, name)
+		}
+	}
+	return options
+}
+
+func servicePlanCustomerCloudAccountExists(accounts []servicePlanCustomerCloudAccountRow, instanceID string) bool {
+	for _, account := range accounts {
+		if strings.EqualFold(strings.TrimSpace(account.InstanceID), strings.TrimSpace(instanceID)) {
+			return true
+		}
+	}
+	return false
+}
+
+func servicePlanDeploymentParametersForSelectedResource(form servicePlanDeploymentForm, resourceName string) []servicePlanDeploymentParameter {
+	parameters, _ := servicePlanDeploymentParametersForResource(form, resourceName)
+	return parameters
+}
+
+func servicePlanDeploymentParametersByCustomFlag(form servicePlanDeploymentForm, resourceName string, custom bool) []servicePlanDeploymentParameter {
+	parameters := servicePlanDeploymentParametersForSelectedResource(form, resourceName)
+	filtered := make([]servicePlanDeploymentParameter, 0, len(parameters))
+	for _, parameter := range parameters {
+		if parameter.Custom == custom {
+			filtered = append(filtered, parameter)
+		}
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		return filtered[i].Key < filtered[j].Key
+	})
+	return filtered
+}
+
+func servicePlanDeploymentParameterLabel(parameter servicePlanDeploymentParameter) string {
+	label := strings.TrimSpace(parameter.DisplayName)
+	if label == "" {
+		label = parameter.Key
+	}
+	return label
+}
+
+func servicePlanSubscriptionIDForCustomer(subscriptions []servicePlanSubscriptionRow, customer servicePlanDeploymentCustomer) string {
+	if customer.Self {
+		return ""
+	}
+	for _, subscription := range subscriptions {
+		if customer.UserID != "" && strings.EqualFold(subscription.RootUserID, customer.UserID) {
+			return strings.TrimSpace(subscription.ID)
+		}
+		if customer.Email != "" && strings.EqualFold(subscription.RootUserEmail, customer.Email) {
+			return strings.TrimSpace(subscription.ID)
+		}
+	}
+	return ""
+}
+
+func servicePlanDeploymentResourceByName(form servicePlanDeploymentForm, resourceName string) (servicePlanDeploymentResource, bool) {
+	for _, resource := range form.Resources {
+		if strings.EqualFold(resource.Name, resourceName) ||
+			strings.EqualFold(resource.ID, resourceName) ||
+			strings.EqualFold(resource.URLKey, resourceName) {
+			return resource, true
+		}
+	}
+	return servicePlanDeploymentResource{}, false
+}
+
+func servicePlanDeploymentParametersForResource(form servicePlanDeploymentForm, resourceName string) ([]servicePlanDeploymentParameter, string) {
+	if form.ParametersByResource == nil {
+		return form.Parameters, ""
+	}
+	resource, ok := servicePlanDeploymentResourceByName(form, resourceName)
+	if !ok {
+		return form.Parameters, ""
+	}
+	parameters, ok := form.ParametersByResource[resource.ID]
+	if !ok {
+		return form.Parameters, resource.ID
+	}
+	return parameters, resource.ID
+}
+
+func servicePlanContainsFold(values []string, value string) bool {
+	for _, existing := range values {
+		if strings.EqualFold(strings.TrimSpace(existing), strings.TrimSpace(value)) {
+			return true
+		}
+	}
+	return false
+}
+
+func firstString(values []string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func nonEmptyStrings(values []string) []string {
+	nonEmpty := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			nonEmpty = append(nonEmpty, value)
+		}
+	}
+	return nonEmpty
 }
 
 func (m servicePlanBrowserModel) loadDetailsCmd(env servicePlanBrowserEnvironment) tea.Cmd {
@@ -1536,6 +2775,13 @@ func (productionServicePlanBrowserLoader) LoadEnvironmentDetails(ctx context.Con
 		return servicePlanEnvironmentDetails{}, err
 	}
 	activeSubscriptions := activeServicePlanSubscriptions(subscriptions)
+	customerCloudAccounts := []servicePlanCustomerCloudAccountRow{}
+	if servicePlanEnvironmentRequiresCustomerAccount(env) {
+		customerCloudAccounts, err = listServicePlanCustomerCloudAccounts(ctx, token, env, activeSubscriptions)
+		if err != nil {
+			return servicePlanEnvironmentDetails{}, err
+		}
+	}
 
 	allUsers := make([]openapiclientfleet.User, 0)
 	for _, subscription := range activeSubscriptions {
@@ -1557,18 +2803,397 @@ func (productionServicePlanBrowserLoader) LoadEnvironmentDetails(ctx context.Con
 
 	clouds, regions := productTierCloudsAndRegions(productTier)
 	detail := servicePlanEnvironmentDetails{
-		DeploymentModel:          servicePlanDeploymentModel(env, productTier),
-		EnabledFeatures:          productTierEnabledFeatures(productTier),
-		Clouds:                   clouds,
-		Regions:                  regions,
-		Deployments:              servicePlanDeploymentRows(deployments),
-		Subscriptions:            servicePlanSubscriptionRows(activeSubscriptions),
-		Users:                    servicePlanUserRows(uniqueUsers),
-		DeploymentsCount:         len(deployments),
-		ActiveSubscriptionsCount: len(activeSubscriptions),
-		UniqueUsersCount:         len(uniqueUsers),
+		DeploymentModel:            servicePlanDeploymentModel(env, productTier),
+		EnabledFeatures:            productTierEnabledFeatures(productTier),
+		Clouds:                     clouds,
+		Regions:                    regions,
+		Deployments:                servicePlanDeploymentRows(deployments),
+		Subscriptions:              servicePlanSubscriptionRows(activeSubscriptions),
+		Users:                      servicePlanUserRows(uniqueUsers),
+		CustomerCloudAccounts:      customerCloudAccounts,
+		DeploymentsCount:           len(deployments),
+		ActiveSubscriptionsCount:   len(activeSubscriptions),
+		UniqueUsersCount:           len(uniqueUsers),
+		CustomerCloudAccountsCount: len(customerCloudAccounts),
 	}
 	return detail, nil
+}
+
+func (productionServicePlanBrowserLoader) LoadDeploymentForm(ctx context.Context, token string, env servicePlanBrowserEnvironment) (servicePlanDeploymentForm, error) {
+	version, err := dataaccess.FindPreferredVersion(ctx, token, env.ServiceID, env.PlanID)
+	if err != nil {
+		version, err = dataaccess.FindLatestVersion(ctx, token, env.ServiceID, env.PlanID)
+		if err != nil {
+			return servicePlanDeploymentForm{}, err
+		}
+	}
+
+	offeringResult, err := dataaccess.DescribeServiceOffering(ctx, token, env.ServiceID, env.PlanID, version)
+	if err != nil {
+		return servicePlanDeploymentForm{}, err
+	}
+	offering, err := selectServicePlanOffering(offeringResult, env)
+	if err != nil {
+		return servicePlanDeploymentForm{}, err
+	}
+
+	resources := servicePlanDeploymentResources(offering.ResourceParameters)
+	if len(resources) == 0 {
+		return servicePlanDeploymentForm{}, fmt.Errorf("no deployable resources found for %s / %s", env.ServiceName, env.PlanName)
+	}
+
+	parametersByResource := map[string][]servicePlanDeploymentParameter{}
+	for _, resource := range resources {
+		parametersResult, err := dataaccess.ListInputParameters(ctx, token, env.ServiceID, resource.ID, env.PlanID, version)
+		if err != nil {
+			return servicePlanDeploymentForm{}, err
+		}
+		parametersByResource[resource.ID] = servicePlanDeploymentParameters(parametersResult.GetInputParameters())
+	}
+
+	pageSize := int64(100)
+	exclude := true
+	includeInactive := false
+	subscriptions, err := dataaccess.ListAllSubscriptions(ctx, token, env.ServiceID, env.ID, &dataaccess.ListSubscriptionsOptions{
+		ProductTierId:   &env.PlanID,
+		IncludeInactive: &includeInactive,
+		ExcludePricing:  &exclude,
+		PageSize:        &pageSize,
+	})
+	if err != nil {
+		return servicePlanDeploymentForm{}, err
+	}
+	activeSubscriptions := activeServicePlanSubscriptions(subscriptions)
+
+	customers := []servicePlanDeploymentCustomer{}
+	if servicePlanEnvironmentIsProduction(env) {
+		customers, err = listServicePlanDeploymentCustomers(ctx, token)
+		if err != nil {
+			return servicePlanDeploymentForm{}, err
+		}
+	}
+
+	customerCloudAccounts := []servicePlanCustomerCloudAccountRow{}
+	requiresCustomerAccount := servicePlanEnvironmentRequiresCustomerAccount(env) || servicePlanOfferingRequiresCustomerAccount(offering)
+	if requiresCustomerAccount {
+		customerCloudAccounts, err = listServicePlanCustomerCloudAccounts(ctx, token, env, activeSubscriptions)
+		if err != nil {
+			return servicePlanDeploymentForm{}, err
+		}
+	}
+
+	cloudProviders, regionsByCloud := servicePlanOfferingCloudsAndRegions(offering)
+	form := servicePlanDeploymentForm{
+		Environment:              env,
+		Version:                  version,
+		ServiceProviderID:        offeringResult.ConsumptionDescribeServiceOfferingResult.ServiceProviderId,
+		ServiceURLKey:            offeringResult.ConsumptionDescribeServiceOfferingResult.ServiceURLKey,
+		ServiceAPIVersion:        offering.ServiceAPIVersion,
+		ServiceEnvironmentURLKey: offering.ServiceEnvironmentURLKey,
+		ServiceModelURLKey:       offering.ServiceModelURLKey,
+		ProductTierURLKey:        offering.ProductTierURLKey,
+		Resources:                resources,
+		CloudProviders:           cloudProviders,
+		RegionsByCloud:           regionsByCloud,
+		Parameters:               parametersByResource[resources[0].ID],
+		ParametersByResource:     parametersByResource,
+		CustomerCloudAccounts:    customerCloudAccounts,
+		Customers:                customers,
+		Subscriptions:            servicePlanSubscriptionRows(activeSubscriptions),
+		RequiresCustomerAccount:  requiresCustomerAccount,
+	}
+	return form, nil
+}
+
+func (productionServicePlanBrowserLoader) LaunchDeployment(ctx context.Context, token string, request servicePlanDeploymentLaunchRequest) (string, error) {
+	resource, ok := servicePlanDeploymentResourceByName(request.Form, request.ResourceName)
+	if !ok {
+		return "", fmt.Errorf("resource %q is not available for this plan", request.ResourceName)
+	}
+
+	params := request.Params
+	if params == nil {
+		params = map[string]any{}
+	}
+	if request.Form.RequiresCustomerAccount {
+		customerAccountID := strings.TrimSpace(request.CustomerAccountID)
+		if customerAccountID == "" {
+			return "", fmt.Errorf("customer cloud account is required for BYOC plans")
+		}
+		params[servicePlanCustomerAccountConfigIDParamKey] = customerAccountID
+	}
+
+	subscriptionID := strings.TrimSpace(request.SubscriptionID)
+	if !request.Customer.Self {
+		if subscriptionID == "" {
+			createResp, err := dataaccess.CreateSubscriptionOnBehalf(ctx, token, request.Form.Environment.ServiceID, request.Form.Environment.ID, &dataaccess.CreateSubscriptionOnBehalfOptions{
+				ProductTierID:            request.Form.Environment.PlanID,
+				OnBehalfOfCustomerUserID: request.Customer.UserID,
+				OnBehalfOfCustomerEmail:  request.Customer.Email,
+			})
+			if err != nil {
+				return "", fmt.Errorf("failed to create subscription for %s: %w", servicePlanDeploymentCustomerLabel(request.Customer), err)
+			}
+			subscriptionID = strings.TrimSpace(createResp.GetId())
+			if subscriptionID == "" {
+				return "", fmt.Errorf("subscription creation for %s returned an empty subscription ID", servicePlanDeploymentCustomerLabel(request.Customer))
+			}
+		}
+	}
+
+	createRequest := openapiclientfleet.FleetCreateResourceInstanceRequest2{
+		ProductTierVersion: &request.Form.Version,
+		CloudProvider:      &request.CloudProvider,
+		Region:             &request.Region,
+		RequestParams:      params,
+	}
+	if subscriptionID != "" {
+		createRequest.SubscriptionId = &subscriptionID
+	}
+	instance, err := dataaccess.CreateResourceInstance(
+		ctx,
+		token,
+		request.Form.ServiceProviderID,
+		request.Form.ServiceURLKey,
+		request.Form.ServiceAPIVersion,
+		request.Form.ServiceEnvironmentURLKey,
+		request.Form.ServiceModelURLKey,
+		request.Form.ProductTierURLKey,
+		resource.URLKey,
+		createRequest,
+	)
+	if err != nil {
+		return "", err
+	}
+	if instance == nil || strings.TrimSpace(instance.GetId()) == "" {
+		return "", fmt.Errorf("deployment create response did not include an instance ID")
+	}
+	return instance.GetId(), nil
+}
+
+func selectServicePlanOffering(result *openapiclientfleet.InventoryDescribeServiceOfferingResult, env servicePlanBrowserEnvironment) (*openapiclientfleet.ServiceOffering, error) {
+	if result == nil || result.ConsumptionDescribeServiceOfferingResult == nil {
+		return nil, fmt.Errorf("service offering response is empty for %s / %s", env.ServiceName, env.PlanName)
+	}
+
+	var planMatch *openapiclientfleet.ServiceOffering
+	for i := range result.ConsumptionDescribeServiceOfferingResult.Offerings {
+		offering := &result.ConsumptionDescribeServiceOfferingResult.Offerings[i]
+		if !strings.EqualFold(offering.ProductTierID, env.PlanID) {
+			continue
+		}
+		if planMatch == nil {
+			planMatch = offering
+		}
+		if strings.EqualFold(offering.ServiceEnvironmentID, env.ID) {
+			return offering, nil
+		}
+	}
+	if planMatch != nil {
+		return planMatch, nil
+	}
+	return nil, fmt.Errorf("service offering not found for %s / %s", env.ServiceName, env.PlanName)
+}
+
+func servicePlanDeploymentResources(resources []openapiclientfleet.ResourceEntity) []servicePlanDeploymentResource {
+	result := make([]servicePlanDeploymentResource, 0, len(resources))
+	for _, resource := range resources {
+		if resource.IsDeprecated {
+			continue
+		}
+		result = append(result, servicePlanDeploymentResource{
+			ID:     strings.TrimSpace(resource.ResourceId),
+			Name:   strings.TrimSpace(resource.Name),
+			URLKey: strings.TrimSpace(resource.UrlKey),
+		})
+	}
+	return result
+}
+
+func servicePlanDeploymentParameters(parameters []openapiclient.DescribeInputParameterResult) []servicePlanDeploymentParameter {
+	result := make([]servicePlanDeploymentParameter, 0, len(parameters))
+	for _, parameter := range parameters {
+		defaultValue := ""
+		if value, ok := parameter.GetDefaultValueOk(); ok && value != nil {
+			defaultValue = *value
+		}
+		result = append(result, servicePlanDeploymentParameter{
+			Key:          strings.TrimSpace(parameter.GetKey()),
+			DisplayName:  strings.TrimSpace(parameter.GetName()),
+			Description:  strings.TrimSpace(parameter.GetDescription()),
+			Type:         strings.TrimSpace(parameter.GetType()),
+			Required:     parameter.GetRequired(),
+			IsList:       parameter.GetIsList(),
+			Custom:       servicePlanInputParameterIsCustom(parameter),
+			DefaultValue: defaultValue,
+			Options:      parameter.GetOptions(),
+		})
+	}
+	return result
+}
+
+func servicePlanInputParameterIsCustom(parameter openapiclient.DescribeInputParameterResult) bool {
+	value, ok := parameter.AdditionalProperties["custom"]
+	if !ok {
+		return false
+	}
+	custom, ok := value.(bool)
+	return ok && custom
+}
+
+func servicePlanOfferingCloudsAndRegions(offering *openapiclientfleet.ServiceOffering) ([]string, map[string][]string) {
+	regionsByCloud := map[string][]string{}
+	if offering == nil {
+		return nil, regionsByCloud
+	}
+
+	add := func(cloud string, regions []string) {
+		cloud = strings.ToLower(strings.TrimSpace(cloud))
+		if cloud == "" {
+			return
+		}
+		normalizedRegions := make([]string, 0, len(regions))
+		for _, region := range regions {
+			region = strings.TrimSpace(region)
+			if region != "" {
+				normalizedRegions = append(normalizedRegions, region)
+			}
+		}
+		if len(normalizedRegions) == 0 {
+			return
+		}
+		sort.Strings(normalizedRegions)
+		regionsByCloud[cloud] = normalizedRegions
+	}
+
+	add("aws", offering.AwsRegions)
+	add("azure", offering.AzureRegions)
+	add("gcp", offering.GcpRegions)
+	add("oci", offering.OciRegions)
+	add("nebius", offering.NebiusRegions)
+	add("private", offering.PrivateRegions)
+	add("on-prem", offering.OnPremPlatforms)
+
+	cloudSet := map[string]bool{}
+	for _, cloud := range offering.CloudProviders {
+		cloud = strings.ToLower(strings.TrimSpace(cloud))
+		if cloud != "" {
+			cloudSet[cloud] = true
+		}
+	}
+	for cloud := range regionsByCloud {
+		cloudSet[cloud] = true
+	}
+	return sortedKeys(cloudSet), regionsByCloud
+}
+
+func listServicePlanCustomerCloudAccounts(
+	ctx context.Context,
+	token string,
+	env servicePlanBrowserEnvironment,
+	subscriptions []openapiclientfleet.FleetDescribeSubscriptionResult,
+) ([]servicePlanCustomerCloudAccountRow, error) {
+	searchResult, err := dataaccess.SearchInventory(ctx, token, "resourceinstance:i")
+	if err != nil {
+		return nil, err
+	}
+
+	emailsBySubscription := servicePlanEmailsBySubscription(subscriptions)
+	rows := make([]servicePlanCustomerCloudAccountRow, 0)
+	for _, record := range searchResult.ResourceInstanceResults {
+		resourceID := strings.TrimSpace(utils.FromPtr(record.ResourceId))
+		if !strings.HasPrefix(resourceID, servicePlanCustomerAccountResourcePrefix) {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(record.ServiceId), strings.TrimSpace(env.ServiceID)) {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(record.ServiceEnvironmentId), strings.TrimSpace(env.ID)) {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(record.ProductTierId), strings.TrimSpace(env.PlanID)) {
+			continue
+		}
+
+		subscriptionID := strings.TrimSpace(utils.FromPtr(record.SubscriptionId))
+		rows = append(rows, servicePlanCustomerCloudAccountRow{
+			InstanceID:     strings.TrimSpace(record.Id),
+			CloudProvider:  strings.TrimSpace(record.CloudProvider),
+			Status:         strings.TrimSpace(record.Status),
+			SubscriptionID: subscriptionID,
+			CustomerEmail:  emailsBySubscription[subscriptionID],
+			Resource:       strings.TrimSpace(record.ResourceName),
+			Region:         strings.TrimSpace(record.RegionCode),
+		})
+	}
+
+	sort.Slice(rows, func(i, j int) bool {
+		return rows[i].InstanceID < rows[j].InstanceID
+	})
+	return rows, nil
+}
+
+func listServicePlanDeploymentCustomers(ctx context.Context, token string) ([]servicePlanDeploymentCustomer, error) {
+	customers := make([]servicePlanDeploymentCustomer, 0)
+	nextPageToken := ""
+	for {
+		result, err := dataaccess.ListCustomerUsers(ctx, token, dataaccess.CustomerUserListOptions{
+			NextPageToken: nextPageToken,
+			PageSize:      100,
+			ExcludeStats:  true,
+		})
+		if err != nil {
+			return nil, err
+		}
+		for _, user := range result.GetUsers() {
+			email := strings.TrimSpace(utils.FromPtr(user.Email))
+			userID := strings.TrimSpace(utils.FromPtr(user.UserId))
+			if email == "" && userID == "" {
+				continue
+			}
+			customers = append(customers, servicePlanDeploymentCustomer{
+				UserID:  userID,
+				Email:   email,
+				Name:    strings.TrimSpace(utils.FromPtr(user.UserName)),
+				OrgName: strings.TrimSpace(utils.FromPtr(user.OrgName)),
+			})
+		}
+		nextPageToken = result.GetNextPageToken()
+		if nextPageToken == "" {
+			break
+		}
+	}
+	sort.Slice(customers, func(i, j int) bool {
+		return strings.ToLower(customers[i].Email) < strings.ToLower(customers[j].Email)
+	})
+	return customers, nil
+}
+
+func servicePlanEmailsBySubscription(subscriptions []openapiclientfleet.FleetDescribeSubscriptionResult) map[string]string {
+	emails := map[string]string{}
+	for _, subscription := range subscriptions {
+		id := strings.TrimSpace(subscription.Id)
+		if id != "" && strings.TrimSpace(subscription.RootUserEmail) != "" {
+			emails[id] = strings.TrimSpace(subscription.RootUserEmail)
+		}
+	}
+	return emails
+}
+
+func servicePlanEnvironmentRequiresCustomerAccount(env servicePlanBrowserEnvironment) bool {
+	return servicePlanHostingBadgeForValues(env.TenancyType, env.DeploymentType).Label == "BYOC"
+}
+
+func servicePlanEnvironmentIsProduction(env servicePlanBrowserEnvironment) bool {
+	normalized := strings.ToLower(strings.TrimSpace(env.Name))
+	return normalized == "prod" || normalized == "production"
+}
+
+func servicePlanOfferingRequiresCustomerAccount(offering *openapiclientfleet.ServiceOffering) bool {
+	if offering == nil {
+		return false
+	}
+	return servicePlanHostingBadgeForValues(offering.ServiceModelType, offering.ProductTierType).Label == "BYOC"
 }
 
 func activeServicePlanSubscriptions(subscriptions []openapiclientfleet.FleetDescribeSubscriptionResult) []openapiclientfleet.FleetDescribeSubscriptionResult {
@@ -1718,6 +3343,7 @@ func servicePlanSubscriptionRows(subscriptions []openapiclientfleet.FleetDescrib
 			ID:            subscription.Id,
 			Status:        subscription.Status,
 			RootUserEmail: subscription.RootUserEmail,
+			RootUserID:    subscription.RootUserId,
 			RootUserName:  subscription.RootUserName,
 			InstanceCount: subscription.InstanceCount,
 		})

--- a/cmd/serviceplan/browser.go
+++ b/cmd/serviceplan/browser.go
@@ -1012,10 +1012,12 @@ func (m servicePlanBrowserModel) renderEnvironmentTabs(width int) string {
 		}
 
 		border, _, _, _, _ := style.GetBorder()
-		if i == 0 && i == m.activeTab {
-			border.BottomLeft = "│"
-		} else if i == 0 {
-			border.BottomLeft = "├"
+		if i == 0 {
+			if i == m.activeTab {
+				border.BottomLeft = "│"
+			} else {
+				border.BottomLeft = "├"
+			}
 		}
 		style = style.Border(border)
 		renderedTabs = append(renderedTabs, style.Render(emptyValue(name)))
@@ -1387,23 +1389,6 @@ func renderServicePlanHostingBadge(badge servicePlanHostingBadge) string {
 		Background(badge.Color).
 		Padding(0, 1).
 		Render(badge.Label)
-}
-
-func servicePlanEnvironmentSummary(plan servicePlanBrowserPlan) string {
-	if len(plan.Environments) == 0 {
-		return "no environments"
-	}
-
-	names := make([]string, 0, len(plan.Environments))
-	for _, env := range plan.Environments {
-		if strings.TrimSpace(env.Name) != "" {
-			names = append(names, env.Name)
-		}
-	}
-	if len(names) == 0 {
-		return fmt.Sprintf("%d environment(s)", len(plan.Environments))
-	}
-	return fmt.Sprintf("%d environment(s)  |  %s", len(plan.Environments), strings.Join(names, ", "))
 }
 
 func (m servicePlanBrowserModel) selectedPlan() *servicePlanBrowserPlan {

--- a/cmd/serviceplan/browser.go
+++ b/cmd/serviceplan/browser.go
@@ -1,0 +1,1670 @@
+package serviceplan
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
+	openapiclient "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
+	"golang.org/x/term"
+)
+
+const (
+	defaultServicePlanBrowserWidth       = 120
+	defaultServicePlanBrowserHeight      = 32
+	servicePlanBrowserListMinWidth       = 34
+	servicePlanBrowserListPreferredWidth = 42
+	servicePlanBrowserHelpHeight         = 2
+	servicePlanBrowserHeaderHeight       = 5
+
+	servicePlanBrowserFocusLeft servicePlanBrowserFocus = iota
+	servicePlanBrowserFocusDetails
+
+	servicePlanBrowserModalDeployments   servicePlanBrowserModalKind = "deployments"
+	servicePlanBrowserModalSubscriptions servicePlanBrowserModalKind = "subscriptions"
+	servicePlanBrowserModalUsers         servicePlanBrowserModalKind = "users"
+)
+
+type servicePlanBrowserFocus int
+
+type servicePlanBrowserModalKind string
+
+type servicePlanBrowserCatalog struct {
+	Services []servicePlanBrowserService
+}
+
+type servicePlanBrowserService struct {
+	ID    string
+	Name  string
+	Plans []servicePlanBrowserPlan
+}
+
+type servicePlanBrowserPlan struct {
+	Name         string
+	ServiceID    string
+	ServiceName  string
+	Environments []servicePlanBrowserEnvironment
+}
+
+type servicePlanHostingBadge struct {
+	Label string
+	Color lipgloss.Color
+}
+
+type servicePlanBrowserEnvironment struct {
+	ID             string
+	Name           string
+	PlanID         string
+	PlanName       string
+	ServiceID      string
+	ServiceName    string
+	DeploymentType string
+	TenancyType    string
+}
+
+type servicePlanEnvironmentDetails struct {
+	DeploymentModel          string
+	EnabledFeatures          []string
+	Clouds                   []string
+	Regions                  []string
+	Deployments              []servicePlanDeploymentRow
+	Subscriptions            []servicePlanSubscriptionRow
+	Users                    []servicePlanUserRow
+	DeploymentsCount         int
+	ActiveSubscriptionsCount int
+	UniqueUsersCount         int
+	Err                      string
+}
+
+type servicePlanDeploymentRow struct {
+	ID           string
+	Status       string
+	Cloud        string
+	Region       string
+	Subscription string
+	Owner        string
+}
+
+type servicePlanSubscriptionRow struct {
+	ID            string
+	Status        string
+	RootUserEmail string
+	RootUserName  string
+	InstanceCount int64
+}
+
+type servicePlanUserRow struct {
+	ID      string
+	Email   string
+	Name    string
+	Status  string
+	OrgName string
+}
+
+type servicePlanBrowserLoader interface {
+	LoadEnvironmentDetails(context.Context, string, servicePlanBrowserEnvironment) (servicePlanEnvironmentDetails, error)
+}
+
+type productionServicePlanBrowserLoader struct{}
+
+type servicePlanBrowserModel struct {
+	catalog                servicePlanBrowserCatalog
+	loadEnvironmentDetails func(servicePlanBrowserEnvironment) (servicePlanEnvironmentDetails, error)
+	expanded               map[int]bool
+	detailCache            map[string]servicePlanEnvironmentDetails
+	loadingDetails         map[string]bool
+	items                  []servicePlanBrowserLeftItem
+	list                   list.Model
+	viewport               viewport.Model
+	spinner                spinner.Model
+	focus                  servicePlanBrowserFocus
+	detailCursor           int
+	detailViewportTop      bool
+	activeTab              int
+	serviceIndex           int
+	planIndex              int
+	width                  int
+	height                 int
+	listPanelWidth         int
+	detailPanelWidth       int
+	statusMessage          string
+	modal                  *servicePlanBrowserModal
+}
+
+type servicePlanBrowserLeftItem struct {
+	key          string
+	parentKey    string
+	title        string
+	description  string
+	level        int
+	expandable   bool
+	expanded     bool
+	isService    bool
+	hostingBadge servicePlanHostingBadge
+	serviceIndex int
+	planIndex    int
+}
+
+func (i servicePlanBrowserLeftItem) Title() string       { return i.title }
+func (i servicePlanBrowserLeftItem) Description() string { return i.description }
+func (i servicePlanBrowserLeftItem) FilterValue() string {
+	return i.title + " " + i.description
+}
+
+type servicePlanBrowserDelegate struct {
+	list.DefaultDelegate
+}
+
+type servicePlanBrowserDetailRow struct {
+	Label     string
+	Value     string
+	ModalKind servicePlanBrowserModalKind
+}
+
+type servicePlanBrowserModal struct {
+	Kind   servicePlanBrowserModalKind
+	Title  string
+	Rows   []servicePlanBrowserModalRow
+	Filter string
+	Cursor int
+}
+
+type servicePlanBrowserModalRow struct {
+	Text   string
+	Search string
+}
+
+type servicePlanBrowserDetailsLoadedMsg struct {
+	cacheKey string
+	detail   servicePlanEnvironmentDetails
+}
+
+func newServicePlanBrowserDelegate() servicePlanBrowserDelegate {
+	delegate := servicePlanBrowserDelegate{DefaultDelegate: list.NewDefaultDelegate()}
+	delegate.SetHeight(2)
+	delegate.SetSpacing(0)
+	return delegate
+}
+
+func (d servicePlanBrowserDelegate) Render(writer io.Writer, model list.Model, index int, item list.Item) {
+	browserItem, ok := item.(servicePlanBrowserLeftItem)
+	if !ok {
+		d.DefaultDelegate.Render(writer, model, index, item)
+		return
+	}
+
+	isSelected := index == model.Index()
+	titleStyle := lipgloss.NewStyle().Padding(0, 0, 0, 1)
+	descriptionStyle := lipgloss.NewStyle().Padding(0, 0, 0, 1).Foreground(lipgloss.Color("245"))
+	if isSelected {
+		titleStyle = titleStyle.Bold(true).Foreground(lipgloss.Color("230")).Background(lipgloss.Color("62"))
+		descriptionStyle = descriptionStyle.Foreground(lipgloss.Color("252"))
+	}
+
+	indent := strings.Repeat("  ", browserItem.level)
+	titlePrefix := ""
+	switch {
+	case browserItem.expandable && browserItem.expanded:
+		titlePrefix = "▾ "
+	case browserItem.expandable:
+		titlePrefix = "▸ "
+	case browserItem.level > 0:
+		titlePrefix = "• "
+	}
+
+	title := indent + titlePrefix + browserItem.title
+	description := browserItem.description
+	if description != "" {
+		description = indent + "  " + description
+	}
+
+	renderedTitle := titleStyle.Render(title)
+	if browserItem.hostingBadge.Label != "" {
+		renderedTitle = lipgloss.JoinHorizontal(lipgloss.Center, renderedTitle, " ", renderServicePlanHostingBadge(browserItem.hostingBadge))
+	}
+
+	fmt.Fprintf(writer, "%s\n%s", renderedTitle, descriptionStyle.Render(description))
+}
+
+func buildServicePlanBrowserCatalog(services []openapiclient.DescribeServiceResult, filterMaps []map[string]string) servicePlanBrowserCatalog {
+	catalog := servicePlanBrowserCatalog{Services: make([]servicePlanBrowserService, 0, len(services))}
+
+	for _, service := range services {
+		browserService := servicePlanBrowserService{
+			ID:    service.Id,
+			Name:  service.Name,
+			Plans: make([]servicePlanBrowserPlan, 0),
+		}
+		planIndexes := map[string]int{}
+
+		for _, env := range service.ServiceEnvironments {
+			for _, plan := range env.ServicePlans {
+				formatted := formatServicePlan(service.Id, service.Name, env.Name, plan, false)
+				match, err := utils.MatchesFilters(formatted, filterMaps)
+				if err != nil || !match {
+					continue
+				}
+
+				planName := strings.TrimSpace(plan.Name)
+				if planName == "" {
+					planName = plan.ProductTierID
+				}
+				planKey := strings.ToLower(planName)
+				planIndex, ok := planIndexes[planKey]
+				if !ok {
+					planIndex = len(browserService.Plans)
+					planIndexes[planKey] = planIndex
+					browserService.Plans = append(browserService.Plans, servicePlanBrowserPlan{
+						Name:        planName,
+						ServiceID:   service.Id,
+						ServiceName: service.Name,
+					})
+				}
+
+				browserService.Plans[planIndex].Environments = append(browserService.Plans[planIndex].Environments, servicePlanBrowserEnvironment{
+					ID:             env.Id,
+					Name:           env.Name,
+					PlanID:         plan.ProductTierID,
+					PlanName:       planName,
+					ServiceID:      service.Id,
+					ServiceName:    service.Name,
+					DeploymentType: plan.TierType,
+					TenancyType:    plan.ModelType,
+				})
+			}
+		}
+
+		if len(browserService.Plans) > 0 {
+			catalog.Services = append(catalog.Services, browserService)
+		}
+	}
+
+	return catalog
+}
+
+func runServicePlanBrowser(ctx context.Context, token string, catalog servicePlanBrowserCatalog) error {
+	model := newServicePlanBrowserModel(ctx, token, catalog, productionServicePlanBrowserLoader{})
+
+	snapshot := renderServicePlanBrowserSnapshot(model)
+	utils.LastPrintedString = snapshot
+
+	if !isServicePlanBrowserInteractive() {
+		fmt.Println(snapshot)
+		return nil
+	}
+
+	program := tea.NewProgram(model, tea.WithAltScreen())
+	if _, err := program.Run(); err != nil {
+		return fmt.Errorf("failed to launch service plan browser: %w", err)
+	}
+
+	return nil
+}
+
+func newServicePlanBrowserModel(ctx context.Context, token string, catalog servicePlanBrowserCatalog, loader servicePlanBrowserLoader) servicePlanBrowserModel {
+	delegate := newServicePlanBrowserDelegate()
+	planList := list.New(nil, delegate, 0, 0)
+	planList.Title = "Service Plans"
+	planList.SetShowHelp(false)
+	planList.SetShowFilter(false)
+	planList.SetShowStatusBar(false)
+	planList.SetFilteringEnabled(false)
+	planList.DisableQuitKeybindings()
+	planList.Styles.Title = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("117")).Padding(0, 1)
+
+	detailSpinner := spinner.New()
+	detailSpinner.Spinner = spinner.Dot
+	detailSpinner.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("117"))
+
+	model := servicePlanBrowserModel{
+		catalog:        catalog,
+		expanded:       map[int]bool{},
+		detailCache:    map[string]servicePlanEnvironmentDetails{},
+		loadingDetails: map[string]bool{},
+		list:           planList,
+		viewport:       viewport.New(0, 0),
+		spinner:        detailSpinner,
+		focus:          servicePlanBrowserFocusLeft,
+	}
+	if loader != nil {
+		model.loadEnvironmentDetails = func(env servicePlanBrowserEnvironment) (servicePlanEnvironmentDetails, error) {
+			return loader.LoadEnvironmentDetails(ctx, token, env)
+		}
+	}
+	if len(catalog.Services) > 0 {
+		model.expanded[0] = true
+	}
+
+	model.setSize(defaultServicePlanBrowserWidth, defaultServicePlanBrowserHeight)
+	model.rebuildVisibleItems(model.firstPlanKey())
+	if model.requestSelectedDetailsLoad() != nil {
+		model.syncViewportContent()
+	}
+	return model
+}
+
+func (m servicePlanBrowserModel) Init() tea.Cmd {
+	return tea.Batch(m.spinner.Tick, m.selectedDetailsLoadCmd())
+}
+
+func (m servicePlanBrowserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.setSize(msg.Width, msg.Height)
+		return m, nil
+	case spinner.TickMsg:
+		if !m.hasLoadingDetails() {
+			return m, nil
+		}
+		var cmd tea.Cmd
+		m.spinner, cmd = m.spinner.Update(msg)
+		m.syncViewportContent()
+		return m, cmd
+	case servicePlanBrowserDetailsLoadedMsg:
+		delete(m.loadingDetails, msg.cacheKey)
+		m.detailCache[msg.cacheKey] = msg.detail
+		m.syncViewportContent()
+		return m, nil
+	case tea.KeyMsg:
+		if m.modal != nil {
+			return m.updateModal(msg), nil
+		}
+
+		switch msg.String() {
+		case "ctrl+c", "q":
+			return m, tea.Quit
+		}
+
+		if m.focus == servicePlanBrowserFocusDetails {
+			return m.updateDetails(msg)
+		}
+
+		switch msg.String() {
+		case "enter":
+			_, loadCmd := m.enterDetailsPane()
+			return m, loadCmd
+		case " ", "right":
+			if m.expandSelectedService() {
+				return m, nil
+			}
+			if entered, loadCmd := m.enterDetailsPane(); entered {
+				return m, loadCmd
+			}
+		case "left":
+			if m.collapseSelectedItem() {
+				return m, nil
+			}
+		}
+	}
+
+	previousKey := m.selectedLeftItemKey()
+	var cmd tea.Cmd
+	m.list, cmd = m.list.Update(msg)
+	if m.selectedLeftItemKey() != previousKey {
+		m.syncSelectionFromList()
+		loadCmd := m.requestSelectedDetailsLoad()
+		m.syncViewportContent()
+		cmd = tea.Batch(cmd, loadCmd)
+	}
+	return m, cmd
+}
+
+func (m servicePlanBrowserModel) updateDetails(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "left":
+		m.focus = servicePlanBrowserFocusLeft
+		m.syncViewportContent()
+	case "tab":
+		return m, m.moveTab(1)
+	case "shift+tab":
+		return m, m.moveTab(-1)
+	case "enter":
+		m.openSelectedModal()
+	case "down":
+		m.moveDetailCursor(1)
+	case "up":
+		m.moveDetailCursor(-1)
+	case "pgdown", "f", " ":
+		m.detailViewportTop = false
+		m.viewport.PageDown()
+	case "pgup", "b":
+		m.detailViewportTop = false
+		m.viewport.PageUp()
+	case "g", "home":
+		m.detailCursor = -1
+		m.detailViewportTop = true
+		m.syncViewportContent()
+	case "G", "end":
+		m.detailViewportTop = false
+		m.viewport.GotoBottom()
+	}
+	return m, nil
+}
+
+func (m servicePlanBrowserModel) updateModal(msg tea.KeyMsg) servicePlanBrowserModel {
+	switch msg.String() {
+	case "ctrl+c", "q":
+		return m
+	case "esc":
+		m.modal = nil
+		return m
+	case "up", "k":
+		m.modal.Cursor = spClamp(m.modal.Cursor-1, spMax(0, len(m.modal.filteredRows())-1))
+		return m
+	case "down", "j":
+		m.modal.Cursor = spClamp(m.modal.Cursor+1, spMax(0, len(m.modal.filteredRows())-1))
+		return m
+	case "backspace", "ctrl+h":
+		if m.modal.Filter != "" {
+			runes := []rune(m.modal.Filter)
+			m.modal.Filter = string(runes[:len(runes)-1])
+			m.modal.Cursor = 0
+		}
+		return m
+	}
+
+	if len(msg.Runes) > 0 {
+		m.modal.Filter += string(msg.Runes)
+		m.modal.Cursor = 0
+	}
+
+	return m
+}
+
+func (m servicePlanBrowserModel) View() string {
+	if m.modal != nil {
+		return m.renderModal()
+	}
+
+	header := renderServicePlanBrowserHeader(m.catalog)
+
+	listPanelStyle := servicePlanBrowserPanelStyle(m.focusBorderColor(servicePlanBrowserFocusLeft))
+	detailPanelStyle := servicePlanBrowserPanelStyle(m.focusBorderColor(servicePlanBrowserFocusDetails))
+	plansPanel := listPanelStyle.Width(m.listPanelWidth).Render(m.list.View())
+	detailsPanel := detailPanelStyle.Width(m.detailPanelWidth).Render(m.viewport.View())
+	body := lipgloss.JoinHorizontal(lipgloss.Top, plansPanel, " ", detailsPanel)
+
+	help := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render(m.helpLine())
+	status := lipgloss.NewStyle().Foreground(lipgloss.Color("111")).Render(m.statusLine())
+	return lipgloss.JoinVertical(lipgloss.Left, header, body, help, status)
+}
+
+func renderServicePlanBrowserSnapshot(model servicePlanBrowserModel) string {
+	return strings.TrimRight(model.View(), "\n")
+}
+
+func (m *servicePlanBrowserModel) setSize(width, height int) {
+	if width <= 0 {
+		width = defaultServicePlanBrowserWidth
+	}
+	if height <= 0 {
+		height = defaultServicePlanBrowserHeight
+	}
+
+	m.width = width
+	m.height = height
+
+	listPanelWidth := spMin(spMax(width/3, servicePlanBrowserListMinWidth), servicePlanBrowserListPreferredWidth)
+	bodyHeight := spMax(height-servicePlanBrowserHeaderHeight-servicePlanBrowserHelpHeight, 12)
+	detailPanelWidth := spMax(width-listPanelWidth-1, 40)
+	panelFrameWidth := servicePlanBrowserPanelStyle(lipgloss.Color("240")).GetHorizontalFrameSize()
+
+	m.listPanelWidth = listPanelWidth
+	m.detailPanelWidth = detailPanelWidth
+	m.list.SetWidth(spMax(listPanelWidth-panelFrameWidth, 10))
+	m.list.SetHeight(bodyHeight)
+	m.viewport.Width = spMax(detailPanelWidth-panelFrameWidth, 10)
+	m.viewport.Height = bodyHeight
+	m.syncViewportContent()
+}
+
+func servicePlanBrowserPanelStyle(borderColor lipgloss.Color) lipgloss.Style {
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(borderColor).
+		Padding(0, 1)
+}
+
+func (m servicePlanBrowserModel) focusBorderColor(focus servicePlanBrowserFocus) lipgloss.Color {
+	if m.focus == focus {
+		return lipgloss.Color("117")
+	}
+	return lipgloss.Color("240")
+}
+
+func (m servicePlanBrowserModel) statusLine() string {
+	if strings.TrimSpace(m.statusMessage) != "" {
+		return m.statusMessage
+	}
+	if m.focus == servicePlanBrowserFocusDetails {
+		return "Use tab or shift+tab to cycle environments. Use esc or left to return to the plan list."
+	}
+	return "Use enter on a plan to focus details. Plan details update as the selector moves."
+}
+
+func (m servicePlanBrowserModel) helpLine() string {
+	if m.focus == servicePlanBrowserFocusDetails {
+		return "↑/↓: detail rows  enter: open row  tab/shift+tab: environment  esc/←: focus plans  q: quit"
+	}
+	return "↑/↓: navigate plans  enter/→: details/open  ←/→: expand/collapse services  q: quit"
+}
+
+func (m *servicePlanBrowserModel) rebuildVisibleItems(selectedKey string) {
+	if selectedKey == "" {
+		selectedKey = m.selectedLeftItemKey()
+	}
+	if selectedKey == "" {
+		selectedKey = m.firstPlanKey()
+	}
+
+	m.items = m.leftItems()
+	listItems := make([]list.Item, len(m.items))
+	selectedIndex := 0
+	for index, item := range m.items {
+		listItems[index] = item
+		if item.key == selectedKey {
+			selectedIndex = index
+		}
+	}
+
+	_ = m.list.SetItems(listItems)
+	if len(listItems) > 0 {
+		m.list.Select(selectedIndex)
+	}
+	m.syncSelectionFromList()
+	m.syncViewportContent()
+}
+
+func (m servicePlanBrowserModel) firstPlanKey() string {
+	for _, item := range m.leftItems() {
+		if !item.isService {
+			return item.key
+		}
+	}
+	return ""
+}
+
+func (m servicePlanBrowserModel) selectedLeftItemKey() string {
+	item := m.selectedLeftItem()
+	if item == nil {
+		return ""
+	}
+	return item.key
+}
+
+func (m servicePlanBrowserModel) selectedLeftItem() *servicePlanBrowserLeftItem {
+	index := m.list.Index()
+	if index < 0 || index >= len(m.items) {
+		return nil
+	}
+	return &m.items[index]
+}
+
+func (m *servicePlanBrowserModel) syncSelectionFromList() {
+	item := m.selectedLeftItem()
+	if item == nil {
+		return
+	}
+
+	if item.isService {
+		m.serviceIndex = item.serviceIndex
+		return
+	}
+
+	changed := m.serviceIndex != item.serviceIndex || m.planIndex != item.planIndex
+	m.serviceIndex = item.serviceIndex
+	m.planIndex = item.planIndex
+	if changed {
+		m.activeTab = 0
+		m.detailCursor = 0
+		m.detailViewportTop = false
+	}
+}
+
+func (m *servicePlanBrowserModel) syncViewportContent() {
+	selected := m.selectedLeftItem()
+	if selected == nil {
+		m.viewport.SetContent("No service plans found.")
+		return
+	}
+
+	if selected.isService {
+		m.viewport.SetContent(m.renderServiceContent(*selected, m.viewport.Width))
+		m.viewport.GotoTop()
+		return
+	}
+
+	content, cursorLine := m.renderPlanContentWithCursorLine(m.viewport.Width)
+	m.viewport.SetContent(content)
+	if m.focus == servicePlanBrowserFocusDetails {
+		if m.detailViewportTop {
+			m.viewport.GotoTop()
+		} else {
+			m.ensureViewportLineVisible(cursorLine, len(strings.Split(content, "\n")))
+		}
+	} else {
+		m.viewport.GotoTop()
+	}
+}
+
+func (m servicePlanBrowserModel) renderServiceContent(item servicePlanBrowserLeftItem, width int) string {
+	service := m.catalog.Services[item.serviceIndex]
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230"))
+	sectionStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("117"))
+	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("111"))
+	valueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+
+	lines := []string{
+		titleStyle.Render(service.Name),
+		"",
+		sectionStyle.Render("Overview"),
+	}
+	lines = append(lines, renderServicePlanField("Service ID", emptyValue(service.ID), width, keyStyle, valueStyle)...)
+	lines = append(lines, renderServicePlanField("Plans", fmt.Sprintf("%d", len(service.Plans)), width, keyStyle, valueStyle)...)
+	lines = append(lines, "", sectionStyle.Render("Plan names"))
+	for _, plan := range service.Plans {
+		lines = append(lines, renderServicePlanBullet(fmt.Sprintf("%s: %s", plan.Name, servicePlanEnvironmentSummary(plan)), width, keyStyle, valueStyle)...)
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func (m servicePlanBrowserModel) renderPlanContentWithCursorLine(width int) (string, int) {
+	plan := m.selectedPlan()
+	if plan == nil {
+		return "No plan selected.", -1
+	}
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230"))
+	sectionStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("117"))
+	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("111"))
+	valueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	selectedKeyStyle := keyStyle.Foreground(lipgloss.Color("230")).Background(lipgloss.Color("62"))
+	selectedValueStyle := valueStyle.Foreground(lipgloss.Color("230")).Background(lipgloss.Color("62"))
+
+	lines := []string{
+		titleStyle.Render(plan.ServiceName + " / " + plan.Name),
+		m.renderEnvironmentSelector(width),
+		"",
+		sectionStyle.Render("Overview"),
+	}
+	lines = append(lines, renderServicePlanField("Plan name", plan.Name, width, keyStyle, valueStyle)...)
+	lines = append(lines, renderServicePlanField("Service ID", emptyValue(plan.ServiceID), width, keyStyle, valueStyle)...)
+	lines = append(lines, renderServicePlanField("Environments", servicePlanEnvironmentSummary(*plan), width, keyStyle, valueStyle)...)
+
+	env := m.selectedEnvironment()
+	if env == nil {
+		lines = append(lines, "", sectionStyle.Render("Environment"))
+		lines = append(lines, renderServicePlanField("Status", "No environment selected", width, keyStyle, valueStyle)...)
+		return strings.Join(lines, "\n"), -1
+	}
+
+	lines = append(lines, "", sectionStyle.Render("Environment"))
+	lines = append(lines, renderServicePlanField("Name", env.Name, width, keyStyle, valueStyle)...)
+	lines = append(lines, renderServicePlanField("Plan ID", emptyValue(env.PlanID), width, keyStyle, valueStyle)...)
+
+	lines = append(lines, "", sectionStyle.Render("Details"))
+	rows := m.detailRows()
+	cursorLine := -1
+	for index, row := range rows {
+		value := row.Value
+		if row.ModalKind != "" {
+			value += " (enter)"
+		}
+		rowKeyStyle := keyStyle
+		rowValueStyle := valueStyle
+		label := row.Label
+		if m.focus == servicePlanBrowserFocusDetails && index == m.detailCursor {
+			rowKeyStyle = selectedKeyStyle
+			rowValueStyle = selectedValueStyle
+			label = "▸ " + label
+		}
+		if index == m.detailCursor {
+			cursorLine = servicePlanRenderedLineCount(lines)
+		}
+		lines = append(lines, renderServicePlanField(label, value, width, rowKeyStyle, rowValueStyle)...)
+	}
+
+	return strings.Join(lines, "\n"), cursorLine
+}
+
+func servicePlanRenderedLineCount(lines []string) int {
+	if len(lines) == 0 {
+		return 0
+	}
+	return len(strings.Split(strings.Join(lines, "\n"), "\n"))
+}
+
+func renderServicePlanField(label, value string, width int, keyStyle, valueStyle lipgloss.Style) []string {
+	prefix := label + ": "
+	valueWidth := spMax(width-lipgloss.Width(prefix), 16)
+	valueLines := wrapServicePlanLine(value, valueWidth)
+	if len(valueLines) == 0 {
+		valueLines = []string{""}
+	}
+
+	rendered := make([]string, 0, len(valueLines))
+	continuationIndent := strings.Repeat(" ", lipgloss.Width(prefix))
+	for index, valueLine := range valueLines {
+		if index == 0 {
+			rendered = append(rendered, keyStyle.Render(prefix)+valueStyle.Render(valueLine))
+			continue
+		}
+		rendered = append(rendered, continuationIndent+valueStyle.Render(valueLine))
+	}
+
+	return rendered
+}
+
+func renderServicePlanBullet(line string, width int, keyStyle, valueStyle lipgloss.Style) []string {
+	item := strings.TrimSpace(line)
+	if item == "" {
+		return []string{line}
+	}
+
+	if label, value, ok := strings.Cut(item, ": "); ok {
+		prefix := "• " + label + ": "
+		valueWidth := spMax(width-lipgloss.Width(prefix), 16)
+		valueLines := wrapServicePlanLine(value, valueWidth)
+		if len(valueLines) == 0 {
+			valueLines = []string{""}
+		}
+
+		rendered := make([]string, 0, len(valueLines))
+		continuationIndent := strings.Repeat(" ", lipgloss.Width(prefix))
+		for index, valueLine := range valueLines {
+			if index == 0 {
+				rendered = append(rendered, keyStyle.Render("• "+label+": ")+valueStyle.Render(valueLine))
+				continue
+			}
+			rendered = append(rendered, continuationIndent+valueStyle.Render(valueLine))
+		}
+		return rendered
+	}
+
+	wrapped := wrapServicePlanLine("• "+item, width)
+	rendered := make([]string, 0, len(wrapped))
+	for _, wrappedLine := range wrapped {
+		rendered = append(rendered, keyStyle.Render(wrappedLine))
+	}
+	return rendered
+}
+
+func wrapServicePlanLine(line string, width int) []string {
+	if width <= 0 || line == "" || lipgloss.Width(line) <= width {
+		return []string{line}
+	}
+
+	runes := []rune(line)
+	wrapped := make([]string, 0, 2)
+	for len(runes) > 0 {
+		currentWidth := 0
+		splitIndex := 0
+		lastSoftBreak := 0
+
+		for index, r := range runes {
+			runeWidth := lipgloss.Width(string(r))
+			if currentWidth+runeWidth > width {
+				break
+			}
+			currentWidth += runeWidth
+			splitIndex = index + 1
+			if isServicePlanSoftBreak(r) {
+				lastSoftBreak = splitIndex
+			}
+		}
+
+		if splitIndex == 0 {
+			splitIndex = 1
+		}
+		if splitIndex < len(runes) && lastSoftBreak > 0 {
+			splitIndex = lastSoftBreak
+		}
+
+		wrapped = append(wrapped, string(runes[:splitIndex]))
+		runes = runes[splitIndex:]
+	}
+
+	return wrapped
+}
+
+func isServicePlanSoftBreak(r rune) bool {
+	return unicode.IsSpace(r) || strings.ContainsRune("/:?&=_-.,", r)
+}
+
+func renderServicePlanBrowserHeader(catalog servicePlanBrowserCatalog) string {
+	serviceCount := len(catalog.Services)
+	planCount := 0
+	envCount := 0
+	for _, service := range catalog.Services {
+		planCount += len(service.Plans)
+		for _, plan := range service.Plans {
+			envCount += len(plan.Environments)
+		}
+	}
+
+	title := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230")).Render("Service Plan Browser")
+	metadata := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render(
+		fmt.Sprintf("%d service(s)  |  %d plan name(s)  |  %d environment variant(s)", serviceCount, planCount, envCount),
+	)
+	checks := []string{
+		renderServicePlanBrowserCheck("Service catalog loaded", serviceCount > 0),
+		renderServicePlanBrowserCheck("Plan details available", planCount > 0),
+	}
+
+	return lipgloss.JoinVertical(lipgloss.Left, title, metadata, strings.Join(checks, "  "))
+}
+
+func renderServicePlanBrowserCheck(label string, ok bool) string {
+	icon := "○"
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	if ok {
+		icon = "✓"
+		style = lipgloss.NewStyle().Foreground(lipgloss.Color("82")).Bold(true)
+	}
+	return style.Render(fmt.Sprintf("%s %s", icon, label))
+}
+
+func (m servicePlanBrowserModel) renderEnvironmentSelector(width int) string {
+	plan := m.selectedPlan()
+	if plan == nil || len(plan.Environments) == 0 {
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render("No environments")
+	}
+
+	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("111"))
+	items := []string{labelStyle.Render("Environment:")}
+	for i, env := range plan.Environments {
+		envColor := servicePlanEnvironmentColor(env.Name)
+		name := emptyValue(env.Name)
+		if i == m.activeTab {
+			items = append(items, lipgloss.NewStyle().
+				Bold(true).
+				Foreground(envColor).
+				Render("▸ "+name))
+		} else {
+			items = append(items, lipgloss.NewStyle().
+				Foreground(envColor).
+				Faint(true).
+				Render(name))
+		}
+	}
+
+	return lipgloss.NewStyle().MaxWidth(width).Render(strings.Join(items, "  "))
+}
+
+func servicePlanEnvironmentColor(environment string) lipgloss.Color {
+	normalized := strings.ToLower(strings.TrimSpace(environment))
+	switch normalized {
+	case "prod", "production":
+		return lipgloss.Color("160")
+	case "stage", "staging":
+		return lipgloss.Color("214")
+	case "dev", "development":
+		return lipgloss.Color("82")
+	case "qa", "test", "testing":
+		return lipgloss.Color("39")
+	default:
+		return lipgloss.Color("62")
+	}
+}
+
+func (m servicePlanBrowserModel) detailRows() []servicePlanBrowserDetailRow {
+	env := m.selectedEnvironment()
+	if env == nil {
+		return []servicePlanBrowserDetailRow{{Label: "Status", Value: "No environment selected"}}
+	}
+
+	detail, ok := m.detailCache[env.cacheKey()]
+	if !ok {
+		if m.loadingDetails[env.cacheKey()] {
+			return []servicePlanBrowserDetailRow{{Label: "Status", Value: m.spinner.View() + " Loading details"}}
+		}
+		return []servicePlanBrowserDetailRow{{Label: "Status", Value: "Details not loaded"}}
+	}
+	if detail.Err != "" {
+		return []servicePlanBrowserDetailRow{{Label: "Error", Value: detail.Err}}
+	}
+
+	return []servicePlanBrowserDetailRow{
+		{Label: "Deployment model", Value: emptyValue(detail.DeploymentModel)},
+		{Label: "Enabled features", Value: joinOrNone(detail.EnabledFeatures)},
+		{Label: "Clouds", Value: joinOrNone(detail.Clouds)},
+		{Label: "Regions", Value: joinOrNone(detail.Regions)},
+		{Label: "Deployments", Value: fmt.Sprintf("%d", detail.DeploymentsCount), ModalKind: servicePlanBrowserModalDeployments},
+		{Label: "Subscriptions", Value: fmt.Sprintf("%d", detail.ActiveSubscriptionsCount), ModalKind: servicePlanBrowserModalSubscriptions},
+		{Label: "Users", Value: fmt.Sprintf("%d", detail.UniqueUsersCount), ModalKind: servicePlanBrowserModalUsers},
+	}
+}
+
+func (m servicePlanBrowserModel) renderModal() string {
+	rows := m.modal.filteredRows()
+	width := spMax(m.width, 80)
+	height := spMax(m.height, 24)
+	contentHeight := spMax(height-6, 8)
+
+	lines := []string{
+		lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230")).Background(lipgloss.Color("62")).Render(" " + m.modal.Title + " "),
+		"Filter: " + m.modal.Filter,
+		"",
+	}
+
+	if len(rows) == 0 {
+		lines = append(lines, "No matching rows")
+	} else {
+		start := 0
+		if m.modal.Cursor >= contentHeight {
+			start = m.modal.Cursor - contentHeight + 1
+		}
+		end := spMin(len(rows), start+contentHeight)
+		for i := start; i < end; i++ {
+			prefix := "  "
+			style := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+			if i == m.modal.Cursor {
+				prefix = "▸ "
+				style = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230"))
+			}
+			lines = append(lines, style.Render(prefix+rows[i].Text))
+		}
+	}
+
+	lines = append(lines, "", lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render("esc: close  type: filter  ↑/↓: navigate"))
+
+	return servicePlanBrowserPanelStyle(lipgloss.Color("117")).
+		Width(width - 4).
+		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
+}
+
+func (m *servicePlanBrowserModel) moveDetailCursor(delta int) {
+	rows := m.detailRows()
+	if len(rows) == 0 {
+		m.detailCursor = -1
+		m.detailViewportTop = true
+		m.syncViewportContent()
+		return
+	}
+
+	switch {
+	case m.detailCursor <= 0 && delta < 0:
+		m.detailCursor = -1
+		m.detailViewportTop = true
+	case m.detailCursor < 0 && delta <= 0:
+		m.detailCursor = -1
+		m.detailViewportTop = true
+	case m.detailCursor < 0 && delta > 0:
+		m.detailCursor = 0
+		m.detailViewportTop = false
+	default:
+		m.detailCursor = spClamp(m.detailCursor+delta, len(rows)-1)
+		m.detailViewportTop = false
+	}
+	m.syncViewportContent()
+}
+
+func (m *servicePlanBrowserModel) ensureViewportLineVisible(line, totalLines int) {
+	if line < 0 {
+		return
+	}
+
+	visibleRows := m.viewport.Height
+	if visibleRows < 1 {
+		visibleRows = 1
+	}
+
+	maxScroll := totalLines - visibleRows
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+
+	if m.viewport.YOffset < 0 {
+		m.viewport.YOffset = 0
+	}
+	if m.viewport.YOffset > maxScroll {
+		m.viewport.YOffset = maxScroll
+	}
+	if line < m.viewport.YOffset {
+		m.viewport.YOffset = line
+	}
+	if line >= m.viewport.YOffset+visibleRows {
+		m.viewport.YOffset = line - visibleRows + 1
+	}
+	if m.viewport.YOffset > maxScroll {
+		m.viewport.YOffset = maxScroll
+	}
+}
+
+func (m *servicePlanBrowserModel) moveTab(delta int) tea.Cmd {
+	selected := m.selectedLeftItem()
+	if selected == nil || selected.isService {
+		return nil
+	}
+
+	plan := m.selectedPlan()
+	if plan == nil || len(plan.Environments) == 0 {
+		m.activeTab = 0
+		return nil
+	}
+	m.activeTab = (m.activeTab + delta + len(plan.Environments)) % len(plan.Environments)
+	m.detailCursor = -1
+	m.detailViewportTop = true
+	loadCmd := m.requestSelectedDetailsLoad()
+	m.syncViewportContent()
+	return loadCmd
+}
+
+func (m *servicePlanBrowserModel) enterDetailsPane() (bool, tea.Cmd) {
+	selected := m.selectedLeftItem()
+	if selected == nil || selected.isService {
+		return false, nil
+	}
+
+	m.focus = servicePlanBrowserFocusDetails
+	m.syncSelectionFromList()
+	loadCmd := m.requestSelectedDetailsLoad()
+	m.syncViewportContent()
+	return true, loadCmd
+}
+
+func (m *servicePlanBrowserModel) expandSelectedService() bool {
+	selected := m.selectedLeftItem()
+	if selected == nil || !selected.expandable {
+		return false
+	}
+	if selected.expanded {
+		return false
+	}
+
+	m.expanded[selected.serviceIndex] = true
+	m.rebuildVisibleItems(selected.key)
+	return true
+}
+
+func (m *servicePlanBrowserModel) collapseSelectedItem() bool {
+	selected := m.selectedLeftItem()
+	if selected == nil {
+		return false
+	}
+
+	if selected.expandable && selected.expanded {
+		m.expanded[selected.serviceIndex] = false
+		m.rebuildVisibleItems(selected.key)
+		return true
+	}
+
+	if selected.parentKey == "" {
+		return false
+	}
+
+	m.expanded[selected.serviceIndex] = false
+	m.rebuildVisibleItems(selected.parentKey)
+	return true
+}
+
+func (m *servicePlanBrowserModel) openSelectedModal() {
+	rows := m.detailRows()
+	if len(rows) == 0 || m.detailCursor < 0 || m.detailCursor >= len(rows) {
+		return
+	}
+	row := rows[m.detailCursor]
+	if row.ModalKind == "" {
+		m.statusMessage = "Selected detail row does not have expandable rows"
+		return
+	}
+
+	detail, ok := m.selectedDetails()
+	if !ok {
+		return
+	}
+
+	modalRows := make([]servicePlanBrowserModalRow, 0)
+	title := row.Label
+	switch row.ModalKind {
+	case servicePlanBrowserModalDeployments:
+		for _, deployment := range detail.Deployments {
+			text := fmt.Sprintf("%s | %s | %s | %s | %s", emptyValue(deployment.ID), emptyValue(deployment.Status), emptyValue(deployment.Cloud), emptyValue(deployment.Region), emptyValue(deployment.Owner))
+			modalRows = append(modalRows, servicePlanBrowserModalRow{Text: text, Search: strings.ToLower(text)})
+		}
+	case servicePlanBrowserModalSubscriptions:
+		for _, subscription := range detail.Subscriptions {
+			text := fmt.Sprintf("%s | %s | %s | %s | instances=%d", emptyValue(subscription.ID), emptyValue(subscription.Status), emptyValue(subscription.RootUserEmail), emptyValue(subscription.RootUserName), subscription.InstanceCount)
+			modalRows = append(modalRows, servicePlanBrowserModalRow{Text: text, Search: strings.ToLower(text)})
+		}
+	case servicePlanBrowserModalUsers:
+		for _, user := range detail.Users {
+			text := fmt.Sprintf("%s | %s | %s | %s | %s", emptyValue(user.ID), emptyValue(user.Email), emptyValue(user.Name), emptyValue(user.Status), emptyValue(user.OrgName))
+			modalRows = append(modalRows, servicePlanBrowserModalRow{Text: text, Search: strings.ToLower(text)})
+		}
+	}
+
+	m.modal = &servicePlanBrowserModal{
+		Kind:  row.ModalKind,
+		Title: title,
+		Rows:  modalRows,
+	}
+}
+
+func (m servicePlanBrowserModel) leftItems() []servicePlanBrowserLeftItem {
+	items := make([]servicePlanBrowserLeftItem, 0)
+	for serviceIndex, service := range m.catalog.Services {
+		serviceKey := fmt.Sprintf("service:%d", serviceIndex)
+		items = append(items, servicePlanBrowserLeftItem{
+			key:          serviceKey,
+			title:        service.Name,
+			description:  fmt.Sprintf("%d plan name(s)", len(service.Plans)),
+			expandable:   len(service.Plans) > 0,
+			expanded:     m.expanded[serviceIndex],
+			isService:    true,
+			serviceIndex: serviceIndex,
+		})
+		if !m.expanded[serviceIndex] {
+			continue
+		}
+		for planIndex, plan := range service.Plans {
+			items = append(items, servicePlanBrowserLeftItem{
+				key:          fmt.Sprintf("%s/plan:%d", serviceKey, planIndex),
+				parentKey:    serviceKey,
+				title:        plan.Name,
+				description:  servicePlanEnvironmentSummary(plan),
+				level:        1,
+				hostingBadge: servicePlanHostingBadgeForPlan(plan),
+				serviceIndex: serviceIndex,
+				planIndex:    planIndex,
+			})
+		}
+	}
+	return items
+}
+
+func servicePlanHostingBadgeForPlan(plan servicePlanBrowserPlan) servicePlanHostingBadge {
+	for _, env := range plan.Environments {
+		if badge := servicePlanHostingBadgeForValues(env.TenancyType, env.DeploymentType); badge.Label != "" {
+			return badge
+		}
+	}
+	return servicePlanHostingBadgeForValues("", "")
+}
+
+func servicePlanHostingBadgeForValues(modelType, tierType string) servicePlanHostingBadge {
+	values := []string{modelType, tierType}
+	normalizedValues := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.ToUpper(strings.TrimSpace(value))
+		value = strings.ReplaceAll(value, "-", "_")
+		value = strings.ReplaceAll(value, " ", "_")
+		if value != "" {
+			normalizedValues = append(normalizedValues, value)
+		}
+	}
+
+	for _, value := range normalizedValues {
+		switch value {
+		case "CUSTOMER_CLOUD", "BYOA", "BYOC":
+			return servicePlanHostingBadge{Label: "BYOC", Color: lipgloss.Color("166")}
+		}
+	}
+	for _, value := range normalizedValues {
+		if value == "OMNISTRATE_HOSTED" {
+			return servicePlanHostingBadge{Label: "Omnistrate Hosted", Color: lipgloss.Color("29")}
+		}
+	}
+	for _, value := range normalizedValues {
+		switch value {
+		case "CUSTOMER_HOSTED", "HOSTED", "DEDICATED", "SHARED", "OMNISTRATE_DEDICATED_TENANCY", "OMNISTRATE_MULTI_TENANCY":
+			return servicePlanHostingBadge{Label: "Hosted", Color: lipgloss.Color("33")}
+		}
+	}
+	return servicePlanHostingBadge{Label: "Hosted", Color: lipgloss.Color("33")}
+}
+
+func renderServicePlanHostingBadge(badge servicePlanHostingBadge) string {
+	if badge.Label == "" {
+		return ""
+	}
+
+	return lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("230")).
+		Background(badge.Color).
+		Padding(0, 1).
+		Render(badge.Label)
+}
+
+func servicePlanEnvironmentSummary(plan servicePlanBrowserPlan) string {
+	if len(plan.Environments) == 0 {
+		return "no environments"
+	}
+
+	names := make([]string, 0, len(plan.Environments))
+	for _, env := range plan.Environments {
+		if strings.TrimSpace(env.Name) != "" {
+			names = append(names, env.Name)
+		}
+	}
+	if len(names) == 0 {
+		return fmt.Sprintf("%d environment(s)", len(plan.Environments))
+	}
+	return fmt.Sprintf("%d environment(s)  |  %s", len(plan.Environments), strings.Join(names, ", "))
+}
+
+func (m servicePlanBrowserModel) selectedPlan() *servicePlanBrowserPlan {
+	if m.serviceIndex < 0 || m.serviceIndex >= len(m.catalog.Services) {
+		return nil
+	}
+	plans := m.catalog.Services[m.serviceIndex].Plans
+	if m.planIndex < 0 || m.planIndex >= len(plans) {
+		return nil
+	}
+	return &plans[m.planIndex]
+}
+
+func (m servicePlanBrowserModel) selectedEnvironment() *servicePlanBrowserEnvironment {
+	plan := m.selectedPlan()
+	if plan == nil || len(plan.Environments) == 0 {
+		return nil
+	}
+	activeTab := spClamp(m.activeTab, len(plan.Environments)-1)
+	return &plan.Environments[activeTab]
+}
+
+func (m servicePlanBrowserModel) selectedDetails() (servicePlanEnvironmentDetails, bool) {
+	env := m.selectedEnvironment()
+	if env == nil {
+		return servicePlanEnvironmentDetails{}, false
+	}
+	detail, ok := m.detailCache[env.cacheKey()]
+	return detail, ok
+}
+
+func (m *servicePlanBrowserModel) requestSelectedDetailsLoad() tea.Cmd {
+	env := m.selectedEnvironment()
+	if env == nil {
+		return nil
+	}
+	key := env.cacheKey()
+	if _, ok := m.detailCache[key]; ok {
+		return nil
+	}
+	if m.loadingDetails[key] {
+		return nil
+	}
+	if m.loadEnvironmentDetails == nil {
+		return nil
+	}
+
+	m.loadingDetails[key] = true
+	return tea.Batch(m.spinner.Tick, m.loadDetailsCmd(*env))
+}
+
+func (m servicePlanBrowserModel) selectedDetailsLoadCmd() tea.Cmd {
+	env := m.selectedEnvironment()
+	if env == nil {
+		return nil
+	}
+	if !m.loadingDetails[env.cacheKey()] {
+		return nil
+	}
+	return m.loadDetailsCmd(*env)
+}
+
+func (m servicePlanBrowserModel) loadDetailsCmd(env servicePlanBrowserEnvironment) tea.Cmd {
+	if m.loadEnvironmentDetails == nil {
+		return nil
+	}
+
+	return func() tea.Msg {
+		detail, err := m.loadEnvironmentDetails(env)
+		if err != nil {
+			detail = servicePlanEnvironmentDetails{Err: err.Error()}
+		}
+		return servicePlanBrowserDetailsLoadedMsg{
+			cacheKey: env.cacheKey(),
+			detail:   detail,
+		}
+	}
+}
+
+func (m servicePlanBrowserModel) hasLoadingDetails() bool {
+	for _, loading := range m.loadingDetails {
+		if loading {
+			return true
+		}
+	}
+	return false
+}
+
+func (e servicePlanBrowserEnvironment) cacheKey() string {
+	return e.ServiceID + "/" + e.ID + "/" + e.PlanID
+}
+
+func (m servicePlanBrowserModal) filteredRows() []servicePlanBrowserModalRow {
+	return filterServicePlanModalRows(m.Rows, m.Filter)
+}
+
+func filterServicePlanModalRows(rows []servicePlanBrowserModalRow, filter string) []servicePlanBrowserModalRow {
+	filter = strings.ToLower(strings.TrimSpace(filter))
+	if filter == "" {
+		return rows
+	}
+
+	filtered := make([]servicePlanBrowserModalRow, 0, len(rows))
+	for _, row := range rows {
+		if strings.Contains(row.Search, filter) || strings.Contains(strings.ToLower(row.Text), filter) {
+			filtered = append(filtered, row)
+		}
+	}
+	return filtered
+}
+
+func (productionServicePlanBrowserLoader) LoadEnvironmentDetails(ctx context.Context, token string, env servicePlanBrowserEnvironment) (servicePlanEnvironmentDetails, error) {
+	pageSize := int64(100)
+	exclude := true
+
+	productTier, err := dataaccess.DescribeProductTier(ctx, token, env.ServiceID, env.PlanID)
+	if err != nil {
+		return servicePlanEnvironmentDetails{}, err
+	}
+
+	deployments, err := dataaccess.ListAllResourceInstances(ctx, token, env.ServiceID, env.ID, &dataaccess.ListResourceInstanceOptions{
+		ProductTierId:           &env.PlanID,
+		PageSize:                &pageSize,
+		ExcludeNetworkTopology:  &exclude,
+		ExcludeHAStatus:         &exclude,
+		ExcludeIntegrations:     &exclude,
+		ExcludeMaintenanceTasks: &exclude,
+	})
+	if err != nil {
+		return servicePlanEnvironmentDetails{}, err
+	}
+
+	includeInactive := false
+	subscriptions, err := dataaccess.ListAllSubscriptions(ctx, token, env.ServiceID, env.ID, &dataaccess.ListSubscriptionsOptions{
+		ProductTierId:   &env.PlanID,
+		IncludeInactive: &includeInactive,
+		ExcludePricing:  &exclude,
+		PageSize:        &pageSize,
+	})
+	if err != nil {
+		return servicePlanEnvironmentDetails{}, err
+	}
+	activeSubscriptions := activeServicePlanSubscriptions(subscriptions)
+
+	allUsers := make([]openapiclientfleet.User, 0)
+	for _, subscription := range activeSubscriptions {
+		if strings.TrimSpace(subscription.Id) == "" {
+			continue
+		}
+		subscriptionID := subscription.Id
+		users, err := dataaccess.ListAllUsers(ctx, token, env.ServiceID, env.ID, &dataaccess.ListUsersOptions{
+			SubscriptionId: &subscriptionID,
+			ExcludeStats:   &exclude,
+			PageSize:       &pageSize,
+		})
+		if err != nil {
+			return servicePlanEnvironmentDetails{}, err
+		}
+		allUsers = append(allUsers, users...)
+	}
+	uniqueUsers := dedupeServicePlanUsers(allUsers)
+
+	clouds, regions := productTierCloudsAndRegions(productTier)
+	detail := servicePlanEnvironmentDetails{
+		DeploymentModel:          servicePlanDeploymentModel(env, productTier),
+		EnabledFeatures:          productTierEnabledFeatures(productTier),
+		Clouds:                   clouds,
+		Regions:                  regions,
+		Deployments:              servicePlanDeploymentRows(deployments),
+		Subscriptions:            servicePlanSubscriptionRows(activeSubscriptions),
+		Users:                    servicePlanUserRows(uniqueUsers),
+		DeploymentsCount:         len(deployments),
+		ActiveSubscriptionsCount: len(activeSubscriptions),
+		UniqueUsersCount:         len(uniqueUsers),
+	}
+	return detail, nil
+}
+
+func activeServicePlanSubscriptions(subscriptions []openapiclientfleet.FleetDescribeSubscriptionResult) []openapiclientfleet.FleetDescribeSubscriptionResult {
+	active := make([]openapiclientfleet.FleetDescribeSubscriptionResult, 0, len(subscriptions))
+	for _, subscription := range subscriptions {
+		status := strings.ToLower(strings.TrimSpace(subscription.Status))
+		switch status {
+		case "inactive", "suspended", "cancelled", "canceled", "terminated", "deleted":
+			continue
+		default:
+			active = append(active, subscription)
+		}
+	}
+	return active
+}
+
+func dedupeServicePlanUsers(users []openapiclientfleet.User) []openapiclientfleet.User {
+	seen := map[string]bool{}
+	unique := make([]openapiclientfleet.User, 0, len(users))
+	for _, user := range users {
+		key := strings.TrimSpace(user.UserId)
+		if key == "" {
+			key = strings.ToLower(strings.TrimSpace(user.Email))
+		}
+		if key == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		unique = append(unique, user)
+	}
+	return unique
+}
+
+func productTierCloudsAndRegions(productTier *openapiclient.DescribeProductTierResult) ([]string, []string) {
+	if productTier == nil {
+		return nil, nil
+	}
+
+	cloudSet := map[string]bool{}
+	regionSet := map[string]bool{}
+	add := func(cloud string, regions []string) {
+		if len(regions) == 0 {
+			return
+		}
+		cloudSet[cloud] = true
+		for _, region := range regions {
+			if strings.TrimSpace(region) != "" {
+				regionSet[region] = true
+			}
+		}
+	}
+
+	add("aws", productTier.AwsRegions)
+	add("azure", productTier.AzureRegions)
+	add("gcp", productTier.GcpRegions)
+	add("oci", productTier.OciRegions)
+	add("nebius", productTier.NebiusRegions)
+	add("private", productTier.PrivateRegions)
+	add("on-prem", productTier.OnPremPlatforms)
+
+	if productTier.CloudProvidersConfigReadiness != nil {
+		for cloud, regions := range *productTier.CloudProvidersConfigReadiness {
+			if strings.TrimSpace(cloud) != "" {
+				cloudSet[cloud] = true
+			}
+			for region := range regions {
+				if strings.TrimSpace(region) != "" {
+					regionSet[region] = true
+				}
+			}
+		}
+	}
+
+	return sortedKeys(cloudSet), sortedKeys(regionSet)
+}
+
+func productTierEnabledFeatures(productTier *openapiclient.DescribeProductTierResult) []string {
+	if productTier == nil {
+		return nil
+	}
+
+	featureSet := map[string]bool{}
+	for _, feature := range productTier.EnabledFeatures {
+		name := strings.TrimSpace(feature.GetFeature())
+		if name == "" {
+			continue
+		}
+		scope := strings.TrimSpace(feature.GetScope())
+		if scope != "" {
+			name = name + " (" + scope + ")"
+		}
+		featureSet[name] = true
+	}
+
+	if productTier.Features != nil {
+		for name, enabled := range *productTier.Features {
+			if enabled && strings.TrimSpace(name) != "" {
+				featureSet[name] = true
+			}
+		}
+	}
+
+	return sortedKeys(featureSet)
+}
+
+func servicePlanDeploymentModel(env servicePlanBrowserEnvironment, productTier *openapiclient.DescribeProductTierResult) string {
+	parts := make([]string, 0, 2)
+	if env.DeploymentType != "" {
+		parts = append(parts, env.DeploymentType)
+	} else if productTier != nil && productTier.TierType != "" {
+		parts = append(parts, productTier.TierType)
+	}
+	if env.TenancyType != "" {
+		parts = append(parts, env.TenancyType)
+	}
+	return strings.Join(parts, " / ")
+}
+
+func servicePlanDeploymentRows(instances []openapiclientfleet.ResourceInstance) []servicePlanDeploymentRow {
+	rows := make([]servicePlanDeploymentRow, 0, len(instances))
+	for _, instance := range instances {
+		result := instance.ConsumptionResourceInstanceResult
+		status := result.GetStatus()
+		if status == "" {
+			status = instance.TierVersionStatus
+		}
+		cloud := instance.CloudProvider
+		if cloud == "" {
+			cloud = result.GetCloudProvider()
+		}
+		rows = append(rows, servicePlanDeploymentRow{
+			ID:           result.GetId(),
+			Status:       status,
+			Cloud:        cloud,
+			Region:       result.GetRegion(),
+			Subscription: instance.SubscriptionId,
+			Owner:        instance.SubscriptionOwnerName,
+		})
+	}
+	return rows
+}
+
+func servicePlanSubscriptionRows(subscriptions []openapiclientfleet.FleetDescribeSubscriptionResult) []servicePlanSubscriptionRow {
+	rows := make([]servicePlanSubscriptionRow, 0, len(subscriptions))
+	for _, subscription := range subscriptions {
+		rows = append(rows, servicePlanSubscriptionRow{
+			ID:            subscription.Id,
+			Status:        subscription.Status,
+			RootUserEmail: subscription.RootUserEmail,
+			RootUserName:  subscription.RootUserName,
+			InstanceCount: subscription.InstanceCount,
+		})
+	}
+	return rows
+}
+
+func servicePlanUserRows(users []openapiclientfleet.User) []servicePlanUserRow {
+	rows := make([]servicePlanUserRow, 0, len(users))
+	for _, user := range users {
+		rows = append(rows, servicePlanUserRow{
+			ID:      user.UserId,
+			Email:   user.Email,
+			Name:    user.UserName,
+			Status:  user.Status,
+			OrgName: user.OrgName,
+		})
+	}
+	return rows
+}
+
+func sortedKeys(values map[string]bool) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func joinOrNone(values []string) string {
+	if len(values) == 0 {
+		return "none"
+	}
+	return strings.Join(values, ", ")
+}
+
+func emptyValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "-"
+	}
+	return value
+}
+
+func isServicePlanBrowserInteractive() bool {
+	return servicePlanBrowserFileIsTerminal(os.Stdout) && servicePlanBrowserFileIsTerminal(os.Stdin)
+}
+
+func servicePlanBrowserFileIsTerminal(file *os.File) bool {
+	if file == nil {
+		return false
+	}
+
+	fd := file.Fd()
+	if fd > uintptr(^uint(0)>>1) {
+		return false
+	}
+
+	return term.IsTerminal(int(fd))
+}
+
+func spMin(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func spMax(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func spClamp(value, maxValue int) int {
+	if maxValue < 0 {
+		return 0
+	}
+	if value < 0 {
+		return 0
+	}
+	if value > maxValue {
+		return maxValue
+	}
+	return value
+}

--- a/cmd/serviceplan/browser.go
+++ b/cmd/serviceplan/browser.go
@@ -6,9 +6,13 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/charmbracelet/bubbles/list"
@@ -22,6 +26,7 @@ import (
 	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
 	openapiclient "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
 	"golang.org/x/term"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -31,7 +36,7 @@ const (
 	servicePlanBrowserListPreferredWidth = 42
 	servicePlanBrowserHelpHeight         = 2
 	servicePlanBrowserHeaderHeight       = 1
-	servicePlanBrowserTabsHeight         = 3
+	servicePlanBrowserTabsHeight         = 4
 
 	servicePlanBrowserFocusLeft servicePlanBrowserFocus = iota
 	servicePlanBrowserFocusDetails
@@ -43,7 +48,28 @@ const (
 
 	servicePlanCustomerAccountConfigIDParamKey = "cloud_provider_account_config_id"
 	servicePlanCustomerAccountResourcePrefix   = "r-injectedaccountconfig"
+	servicePlanCustomerAccountResourceKey      = "omnistrateCloudAccountConfig"
+
+	servicePlanCustomerAccountIacToolKey             = "account_configuration_method"
+	servicePlanCustomerAccountAWSAccountIDKey        = "aws_account_id"
+	servicePlanCustomerAccountAWSBootstrapRoleKey    = "aws_bootstrap_role_arn"
+	servicePlanCustomerAccountGCPProjectIDKey        = "gcp_project_id"
+	servicePlanCustomerAccountGCPProjectNumberKey    = "gcp_project_number"
+	servicePlanCustomerAccountGCPServiceAccountKey   = "gcp_service_account_email"
+	servicePlanCustomerAccountAzureSubscriptionIDKey = "azure_subscription_id"
+	servicePlanCustomerAccountAzureTenantIDKey       = "azure_tenant_id"
+	servicePlanCustomerAccountNebiusTenantIDKey      = "nebius_tenant_id"
+	servicePlanCustomerAccountNebiusBindingsKey      = "nebius_bindings"
+	servicePlanCustomerAccountNebiusBindingsFileKey  = "nebius_bindings_file"
+	servicePlanCustomerAccountReadyPollInterval      = 10 * time.Second
+	servicePlanCustomerAccountProgressPollInterval   = 10 * time.Second
+	servicePlanCustomerAccountReadyTimeout           = 10 * time.Minute
+	servicePlanCustomerAccountConnectOptionValue     = "__connect_customer_cloud_account__"
+	servicePlanCustomerAccountRetryOptionValue       = "__retry_customer_cloud_account__"
+	servicePlanCustomerAccountDeleteOptionValue      = "__delete_customer_cloud_account__"
 )
+
+var servicePlanBrowserCopyToClipboard = copyServicePlanBrowserToClipboard
 
 type servicePlanBrowserFocus int
 
@@ -125,13 +151,32 @@ type servicePlanUserRow struct {
 }
 
 type servicePlanCustomerCloudAccountRow struct {
-	InstanceID     string
-	CloudProvider  string
-	Status         string
-	SubscriptionID string
-	CustomerEmail  string
-	Resource       string
-	Region         string
+	InstanceID                 string
+	ServiceID                  string
+	EnvironmentID              string
+	ResourceID                 string
+	AccountConfigID            string
+	CloudProvider              string
+	Status                     string
+	StatusMessage              string
+	SubscriptionID             string
+	CustomerEmail              string
+	Resource                   string
+	Region                     string
+	AWSAccountID               string
+	AWSBootstrapRoleARN        string
+	AWSCloudFormationURL       string
+	AWSCloudFormationNoLBURL   string
+	GCPProjectID               string
+	GCPProjectNumber           string
+	GCPServiceAccountEmail     string
+	GCPBootstrapShellCommand   string
+	AzureSubscriptionID        string
+	AzureTenantID              string
+	AzureBootstrapShellCommand string
+	NebiusTenantID             string
+	NebiusBindingsCount        int
+	OCIBootstrapShellCommand   string
 }
 
 type servicePlanBrowserLoader interface {
@@ -141,6 +186,17 @@ type servicePlanBrowserLoader interface {
 type servicePlanBrowserDeploymentLauncher interface {
 	LoadDeploymentForm(context.Context, string, servicePlanBrowserEnvironment) (servicePlanDeploymentForm, error)
 	LaunchDeployment(context.Context, string, servicePlanDeploymentLaunchRequest) (string, error)
+}
+
+type servicePlanBrowserCustomerAccountConnector interface {
+	CreateCustomerCloudAccount(context.Context, string, servicePlanCustomerCloudAccountConnectRequest) (servicePlanCustomerCloudAccountRow, error)
+	RefreshCustomerCloudAccount(context.Context, string, servicePlanCustomerCloudAccountActionRequest) (servicePlanCustomerCloudAccountRow, error)
+}
+
+type servicePlanBrowserCustomerAccountManager interface {
+	servicePlanBrowserCustomerAccountConnector
+	DeleteCustomerCloudAccount(context.Context, string, servicePlanCustomerCloudAccountActionRequest) error
+	RetryCustomerCloudAccount(context.Context, string, servicePlanCustomerCloudAccountActionRequest) (servicePlanCustomerCloudAccountRow, error)
 }
 
 type productionServicePlanBrowserLoader struct{}
@@ -172,6 +228,10 @@ type servicePlanBrowserModel struct {
 	deploymentForm         *servicePlanDeploymentFormState
 	loadDeploymentForm     func(servicePlanBrowserEnvironment) (servicePlanDeploymentForm, error)
 	launchDeployment       func(servicePlanDeploymentLaunchRequest) (string, error)
+	createCustomerAccount  func(servicePlanCustomerCloudAccountConnectRequest) (servicePlanCustomerCloudAccountRow, error)
+	refreshCustomerAccount func(servicePlanCustomerCloudAccountActionRequest) (servicePlanCustomerCloudAccountRow, error)
+	deleteCustomerAccount  func(servicePlanCustomerCloudAccountActionRequest) error
+	retryCustomerAccount   func(servicePlanCustomerCloudAccountActionRequest) (servicePlanCustomerCloudAccountRow, error)
 }
 
 type servicePlanBrowserLeftItem struct {
@@ -233,6 +293,29 @@ type servicePlanDeploymentLaunchedMsg struct {
 	err        error
 }
 
+type servicePlanCustomerCloudAccountCreatedMsg struct {
+	account servicePlanCustomerCloudAccountRow
+	err     error
+}
+
+type servicePlanCustomerCloudAccountPollTickMsg struct{}
+
+type servicePlanCustomerCloudAccountRefreshedMsg struct {
+	account servicePlanCustomerCloudAccountRow
+	err     error
+}
+
+type servicePlanBrowserClipboardResultMsg struct {
+	message string
+	err     error
+}
+
+type servicePlanCustomerCloudAccountActionMsg struct {
+	action  servicePlanCustomerCloudAccountAction
+	account servicePlanCustomerCloudAccountRow
+	err     error
+}
+
 type servicePlanDeploymentForm struct {
 	Environment              servicePlanBrowserEnvironment
 	Version                  string
@@ -242,6 +325,7 @@ type servicePlanDeploymentForm struct {
 	ServiceEnvironmentURLKey string
 	ServiceModelURLKey       string
 	ProductTierURLKey        string
+	AccountResource          servicePlanDeploymentResource
 	Resources                []servicePlanDeploymentResource
 	CloudProviders           []string
 	RegionsByCloud           map[string][]string
@@ -290,10 +374,23 @@ type servicePlanDeploymentLaunchRequest struct {
 	Params            map[string]any
 }
 
+type servicePlanCustomerCloudAccountConnectRequest struct {
+	Form          servicePlanDeploymentForm
+	Customer      servicePlanDeploymentCustomer
+	CloudProvider string
+	Values        map[string]string
+}
+
+type servicePlanCustomerCloudAccountActionRequest struct {
+	Form    servicePlanDeploymentForm
+	Account servicePlanCustomerCloudAccountRow
+}
+
 type servicePlanDeploymentFieldKind int
 
 const (
 	servicePlanDeploymentFieldParameter servicePlanDeploymentFieldKind = iota
+	servicePlanDeploymentFieldCustomerAccount
 )
 
 type servicePlanDeploymentFormField struct {
@@ -309,45 +406,81 @@ type servicePlanDeploymentFormField struct {
 }
 
 type servicePlanDeploymentFormState struct {
-	Form                servicePlanDeploymentForm
-	Steps               []servicePlanDeploymentWizardStep
-	StepIndex           int
-	SelectionCursor     int
-	ParamFields         []servicePlanDeploymentFormField
-	ParamCursor         int
-	SelectedCustomer    servicePlanDeploymentCustomer
-	ResourceName        string
-	CloudProvider       string
-	Region              string
-	CustomerAccountID   string
-	ParameterResourceID string
-	ParamValues         map[string]string
-	Launching           bool
-	InstanceID          string
-	Result              string
-	Err                 string
+	Form                         servicePlanDeploymentForm
+	Steps                        []servicePlanDeploymentWizardStep
+	StepIndex                    int
+	SelectionCursor              int
+	AccountActionCursor          int
+	CustomerSearch               textinput.Model
+	OptionInput                  textinput.Model
+	ParamFields                  []servicePlanDeploymentFormField
+	ParamCursor                  int
+	SelectedCustomer             servicePlanDeploymentCustomer
+	ResourceName                 string
+	CloudProvider                string
+	Region                       string
+	CustomerAccountID            string
+	ParameterResourceID          string
+	ParamValues                  map[string]string
+	AccountParamValues           map[string]string
+	Launching                    bool
+	ConnectingAccount            bool
+	CustomerAccountPollScheduled bool
+	ConnectRequest               servicePlanCustomerCloudAccountConnectRequest
+	PendingAccount               servicePlanCustomerCloudAccountRow
+	AccountActionRunning         bool
+	AccountAction                servicePlanCustomerCloudAccountAction
+	InstanceID                   string
+	Result                       string
+	Notice                       string
+	Err                          string
 }
 
 type servicePlanDeploymentWizardStep string
 
 const (
-	servicePlanDeploymentStepCustomer     servicePlanDeploymentWizardStep = "customer"
-	servicePlanDeploymentStepResource     servicePlanDeploymentWizardStep = "resource"
-	servicePlanDeploymentStepCloud        servicePlanDeploymentWizardStep = "cloud"
-	servicePlanDeploymentStepCloudAccount servicePlanDeploymentWizardStep = "cloud-account"
-	servicePlanDeploymentStepRegion       servicePlanDeploymentWizardStep = "region"
-	servicePlanDeploymentStepCustomParams servicePlanDeploymentWizardStep = "custom-params"
-	servicePlanDeploymentStepSystemParams servicePlanDeploymentWizardStep = "system-params"
-	servicePlanDeploymentStepReview       servicePlanDeploymentWizardStep = "review"
-	servicePlanDeploymentStepComplete     servicePlanDeploymentWizardStep = "complete"
+	servicePlanDeploymentStepCustomer       servicePlanDeploymentWizardStep = "customer"
+	servicePlanDeploymentStepResource       servicePlanDeploymentWizardStep = "resource"
+	servicePlanDeploymentStepCloud          servicePlanDeploymentWizardStep = "cloud"
+	servicePlanDeploymentStepCloudAccount   servicePlanDeploymentWizardStep = "cloud-account"
+	servicePlanDeploymentStepConnectAccount servicePlanDeploymentWizardStep = "connect-account"
+	servicePlanDeploymentStepRegion         servicePlanDeploymentWizardStep = "region"
+	servicePlanDeploymentStepCustomParams   servicePlanDeploymentWizardStep = "custom-params"
+	servicePlanDeploymentStepSystemParams   servicePlanDeploymentWizardStep = "system-params"
+	servicePlanDeploymentStepReview         servicePlanDeploymentWizardStep = "review"
+	servicePlanDeploymentStepComplete       servicePlanDeploymentWizardStep = "complete"
 )
 
 type servicePlanDeploymentWizardOption struct {
+	Label          string
+	Description    string
+	Value          string
+	Customer       servicePlanDeploymentCustomer
+	Account        servicePlanCustomerCloudAccountRow
+	ConnectAccount bool
+	AccountAction  servicePlanCustomerCloudAccountAction
+}
+
+type servicePlanCustomerCloudAccountAction string
+
+const (
+	servicePlanCustomerCloudAccountActionNone        servicePlanCustomerCloudAccountAction = ""
+	servicePlanCustomerCloudAccountActionSelect      servicePlanCustomerCloudAccountAction = "select"
+	servicePlanCustomerCloudAccountActionConnect     servicePlanCustomerCloudAccountAction = "connect"
+	servicePlanCustomerCloudAccountActionRetry       servicePlanCustomerCloudAccountAction = "retry"
+	servicePlanCustomerCloudAccountActionDelete      servicePlanCustomerCloudAccountAction = "delete"
+	servicePlanCustomerCloudAccountActionUnavailable servicePlanCustomerCloudAccountAction = "unavailable"
+)
+
+type servicePlanCustomerCloudAccountActionButton struct {
+	Label  string
+	Action servicePlanCustomerCloudAccountAction
+}
+
+type servicePlanCustomerAccountFieldSpec struct {
+	Key         string
 	Label       string
 	Description string
-	Value       string
-	Customer    servicePlanDeploymentCustomer
-	Account     servicePlanCustomerCloudAccountRow
 }
 
 func newServicePlanBrowserDelegate() servicePlanBrowserDelegate {
@@ -511,6 +644,22 @@ func newServicePlanBrowserModel(ctx context.Context, token string, catalog servi
 				return launcher.LaunchDeployment(ctx, token, request)
 			}
 		}
+		if connector, ok := loader.(servicePlanBrowserCustomerAccountConnector); ok {
+			model.createCustomerAccount = func(request servicePlanCustomerCloudAccountConnectRequest) (servicePlanCustomerCloudAccountRow, error) {
+				return connector.CreateCustomerCloudAccount(ctx, token, request)
+			}
+			model.refreshCustomerAccount = func(request servicePlanCustomerCloudAccountActionRequest) (servicePlanCustomerCloudAccountRow, error) {
+				return connector.RefreshCustomerCloudAccount(ctx, token, request)
+			}
+		}
+		if manager, ok := loader.(servicePlanBrowserCustomerAccountManager); ok {
+			model.deleteCustomerAccount = func(request servicePlanCustomerCloudAccountActionRequest) error {
+				return manager.DeleteCustomerCloudAccount(ctx, token, request)
+			}
+			model.retryCustomerAccount = func(request servicePlanCustomerCloudAccountActionRequest) (servicePlanCustomerCloudAccountRow, error) {
+				return manager.RetryCustomerCloudAccount(ctx, token, request)
+			}
+		}
 	}
 	model.setSize(defaultServicePlanBrowserWidth, defaultServicePlanBrowserHeight)
 	model.ensureActiveEnvironmentExpanded()
@@ -531,7 +680,7 @@ func (m servicePlanBrowserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.setSize(msg.Width, msg.Height)
 		return m, nil
 	case spinner.TickMsg:
-		if !m.hasLoadingDetails() && !m.loadingDeploymentForm {
+		if !m.hasLoadingDetails() && !m.loadingDeploymentForm && !m.deploymentFormSpinnerActive() {
 			return m, nil
 		}
 		var cmd tea.Cmd
@@ -557,7 +706,7 @@ func (m servicePlanBrowserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		formState := newServicePlanDeploymentFormState(msg.form, spMax(m.detailPanelWidth-8, 40))
 		m.deploymentForm = &formState
-		return m, nil
+		return m, m.scheduleCustomerCloudAccountPollIfNeeded()
 	case servicePlanDeploymentLaunchedMsg:
 		if m.deploymentForm == nil {
 			return m, nil
@@ -574,6 +723,108 @@ func (m servicePlanBrowserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.deploymentForm.Steps = append(m.deploymentForm.Steps, servicePlanDeploymentStepComplete)
 		m.statusMessage = m.deploymentForm.Result
 		return m, m.refreshSelectedDetails()
+	case servicePlanCustomerCloudAccountCreatedMsg:
+		if m.deploymentForm == nil {
+			return m, nil
+		}
+		if msg.err != nil {
+			m.deploymentForm.ConnectingAccount = false
+			m.deploymentForm.Err = msg.err.Error()
+			return m, nil
+		}
+		m.deploymentForm.PendingAccount = msg.account
+		m.deploymentForm.Err = ""
+		m.deploymentForm.addConnectedCustomerAccount(msg.account)
+		if servicePlanCustomerCloudAccountUsable(msg.account) {
+			return m.completeCustomerCloudAccountConnection(msg.account)
+		}
+		if strings.EqualFold(strings.TrimSpace(msg.account.Status), "FAILED") {
+			m.deploymentForm.ConnectingAccount = false
+			m.deploymentForm.Err = fmt.Sprintf("%s is FAILED", servicePlanCustomerCloudAccountLabel(msg.account))
+			return m, nil
+		}
+		pollCmd := m.scheduleCustomerCloudAccountPollIfNeeded()
+		return m, tea.Batch(m.spinner.Tick, pollCmd)
+	case servicePlanCustomerCloudAccountPollTickMsg:
+		if m.deploymentForm == nil {
+			return m, nil
+		}
+		m.deploymentForm.CustomerAccountPollScheduled = false
+		account, ok := m.deploymentForm.selectedCustomerCloudAccountForRefresh()
+		if !ok {
+			return m, nil
+		}
+		request := servicePlanCustomerCloudAccountActionRequest{Form: m.deploymentForm.Form, Account: account}
+		return m, m.refreshCustomerCloudAccountCmd(request)
+	case servicePlanCustomerCloudAccountRefreshedMsg:
+		if m.deploymentForm == nil {
+			return m, nil
+		}
+		if msg.err != nil {
+			m.deploymentForm.Err = msg.err.Error()
+			return m, m.scheduleCustomerCloudAccountPollIfNeeded()
+		}
+		if m.deploymentForm.ConnectingAccount {
+			m.deploymentForm.PendingAccount = msg.account
+		}
+		m.deploymentForm.Err = ""
+		m.deploymentForm.addConnectedCustomerAccount(msg.account)
+		if m.deploymentForm.ConnectingAccount && servicePlanCustomerCloudAccountUsable(msg.account) {
+			return m.completeCustomerCloudAccountConnection(msg.account)
+		}
+		if m.deploymentForm.ConnectingAccount && strings.EqualFold(strings.TrimSpace(msg.account.Status), "FAILED") {
+			m.deploymentForm.ConnectingAccount = false
+			m.deploymentForm.Err = fmt.Sprintf("%s is FAILED", servicePlanCustomerCloudAccountLabel(msg.account))
+			return m, nil
+		}
+		return m, m.scheduleCustomerCloudAccountPollIfNeeded()
+	case servicePlanCustomerCloudAccountActionMsg:
+		if m.deploymentForm == nil {
+			return m, nil
+		}
+		m.deploymentForm.AccountActionRunning = false
+		m.deploymentForm.AccountAction = servicePlanCustomerCloudAccountActionNone
+		if msg.err != nil {
+			m.deploymentForm.Err = msg.err.Error()
+			return m, nil
+		}
+		switch msg.action {
+		case servicePlanCustomerCloudAccountActionDelete:
+			m.deploymentForm.removeCustomerAccount(msg.account.InstanceID)
+			m.deploymentForm.Err = ""
+			m.statusMessage = "Cloud account deleted"
+			m.deploymentForm.prepareCurrentStep(spMax(m.detailPanelWidth-8, 40))
+			return m, m.refreshSelectedDetails()
+		case servicePlanCustomerCloudAccountActionRetry:
+			m.deploymentForm.addConnectedCustomerAccount(msg.account)
+			m.deploymentForm.Err = ""
+			m.statusMessage = "Cloud account ready"
+			if strings.EqualFold(strings.TrimSpace(msg.account.Status), "READY") && m.deploymentForm.StepIndex < len(m.deploymentForm.Steps)-1 {
+				m.deploymentForm.StepIndex++
+				m.deploymentForm.prepareCurrentStep(spMax(m.detailPanelWidth-8, 40))
+			} else {
+				m.deploymentForm.prepareCurrentStep(spMax(m.detailPanelWidth-8, 40))
+			}
+			return m, m.refreshSelectedDetails()
+		}
+		return m, nil
+	case servicePlanBrowserClipboardResultMsg:
+		if m.deploymentForm != nil {
+			if msg.err != nil {
+				m.deploymentForm.Err = msg.err.Error()
+				m.deploymentForm.Notice = ""
+			} else {
+				m.deploymentForm.Err = ""
+				m.deploymentForm.Notice = msg.message
+			}
+			return m, nil
+		}
+		if msg.err != nil {
+			m.statusMessage = msg.err.Error()
+		} else {
+			m.statusMessage = msg.message
+		}
+		return m, nil
 	case tea.KeyMsg:
 		if m.deploymentForm != nil {
 			return m.updateDeploymentForm(msg)
@@ -707,17 +958,32 @@ func (m servicePlanBrowserModel) View() string {
 	}
 
 	header := renderServicePlanBrowserHeader(m.catalog)
-	tabs := m.renderEnvironmentTabs(m.width)
 
-	listPanelStyle := servicePlanBrowserPanelStyle(m.focusBorderColor(servicePlanBrowserFocusLeft))
-	detailPanelStyle := servicePlanBrowserPanelStyle(m.focusBorderColor(servicePlanBrowserFocusDetails))
-	plansPanel := listPanelStyle.Width(m.listPanelWidth).Render(m.list.View())
-	detailsPanel := detailPanelStyle.Width(m.detailPanelWidth).Render(m.viewport.View())
-	body := lipgloss.JoinHorizontal(lipgloss.Top, plansPanel, " ", detailsPanel)
+	tabsAndBody := m.renderEnvironmentTabsWithBody(m.width, m.renderBrowserBody())
 
 	help := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render(m.helpLine())
-	status := lipgloss.NewStyle().Foreground(lipgloss.Color("111")).Render(m.statusLine())
-	return lipgloss.JoinVertical(lipgloss.Left, header, tabs, body, help, status)
+	sections := []string{header, tabsAndBody, help}
+	if status := m.statusLine(); status != "" {
+		sections = append(sections, lipgloss.NewStyle().Foreground(lipgloss.Color("111")).Render(status))
+	}
+	return lipgloss.JoinVertical(lipgloss.Left, sections...)
+}
+
+func (m servicePlanBrowserModel) renderBrowserBody() string {
+	left := lipgloss.NewStyle().
+		Width(m.listPanelWidth).
+		Height(m.viewport.Height).
+		Render(m.list.View())
+	separator := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("240")).
+		Height(m.viewport.Height).
+		Render("│")
+	right := lipgloss.NewStyle().
+		Width(m.detailPanelWidth).
+		Height(m.viewport.Height).
+		Render(m.viewport.View())
+
+	return lipgloss.JoinHorizontal(lipgloss.Top, left, separator, right)
 }
 
 func renderServicePlanBrowserSnapshot(model servicePlanBrowserModel) string {
@@ -735,16 +1001,16 @@ func (m *servicePlanBrowserModel) setSize(width, height int) {
 	m.width = width
 	m.height = height
 
-	listPanelWidth := spMin(spMax(width/3, servicePlanBrowserListMinWidth), servicePlanBrowserListPreferredWidth)
+	bodyWidth := spMax(width-2, servicePlanBrowserListMinWidth+41)
+	listPanelWidth := spMin(spMax(bodyWidth/3, servicePlanBrowserListMinWidth), servicePlanBrowserListPreferredWidth)
 	bodyHeight := spMax(height-servicePlanBrowserHeaderHeight-servicePlanBrowserTabsHeight-servicePlanBrowserHelpHeight, 12)
-	detailPanelWidth := spMax(width-listPanelWidth-1, 40)
-	panelFrameWidth := servicePlanBrowserPanelStyle(lipgloss.Color("240")).GetHorizontalFrameSize()
+	detailPanelWidth := spMax(bodyWidth-listPanelWidth-1, 40)
 
 	m.listPanelWidth = listPanelWidth
 	m.detailPanelWidth = detailPanelWidth
-	m.list.SetWidth(spMax(listPanelWidth-panelFrameWidth, 10))
+	m.list.SetWidth(spMax(listPanelWidth, 10))
 	m.list.SetHeight(bodyHeight)
-	m.viewport.Width = spMax(detailPanelWidth-panelFrameWidth, 10)
+	m.viewport.Width = spMax(detailPanelWidth, 10)
 	m.viewport.Height = bodyHeight
 	m.syncViewportContent()
 }
@@ -756,21 +1022,11 @@ func servicePlanBrowserPanelStyle(borderColor lipgloss.Color) lipgloss.Style {
 		Padding(0, 1)
 }
 
-func (m servicePlanBrowserModel) focusBorderColor(focus servicePlanBrowserFocus) lipgloss.Color {
-	if m.focus == focus {
-		return lipgloss.Color("117")
-	}
-	return lipgloss.Color("240")
-}
-
 func (m servicePlanBrowserModel) statusLine() string {
 	if strings.TrimSpace(m.statusMessage) != "" {
 		return m.statusMessage
 	}
-	if m.focus == servicePlanBrowserFocusDetails {
-		return "Use d to launch a deployment, r to refresh. Use tab or shift+tab to switch environments. Use esc or left to return to the plan list."
-	}
-	return "Use d to launch a deployment, r to refresh. Plan details update as the selector moves."
+	return ""
 }
 
 func (m servicePlanBrowserModel) helpLine() string {
@@ -1179,34 +1435,23 @@ func (m servicePlanBrowserModel) renderEnvironmentTabs(width int) string {
 	inactiveTabBorder := servicePlanTabBorderWithBottom("┴", "─", "┴")
 	activeTabBorder := servicePlanTabBorderWithBottom("┘", " ", "└")
 
-	inactiveTabStyle := lipgloss.NewStyle().
-		Border(inactiveTabBorder, true).
-		BorderForeground(highlightColor).
-		Padding(0, 1).
-		Bold(true)
-	activeTabStyle := lipgloss.NewStyle().
-		Border(activeTabBorder, true).
-		BorderForeground(highlightColor).
-		Padding(0, 1).
-		Bold(true)
-
 	renderedTabs := make([]string, 0, len(m.environmentTabs))
 	for i, name := range m.environmentTabs {
-		envColor := servicePlanEnvironmentColor(name)
-		style := inactiveTabStyle.Foreground(envColor).Faint(true)
-		if i == m.activeTab {
-			style = activeTabStyle.Foreground(envColor)
+		isFirst := i == 0
+		isActive := i == m.activeTab
+		border := inactiveTabBorder
+		if isActive {
+			border = activeTabBorder
 		}
+		style := servicePlanEnvironmentTabStyle(isActive, border)
 
-		border, _, _, _, _ := style.GetBorder()
-		if i == 0 {
-			if i == m.activeTab {
-				border.BottomLeft = "│"
-			} else {
-				border.BottomLeft = "├"
-			}
+		renderedBorder, _, _, _, _ := style.GetBorder()
+		if isFirst && isActive {
+			renderedBorder.BottomLeft = "│"
+		} else if isFirst && !isActive {
+			renderedBorder.BottomLeft = "├"
 		}
-		style = style.Border(border)
+		style = style.Border(renderedBorder)
 		renderedTabs = append(renderedTabs, style.Render(emptyValue(name)))
 	}
 
@@ -1225,7 +1470,31 @@ func (m servicePlanBrowserModel) renderEnvironmentTabs(width int) string {
 		row = lipgloss.JoinHorizontal(lipgloss.Bottom, row, gapStyle.Render(strings.Repeat(" ", gapWidth)))
 	}
 
-	return lipgloss.NewStyle().MaxWidth(width).Render(row)
+	return row
+}
+
+func (m servicePlanBrowserModel) renderEnvironmentTabsWithBody(width int, body string) string {
+	tabs := m.renderEnvironmentTabs(width)
+	highlightColor := lipgloss.Color("62")
+	windowStyle := lipgloss.NewStyle().
+		BorderForeground(highlightColor).
+		Border(lipgloss.NormalBorder()).
+		UnsetBorderTop().
+		Width(spMax(width-2, 1)).
+		Padding(0, 0)
+
+	return lipgloss.JoinVertical(lipgloss.Left, tabs, windowStyle.Render(body))
+}
+
+func servicePlanEnvironmentTabStyle(active bool, border lipgloss.Border) lipgloss.Style {
+	style := lipgloss.NewStyle().
+		Border(border, true).
+		BorderForeground(lipgloss.Color("62")).
+		Padding(0, 1)
+	if active {
+		return style.Bold(true).Foreground(lipgloss.Color("230"))
+	}
+	return style.Foreground(lipgloss.Color("245"))
 }
 
 func servicePlanTabBorderWithBottom(left, middle, right string) lipgloss.Border {
@@ -1234,22 +1503,6 @@ func servicePlanTabBorderWithBottom(left, middle, right string) lipgloss.Border 
 	border.Bottom = middle
 	border.BottomRight = right
 	return border
-}
-
-func servicePlanEnvironmentColor(environment string) lipgloss.Color {
-	normalized := strings.ToLower(strings.TrimSpace(environment))
-	switch normalized {
-	case "prod", "production":
-		return lipgloss.Color("160")
-	case "stage", "staging":
-		return lipgloss.Color("214")
-	case "dev", "development":
-		return lipgloss.Color("82")
-	case "qa", "test", "testing":
-		return lipgloss.Color("39")
-	default:
-		return lipgloss.Color("62")
-	}
 }
 
 func (m servicePlanBrowserModel) detailRows() []servicePlanBrowserDetailRow {
@@ -1496,13 +1749,12 @@ func (m *servicePlanBrowserModel) openSelectedModal() {
 	case servicePlanBrowserModalCloudAccounts:
 		for _, account := range detail.CustomerCloudAccounts {
 			text := fmt.Sprintf(
-				"%s | %s | %s | %s | %s | %s",
-				emptyValue(account.InstanceID),
+				"%s | %s | %s | %s | %s",
+				emptyValue(servicePlanCustomerCloudAccountLabel(account)),
 				emptyValue(account.CloudProvider),
 				emptyValue(account.Status),
 				emptyValue(account.Region),
 				emptyValue(account.CustomerEmail),
-				emptyValue(account.SubscriptionID),
 			)
 			modalRows = append(modalRows, servicePlanBrowserModalRow{Text: text, Search: strings.ToLower(text)})
 		}
@@ -1734,9 +1986,126 @@ func (m servicePlanBrowserModel) launchDeploymentCmd(request servicePlanDeployme
 	}
 }
 
+func (m servicePlanBrowserModel) createCustomerCloudAccountCmd(request servicePlanCustomerCloudAccountConnectRequest) tea.Cmd {
+	if m.createCustomerAccount == nil {
+		return nil
+	}
+
+	return func() tea.Msg {
+		account, err := m.createCustomerAccount(request)
+		return servicePlanCustomerCloudAccountCreatedMsg{account: account, err: err}
+	}
+}
+
+func (m servicePlanBrowserModel) customerCloudAccountPollTickCmd() tea.Cmd {
+	return tea.Tick(servicePlanCustomerAccountProgressPollInterval, func(time.Time) tea.Msg {
+		return servicePlanCustomerCloudAccountPollTickMsg{}
+	})
+}
+
+func (m *servicePlanBrowserModel) scheduleCustomerCloudAccountPollIfNeeded() tea.Cmd {
+	if m.deploymentForm == nil || m.deploymentForm.CustomerAccountPollScheduled {
+		return nil
+	}
+	if _, ok := m.deploymentForm.selectedCustomerCloudAccountForRefresh(); !ok {
+		return nil
+	}
+	m.deploymentForm.CustomerAccountPollScheduled = true
+	return m.customerCloudAccountPollTickCmd()
+}
+
+func (m servicePlanBrowserModel) refreshCustomerCloudAccountCmd(request servicePlanCustomerCloudAccountActionRequest) tea.Cmd {
+	if m.refreshCustomerAccount == nil {
+		return nil
+	}
+
+	return func() tea.Msg {
+		account, err := m.refreshCustomerAccount(request)
+		if account.InstanceID == "" {
+			account = request.Account
+		}
+		return servicePlanCustomerCloudAccountRefreshedMsg{account: account, err: err}
+	}
+}
+
+func (m servicePlanBrowserModel) deleteCustomerCloudAccountCmd(request servicePlanCustomerCloudAccountActionRequest) tea.Cmd {
+	if m.deleteCustomerAccount == nil {
+		return nil
+	}
+
+	return func() tea.Msg {
+		err := m.deleteCustomerAccount(request)
+		return servicePlanCustomerCloudAccountActionMsg{
+			action:  servicePlanCustomerCloudAccountActionDelete,
+			account: request.Account,
+			err:     err,
+		}
+	}
+}
+
+func (m servicePlanBrowserModel) retryCustomerCloudAccountCmd(request servicePlanCustomerCloudAccountActionRequest) tea.Cmd {
+	if m.retryCustomerAccount == nil {
+		return nil
+	}
+
+	return func() tea.Msg {
+		account, err := m.retryCustomerAccount(request)
+		if account.InstanceID == "" {
+			account = request.Account
+		}
+		return servicePlanCustomerCloudAccountActionMsg{
+			action:  servicePlanCustomerCloudAccountActionRetry,
+			account: account,
+			err:     err,
+		}
+	}
+}
+
+func (m servicePlanBrowserModel) completeCustomerCloudAccountConnection(account servicePlanCustomerCloudAccountRow) (tea.Model, tea.Cmd) {
+	if m.deploymentForm == nil {
+		return m, nil
+	}
+	m.deploymentForm.ConnectingAccount = false
+	m.deploymentForm.PendingAccount = account
+	m.deploymentForm.addConnectedCustomerAccount(account)
+	m.deploymentForm.Err = ""
+	if m.deploymentForm.StepIndex < len(m.deploymentForm.Steps)-1 {
+		m.deploymentForm.StepIndex++
+		m.deploymentForm.prepareCurrentStep(spMax(m.detailPanelWidth-8, 40))
+	}
+	cmd := m.refreshSelectedDetails()
+	return m, cmd
+}
+
+func (m servicePlanBrowserModel) deploymentFormSpinnerActive() bool {
+	return m.deploymentForm != nil && (m.deploymentForm.Launching || m.deploymentForm.ConnectingAccount || m.deploymentForm.AccountActionRunning)
+}
+
 func (m servicePlanBrowserModel) updateDeploymentForm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.deploymentForm == nil {
 		return m, nil
+	}
+
+	if m.deploymentForm.ConnectingAccount || m.deploymentForm.AccountActionRunning {
+		switch msg.String() {
+		case "ctrl+c":
+			return m, tea.Quit
+		case "esc":
+			m.deploymentForm = nil
+			m.statusMessage = ""
+		case "c", "C", "y", "Y":
+			if m.deploymentForm.ConnectingAccount {
+				return m.copyDeploymentCloudFormationTemplateURL()
+			}
+		}
+		return m, nil
+	}
+
+	if cmd, handled := m.deploymentForm.updateActiveTextInput(msg); handled {
+		return m, cmd
+	}
+	if cmd, handled := m.deploymentForm.updateCurrentFormFieldInput(msg); handled {
+		return m, cmd
 	}
 
 	switch msg.String() {
@@ -1746,7 +2115,7 @@ func (m servicePlanBrowserModel) updateDeploymentForm(msg tea.KeyMsg) (tea.Model
 		m.deploymentForm = nil
 		m.statusMessage = ""
 		return m, nil
-	case "left", "backspace":
+	case "left":
 		m.deploymentForm.previousStep(spMax(m.detailPanelWidth-8, 40))
 		return m, nil
 	case "up":
@@ -1754,39 +2123,55 @@ func (m servicePlanBrowserModel) updateDeploymentForm(msg tea.KeyMsg) (tea.Model
 			return m, nil
 		}
 		m.deploymentForm.moveWizardCursor(-1)
-		return m, nil
+		return m, m.scheduleCustomerCloudAccountPollIfNeeded()
 	case "down":
 		if m.deploymentForm.currentStepIsParameters() && m.deploymentForm.moveCurrentParameterOption(1) {
 			return m, nil
 		}
 		m.deploymentForm.moveWizardCursor(1)
-		return m, nil
+		return m, m.scheduleCustomerCloudAccountPollIfNeeded()
 	case "tab":
-		if m.deploymentForm.currentStepIsParameters() {
+		if m.deploymentForm.currentStep() == servicePlanDeploymentStepCloudAccount {
+			m.deploymentForm.moveCustomerCloudAccountActionCursor(1)
+			return m, nil
+		}
+		if m.deploymentForm.currentStepUsesFormFields() {
 			m.deploymentForm.moveWizardCursor(1)
 			return m, nil
 		}
 	case "shift+tab":
-		if m.deploymentForm.currentStepIsParameters() {
+		if m.deploymentForm.currentStep() == servicePlanDeploymentStepCloudAccount {
+			m.deploymentForm.moveCustomerCloudAccountActionCursor(-1)
+			return m, nil
+		}
+		if m.deploymentForm.currentStepUsesFormFields() {
 			m.deploymentForm.moveWizardCursor(-1)
 			return m, nil
 		}
-	case "right", "enter":
+	case "enter":
+		if m.deploymentForm.advanceFormFieldCursor() {
+			return m, nil
+		}
 		return m.advanceDeploymentWizard()
+	case "c", "C", "y", "Y":
+		return m.copyDeploymentCloudFormationTemplateURL()
 	}
+	return m, nil
+}
 
-	if m.deploymentForm.Launching || !m.deploymentForm.currentStepIsParameters() || len(m.deploymentForm.ParamFields) == 0 {
+func (m servicePlanBrowserModel) copyDeploymentCloudFormationTemplateURL() (tea.Model, tea.Cmd) {
+	if m.deploymentForm == nil {
 		return m, nil
 	}
-
-	field := &m.deploymentForm.ParamFields[m.deploymentForm.ParamCursor]
-	if len(field.Options) > 0 {
+	url := m.deploymentForm.selectedCloudFormationTemplateURL()
+	if strings.TrimSpace(url) == "" {
+		m.deploymentForm.Err = "CloudFormation template URL is not available yet"
+		m.deploymentForm.Notice = ""
 		return m, nil
 	}
-	updated, cmd := field.Input.Update(msg)
-	field.Input = updated
 	m.deploymentForm.Err = ""
-	return m, cmd
+	m.deploymentForm.Notice = "Copying CloudFormation template URL..."
+	return m, copyServicePlanBrowserTextCmd(url, "Copied CloudFormation template URL")
 }
 
 func (m servicePlanBrowserModel) advanceDeploymentWizard() (tea.Model, tea.Cmd) {
@@ -1797,6 +2182,32 @@ func (m servicePlanBrowserModel) advanceDeploymentWizard() (tea.Model, tea.Cmd) 
 		m.deploymentForm = nil
 		m.statusMessage = ""
 		return m, nil
+	}
+	if m.deploymentForm.currentStep() == servicePlanDeploymentStepConnectAccount {
+		request, err := m.deploymentForm.customerAccountConnectRequest()
+		if err != nil {
+			m.deploymentForm.Err = err.Error()
+			return m, nil
+		}
+		if m.createCustomerAccount == nil {
+			m.deploymentForm.Err = "customer cloud account connection is not available"
+			return m, nil
+		}
+		m.deploymentForm.Err = ""
+		m.deploymentForm.ConnectingAccount = true
+		m.deploymentForm.ConnectRequest = request
+		m.deploymentForm.PendingAccount = servicePlanCustomerCloudAccountRow{
+			CloudProvider:  strings.ToLower(strings.TrimSpace(request.CloudProvider)),
+			CustomerEmail:  request.Customer.Email,
+			SubscriptionID: servicePlanSubscriptionIDForCustomer(request.Form.Subscriptions, request.Customer),
+		}
+		m.statusMessage = "Creating cloud account connection..."
+		return m, tea.Batch(m.spinner.Tick, m.createCustomerCloudAccountCmd(request))
+	}
+	if m.deploymentForm.currentStep() == servicePlanDeploymentStepCloudAccount {
+		if model, cmd, handled := m.advanceCustomerCloudAccountAction(); handled {
+			return model, cmd
+		}
 	}
 	if m.deploymentForm.currentStep() == servicePlanDeploymentStepReview {
 		request, err := m.deploymentForm.launchRequest()
@@ -1818,20 +2229,75 @@ func (m servicePlanBrowserModel) advanceDeploymentWizard() (tea.Model, tea.Cmd) 
 		m.deploymentForm.Err = err.Error()
 		return m, nil
 	}
-	return m, nil
+	return m, m.scheduleCustomerCloudAccountPollIfNeeded()
+}
+
+func (m servicePlanBrowserModel) advanceCustomerCloudAccountAction() (tea.Model, tea.Cmd, bool) {
+	option, action, ok := m.deploymentForm.selectedCustomerCloudAccountAction()
+	if !ok {
+		return m, nil, false
+	}
+
+	switch action {
+	case servicePlanCustomerCloudAccountActionSelect:
+		return m, nil, false
+	case servicePlanCustomerCloudAccountActionConnect:
+		m.deploymentForm.CustomerAccountID = ""
+		m.deploymentForm.ensureConnectAccountStep()
+		if m.deploymentForm.StepIndex < len(m.deploymentForm.Steps)-1 {
+			m.deploymentForm.StepIndex++
+			m.deploymentForm.prepareCurrentStep(spMax(m.detailPanelWidth-8, 40))
+		}
+		return m, nil, true
+	case servicePlanCustomerCloudAccountActionDelete:
+		if m.deleteCustomerAccount == nil {
+			m.deploymentForm.Err = "customer cloud account delete is not available"
+			return m, nil, true
+		}
+		request := servicePlanCustomerCloudAccountActionRequest{Form: m.deploymentForm.Form, Account: option.Account}
+		m.deploymentForm.Err = ""
+		m.deploymentForm.AccountAction = servicePlanCustomerCloudAccountActionDelete
+		m.deploymentForm.AccountActionRunning = true
+		m.statusMessage = "Deleting cloud account..."
+		return m, tea.Batch(m.spinner.Tick, m.deleteCustomerCloudAccountCmd(request)), true
+	case servicePlanCustomerCloudAccountActionRetry:
+		if m.retryCustomerAccount == nil {
+			m.deploymentForm.Err = "customer cloud account retry is not available"
+			return m, nil, true
+		}
+		request := servicePlanCustomerCloudAccountActionRequest{Form: m.deploymentForm.Form, Account: option.Account}
+		m.deploymentForm.Err = ""
+		m.deploymentForm.AccountAction = servicePlanCustomerCloudAccountActionRetry
+		m.deploymentForm.AccountActionRunning = true
+		m.statusMessage = "Retrying cloud account..."
+		return m, tea.Batch(m.spinner.Tick, m.retryCustomerCloudAccountCmd(request)), true
+	case servicePlanCustomerCloudAccountActionUnavailable:
+		m.deploymentForm.Err = fmt.Sprintf("%s is %s", servicePlanCustomerCloudAccountLabel(option.Account), emptyValue(option.Account.Status))
+		return m, nil, true
+	default:
+		return m, nil, false
+	}
 }
 
 func newServicePlanDeploymentFormState(form servicePlanDeploymentForm, width int) servicePlanDeploymentFormState {
 	customers := servicePlanDeploymentCustomerOptions(form)
 	resourceName := firstString(servicePlanDeploymentResourceOptions(form.Resources))
 	cloudProvider := firstString(form.CloudProviders)
+	customerSearch := textinput.New()
+	customerSearch.Prompt = "Search: "
+	customerSearch.Placeholder = "name, email, company, or user ID"
+	optionInput := textinput.New()
+	optionInput.Prompt = "> "
 	state := servicePlanDeploymentFormState{
-		Form:             form,
-		SelectedCustomer: firstServicePlanDeploymentCustomer(customers),
-		ResourceName:     resourceName,
-		CloudProvider:    cloudProvider,
-		Region:           firstString(form.RegionsByCloud[cloudProvider]),
-		ParamValues:      map[string]string{},
+		Form:               form,
+		SelectedCustomer:   firstServicePlanDeploymentCustomer(customers),
+		ResourceName:       resourceName,
+		CloudProvider:      cloudProvider,
+		Region:             firstString(form.RegionsByCloud[cloudProvider]),
+		CustomerSearch:     customerSearch,
+		OptionInput:        optionInput,
+		ParamValues:        map[string]string{},
+		AccountParamValues: map[string]string{},
 	}
 	state.Steps = servicePlanDeploymentWizardSteps(form)
 	state.CustomerAccountID = state.firstCloudAccountID()
@@ -1844,7 +2310,9 @@ func servicePlanDeploymentWizardSteps(form servicePlanDeploymentForm) []serviceP
 	if servicePlanEnvironmentIsProduction(form.Environment) {
 		steps = append(steps, servicePlanDeploymentStepCustomer)
 	}
-	steps = append(steps, servicePlanDeploymentStepResource)
+	if len(form.Resources) > 1 {
+		steps = append(steps, servicePlanDeploymentStepResource)
+	}
 	steps = append(steps, servicePlanDeploymentStepCloud)
 	if form.RequiresCustomerAccount {
 		steps = append(steps, servicePlanDeploymentStepCloudAccount)
@@ -1875,10 +2343,34 @@ func servicePlanDeploymentFormHasParameters(form servicePlanDeploymentForm, cust
 
 func (s *servicePlanDeploymentFormState) prepareCurrentStep(width int) {
 	s.Err = ""
+	s.CustomerSearch.Blur()
+	s.OptionInput.Blur()
 	s.SelectionCursor = s.selectedOptionIndex()
-	if s.currentStepIsParameters() {
-		_, s.ParameterResourceID = servicePlanDeploymentParametersForResource(s.Form, s.ResourceName)
-		s.ParamFields = s.buildParameterFields(s.currentStep(), width)
+	if s.currentStep() == servicePlanDeploymentStepCustomer {
+		s.CustomerSearch.Width = spMin(spMax(width-18, 24), 72)
+		s.CustomerSearch.Focus()
+		s.SelectionCursor = spClamp(s.SelectionCursor, spMax(0, len(s.currentOptions())-1))
+		return
+	}
+	if s.currentStep() == servicePlanDeploymentStepCloudAccount {
+		s.SelectionCursor = spClamp(s.SelectionCursor, spMax(0, len(s.currentOptions())-1))
+		s.AccountActionCursor = spClamp(s.AccountActionCursor, spMax(0, len(s.selectedCustomerCloudAccountActionButtons())-1))
+		return
+	}
+	if s.currentStepUsesFreeformInput() {
+		s.OptionInput.Width = spMin(spMax(width-18, 24), 72)
+		s.OptionInput.SetValue(s.currentFreeformValue())
+		s.OptionInput.Focus()
+		return
+	}
+	if s.currentStepUsesFormFields() {
+		if s.currentStep() == servicePlanDeploymentStepConnectAccount {
+			s.ParameterResourceID = ""
+			s.ParamFields = s.buildCustomerAccountFields(width)
+		} else {
+			_, s.ParameterResourceID = servicePlanDeploymentParametersForResource(s.Form, s.ResourceName)
+			s.ParamFields = s.buildParameterFields(s.currentStep(), width)
+		}
 		s.ParamCursor = spClamp(s.ParamCursor, spMax(0, len(s.ParamFields)-1))
 		s.syncFocus()
 		return
@@ -1927,6 +2419,29 @@ func (s servicePlanDeploymentFormState) buildParameterFields(step servicePlanDep
 	return fields
 }
 
+func (s servicePlanDeploymentFormState) buildCustomerAccountFields(width int) []servicePlanDeploymentFormField {
+	specs := servicePlanCustomerAccountFieldSpecs(s.CloudProvider)
+	fields := make([]servicePlanDeploymentFormField, 0, len(specs))
+	fieldWidth := spMin(spMax(width-28, 24), 64)
+	for _, spec := range specs {
+		input := textinput.New()
+		input.CharLimit = 0
+		input.Width = fieldWidth
+		input.Prompt = ""
+		input.SetValue(s.AccountParamValues[spec.Key])
+		fields = append(fields, servicePlanDeploymentFormField{
+			Kind:        servicePlanDeploymentFieldCustomerAccount,
+			Key:         spec.Key,
+			Label:       spec.Label,
+			Required:    true,
+			Type:        "string",
+			Description: spec.Description,
+			Input:       input,
+		})
+	}
+	return fields
+}
+
 func (s *servicePlanDeploymentFormState) advanceStep(width int) error {
 	if s.Launching {
 		return nil
@@ -1952,6 +2467,8 @@ func (s *servicePlanDeploymentFormState) previousStep(width int) {
 	}
 	if s.currentStepIsParameters() {
 		_ = s.storeCurrentParameterValues()
+	} else if s.currentStep() == servicePlanDeploymentStepConnectAccount {
+		_ = s.storeCurrentAccountValues()
 	}
 	if s.StepIndex > 0 {
 		s.StepIndex--
@@ -1960,7 +2477,7 @@ func (s *servicePlanDeploymentFormState) previousStep(width int) {
 }
 
 func (s *servicePlanDeploymentFormState) moveWizardCursor(delta int) {
-	if s.currentStepIsParameters() {
+	if s.currentStepUsesFormFields() {
 		if len(s.ParamFields) == 0 {
 			s.ParamCursor = 0
 			return
@@ -1973,9 +2490,84 @@ func (s *servicePlanDeploymentFormState) moveWizardCursor(delta int) {
 	options := s.currentOptions()
 	if len(options) == 0 {
 		s.SelectionCursor = 0
+		s.AccountActionCursor = 0
 		return
 	}
 	s.SelectionCursor = (s.SelectionCursor + delta + len(options)) % len(options)
+	if s.currentStep() == servicePlanDeploymentStepCloudAccount {
+		s.AccountActionCursor = 0
+	}
+}
+
+func (s *servicePlanDeploymentFormState) moveCustomerCloudAccountActionCursor(delta int) {
+	buttons := s.selectedCustomerCloudAccountActionButtons()
+	if len(buttons) == 0 {
+		s.AccountActionCursor = 0
+		return
+	}
+	s.AccountActionCursor = (s.AccountActionCursor + delta + len(buttons)) % len(buttons)
+}
+
+func (s *servicePlanDeploymentFormState) updateActiveTextInput(msg tea.KeyMsg) (tea.Cmd, bool) {
+	if !servicePlanDeploymentTextInputKey(msg) {
+		return nil, false
+	}
+
+	switch {
+	case s.currentStep() == servicePlanDeploymentStepCustomer:
+		updated, cmd := s.CustomerSearch.Update(msg)
+		s.CustomerSearch = updated
+		s.SelectionCursor = spClamp(s.SelectionCursor, spMax(0, len(s.currentOptions())-1))
+		s.Err = ""
+		return cmd, true
+	case s.currentStepUsesFreeformInput():
+		updated, cmd := s.OptionInput.Update(msg)
+		s.OptionInput = updated
+		s.Err = ""
+		return cmd, true
+	default:
+		return nil, false
+	}
+}
+
+func (s *servicePlanDeploymentFormState) updateCurrentFormFieldInput(msg tea.KeyMsg) (tea.Cmd, bool) {
+	if !servicePlanDeploymentTextInputKey(msg) || !s.currentStepUsesFormFields() || len(s.ParamFields) == 0 {
+		return nil, false
+	}
+	field := &s.ParamFields[s.ParamCursor]
+	if len(field.Options) > 0 {
+		return nil, false
+	}
+	updated, cmd := field.Input.Update(msg)
+	field.Input = updated
+	s.Err = ""
+	return cmd, true
+}
+
+func (s *servicePlanDeploymentFormState) advanceFormFieldCursor() bool {
+	if s.Launching || !s.currentStepUsesFormFields() || len(s.ParamFields) == 0 || s.ParamCursor >= len(s.ParamFields)-1 {
+		return false
+	}
+	if err := servicePlanValidateDeploymentFormField(s.ParamFields[s.ParamCursor]); err != nil {
+		s.Err = err.Error()
+		return false
+	}
+	s.ParamCursor++
+	s.syncFocus()
+	s.Err = ""
+	return true
+}
+
+func servicePlanDeploymentTextInputKey(msg tea.KeyMsg) bool {
+	if len(msg.Runes) > 0 {
+		return true
+	}
+	switch msg.String() {
+	case "backspace", "ctrl+h", "delete", "ctrl+u", "ctrl+w":
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *servicePlanDeploymentFormState) moveCurrentParameterOption(delta int) bool {
@@ -2018,13 +2610,40 @@ func (s servicePlanDeploymentFormState) currentStepIsParameters() bool {
 	return step == servicePlanDeploymentStepCustomParams || step == servicePlanDeploymentStepSystemParams
 }
 
+func (s servicePlanDeploymentFormState) currentStepUsesFormFields() bool {
+	return s.currentStepIsParameters() || s.currentStep() == servicePlanDeploymentStepConnectAccount
+}
+
+func (s servicePlanDeploymentFormState) currentStepUsesFreeformInput() bool {
+	if len(s.currentOptions()) > 0 {
+		return false
+	}
+	switch s.currentStep() {
+	case servicePlanDeploymentStepCloud, servicePlanDeploymentStepRegion:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s servicePlanDeploymentFormState) currentFreeformValue() string {
+	switch s.currentStep() {
+	case servicePlanDeploymentStepCloud:
+		return s.CloudProvider
+	case servicePlanDeploymentStepRegion:
+		return s.Region
+	default:
+		return ""
+	}
+}
+
 func (s servicePlanDeploymentFormState) currentStepNumber() int {
 	return spMin(s.StepIndex+1, len(s.Steps))
 }
 
 func (s *servicePlanDeploymentFormState) syncFocus() {
 	for i := range s.ParamFields {
-		if i == s.ParamCursor {
+		if i == s.ParamCursor && len(s.ParamFields[i].Options) == 0 {
 			s.ParamFields[i].Input.Focus()
 		} else {
 			s.ParamFields[i].Input.Blur()
@@ -2037,11 +2656,32 @@ func (s *servicePlanDeploymentFormState) storeCurrentParameterValues() error {
 		s.ParamValues = map[string]string{}
 	}
 	for _, field := range s.ParamFields {
-		value := strings.TrimSpace(field.Input.Value())
-		if field.Required && value == "" {
-			return fmt.Errorf("%s is required", field.Label)
+		if err := servicePlanValidateDeploymentFormField(field); err != nil {
+			return err
 		}
+		value := strings.TrimSpace(field.Input.Value())
 		s.ParamValues[field.Key] = value
+	}
+	return nil
+}
+
+func (s *servicePlanDeploymentFormState) storeCurrentAccountValues() error {
+	if s.AccountParamValues == nil {
+		s.AccountParamValues = map[string]string{}
+	}
+	for _, field := range s.ParamFields {
+		if err := servicePlanValidateDeploymentFormField(field); err != nil {
+			return err
+		}
+		value := strings.TrimSpace(field.Input.Value())
+		s.AccountParamValues[field.Key] = value
+	}
+	return nil
+}
+
+func servicePlanValidateDeploymentFormField(field servicePlanDeploymentFormField) error {
+	if field.Required && strings.TrimSpace(field.Input.Value()) == "" {
+		return fmt.Errorf("%s is required", field.Label)
 	}
 	return nil
 }
@@ -2051,6 +2691,12 @@ func (s *servicePlanDeploymentFormState) applySelectedOption() error {
 	if len(options) == 0 {
 		if s.currentStep() == servicePlanDeploymentStepCloudAccount {
 			return fmt.Errorf("no connected cloud accounts for %s. Run: omnistrate-ctl account customer create --help", emptyValue(s.CloudProvider))
+		}
+		if s.currentStepUsesFreeformInput() {
+			return s.applyFreeformOption()
+		}
+		if s.currentStep() == servicePlanDeploymentStepCustomer {
+			return fmt.Errorf("no customers match %q", strings.TrimSpace(s.CustomerSearch.Value()))
 		}
 		return nil
 	}
@@ -2063,16 +2709,90 @@ func (s *servicePlanDeploymentFormState) applySelectedOption() error {
 		s.ResourceName = option.Value
 		s.ParamFields = nil
 	case servicePlanDeploymentStepCloud:
+		s.removeConnectAccountStep()
 		s.CloudProvider = option.Value
 		s.Region = firstString(s.Form.RegionsByCloud[s.CloudProvider])
 		s.CustomerAccountID = s.firstCloudAccountID()
 	case servicePlanDeploymentStepCloudAccount:
+		if option.ConnectAccount || option.AccountAction == servicePlanCustomerCloudAccountActionConnect {
+			s.CustomerAccountID = ""
+			s.ensureConnectAccountStep()
+			return nil
+		}
+		if option.AccountAction != "" && option.AccountAction != servicePlanCustomerCloudAccountActionSelect {
+			return nil
+		}
+		s.removeConnectAccountStep()
 		s.CustomerAccountID = option.Value
 	case servicePlanDeploymentStepRegion:
 		s.Region = option.Value
 	}
 	s.SelectionCursor = 0
 	return nil
+}
+
+func (s *servicePlanDeploymentFormState) customerAccountConnectRequest() (servicePlanCustomerCloudAccountConnectRequest, error) {
+	request := servicePlanCustomerCloudAccountConnectRequest{
+		Form:          s.Form,
+		Customer:      s.SelectedCustomer,
+		CloudProvider: s.CloudProvider,
+		Values:        map[string]string{},
+	}
+	if err := s.storeCurrentAccountValues(); err != nil {
+		return request, err
+	}
+	if !servicePlanCustomerAccountConnectSupported(s.CloudProvider) {
+		return request, fmt.Errorf("inline cloud account connection is not supported for %s", emptyValue(s.CloudProvider))
+	}
+	if strings.TrimSpace(s.Form.AccountResource.ID) == "" || strings.TrimSpace(s.Form.AccountResource.URLKey) == "" {
+		return request, fmt.Errorf("selected plan does not expose the injected cloud account resource")
+	}
+	for key, value := range s.AccountParamValues {
+		request.Values[key] = value
+	}
+	return request, nil
+}
+
+func (s *servicePlanDeploymentFormState) applyFreeformOption() error {
+	value := strings.TrimSpace(s.OptionInput.Value())
+	switch s.currentStep() {
+	case servicePlanDeploymentStepCloud:
+		s.removeConnectAccountStep()
+		if value == "" {
+			return fmt.Errorf("cloud provider is required")
+		}
+		s.CloudProvider = value
+		s.Region = firstString(s.Form.RegionsByCloud[s.CloudProvider])
+		s.CustomerAccountID = s.firstCloudAccountID()
+	case servicePlanDeploymentStepRegion:
+		if value == "" {
+			return fmt.Errorf("region is required")
+		}
+		s.Region = value
+	}
+	s.SelectionCursor = 0
+	return nil
+}
+
+func (s *servicePlanDeploymentFormState) ensureConnectAccountStep() {
+	s.removeConnectAccountStep()
+	insertAt := spMin(s.StepIndex+1, len(s.Steps))
+	s.Steps = append(s.Steps, "")
+	copy(s.Steps[insertAt+1:], s.Steps[insertAt:])
+	s.Steps[insertAt] = servicePlanDeploymentStepConnectAccount
+}
+
+func (s *servicePlanDeploymentFormState) removeConnectAccountStep() {
+	for i, step := range s.Steps {
+		if step != servicePlanDeploymentStepConnectAccount {
+			continue
+		}
+		s.Steps = append(s.Steps[:i], s.Steps[i+1:]...)
+		if i < s.StepIndex {
+			s.StepIndex--
+		}
+		return
+	}
 }
 
 func (s servicePlanDeploymentFormState) launchRequest() (servicePlanDeploymentLaunchRequest, error) {
@@ -2097,7 +2817,7 @@ func (s servicePlanDeploymentFormState) launchRequest() (servicePlanDeploymentLa
 	if _, ok := servicePlanDeploymentResourceByName(s.Form, request.ResourceName); !ok {
 		return request, fmt.Errorf("resource %q is not available for this plan", request.ResourceName)
 	}
-	if request.CloudProvider != "" && !servicePlanContainsFold(s.Form.CloudProviders, request.CloudProvider) {
+	if request.CloudProvider != "" && len(s.Form.CloudProviders) > 0 && !servicePlanContainsFold(s.Form.CloudProviders, request.CloudProvider) {
 		return request, fmt.Errorf("cloud provider %q is not available for this plan", request.CloudProvider)
 	}
 	if request.Region != "" {
@@ -2110,8 +2830,12 @@ func (s servicePlanDeploymentFormState) launchRequest() (servicePlanDeploymentLa
 		if request.CustomerAccountID == "" {
 			return request, fmt.Errorf("customer cloud account is required for BYOC plans. Run: omnistrate-ctl account customer create --help")
 		}
-		if !servicePlanCustomerCloudAccountExists(s.filteredCloudAccounts(), request.CustomerAccountID) {
+		account, ok := servicePlanCustomerCloudAccountByID(s.filteredCloudAccounts(), request.CustomerAccountID)
+		if !ok {
 			return request, fmt.Errorf("customer cloud account %q is not connected to this plan", request.CustomerAccountID)
+		}
+		if !servicePlanCustomerCloudAccountUsable(account) {
+			return request, fmt.Errorf("%s is %s", servicePlanCustomerCloudAccountLabel(account), emptyValue(account.Status))
 		}
 	}
 
@@ -2225,7 +2949,7 @@ func (m servicePlanBrowserModel) renderDeploymentForm() string {
 		lines = append(lines, form.renderDeploymentCompleteLines(valueStyle)...)
 	case form.currentStep() == servicePlanDeploymentStepReview:
 		lines = append(lines, form.renderDeploymentReviewLines(labelStyle, valueStyle)...)
-	case form.currentStepIsParameters():
+	case form.currentStepUsesFormFields():
 		lines = append(lines, form.renderDeploymentParameterLines(height, labelStyle, selectedLabelStyle, metaStyle)...)
 	default:
 		lines = append(lines, form.renderDeploymentOptionLines(height, selectedLabelStyle, valueStyle, metaStyle)...)
@@ -2234,41 +2958,149 @@ func (m servicePlanBrowserModel) renderDeploymentForm() string {
 	if form.Err != "" {
 		lines = append(lines, "", lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Render("Error: "+form.Err))
 	}
+	if form.Notice != "" {
+		lines = append(lines, "", lipgloss.NewStyle().Foreground(lipgloss.Color("111")).Render(form.Notice))
+	}
 	if form.Launching {
-		lines = append(lines, "", lipgloss.NewStyle().Foreground(lipgloss.Color("111")).Render("Launching deployment..."))
+		lines = append(lines, "", lipgloss.NewStyle().Foreground(lipgloss.Color("111")).Render(m.spinner.View()+" Launching deployment..."))
+	}
+	if form.ConnectingAccount {
+		lines = append(lines, "")
+		if strings.TrimSpace(form.PendingAccount.InstanceID) == "" {
+			lines = append(lines, lipgloss.NewStyle().Foreground(lipgloss.Color("111")).Render(m.spinner.View()+" Creating "+emptyValue(form.CloudProvider)+" account connection..."))
+		} else {
+			lines = append(lines, lipgloss.NewStyle().Foreground(lipgloss.Color("111")).Render(m.spinner.View()+" Waiting for account to become READY..."))
+			lines = append(lines, "")
+			lines = append(lines, servicePlanCustomerCloudAccountOnboardingLines(form.PendingAccount, "", metaStyle)...)
+		}
+	}
+	if form.AccountActionRunning {
+		lines = append(lines, "", lipgloss.NewStyle().Foreground(lipgloss.Color("111")).Render(m.spinner.View()+" "+servicePlanCustomerCloudAccountActionProgressText(form.AccountAction)))
 	}
 
-	help := "enter/→: next  ↑/↓: select  ←: back  esc: close"
-	if form.currentStepIsParameters() {
-		help = "enter/→: next  tab/shift+tab: fields  ↑/↓: select option or move fields  ←: back  esc: close"
-	}
-	if form.currentStep() == servicePlanDeploymentStepReview {
-		help = "enter: launch  ←: back  esc: close"
-	}
-	if form.currentStep() == servicePlanDeploymentStepComplete {
-		help = "enter/esc: close"
-	}
-	lines = append(lines, "", metaStyle.Render(help))
+	lines = append(lines, "", metaStyle.Render(form.deploymentHelpLine()))
 
 	return servicePlanBrowserPanelStyle(lipgloss.Color("117")).
 		Width(width).
 		Render(lipgloss.JoinVertical(lipgloss.Left, lines...))
 }
 
+func servicePlanCustomerCloudAccountActionProgressText(action servicePlanCustomerCloudAccountAction) string {
+	switch action {
+	case servicePlanCustomerCloudAccountActionDelete:
+		return "Deleting cloud account..."
+	case servicePlanCustomerCloudAccountActionRetry:
+		return "Retrying cloud account..."
+	default:
+		return "Updating cloud account..."
+	}
+}
+
 func (s servicePlanDeploymentFormState) renderDeploymentOptionLines(height int, selectedStyle, valueStyle, metaStyle lipgloss.Style) []string {
 	options := s.currentOptions()
-	if len(options) == 0 {
-		if s.currentStep() == servicePlanDeploymentStepCloudAccount {
+	if s.currentStep() == servicePlanDeploymentStepCustomer {
+		lines := []string{
+			valueStyle.Render(s.CustomerSearch.View()),
+			metaStyle.Render(fmt.Sprintf("%d customer option(s)", len(options))),
+			"",
+		}
+		if len(options) == 0 {
+			return append(lines, "No customers match the current search.")
+		}
+		return append(lines, s.renderDeploymentOptionList(options, spMax(height-13, 4), selectedStyle, valueStyle, metaStyle)...)
+	}
+	if s.currentStep() == servicePlanDeploymentStepCloudAccount {
+		if len(options) == 0 {
 			return []string{
-				"No connected cloud accounts match this selection.",
+				"No connected cloud accounts match this selection, and this cloud is not supported by the inline connector.",
 				"",
 				metaStyle.Render("Run: omnistrate-ctl account customer create --help"),
+			}
+		}
+		return s.renderDeploymentCloudAccountLines(options, spMax(height-10, 4), selectedStyle, valueStyle, metaStyle)
+	}
+	if len(options) == 0 {
+		if s.currentStepUsesFreeformInput() {
+			return []string{
+				metaStyle.Render("No fixed options were returned. Type a value."),
+				valueStyle.Render(s.OptionInput.View()),
 			}
 		}
 		return []string{"No options available."}
 	}
 
-	visibleRows := spMax(height-10, 4)
+	return s.renderDeploymentOptionList(options, spMax(height-10, 4), selectedStyle, valueStyle, metaStyle)
+}
+
+func (s servicePlanDeploymentFormState) renderDeploymentCloudAccountLines(options []servicePlanDeploymentWizardOption, visibleRows int, selectedStyle, valueStyle, metaStyle lipgloss.Style) []string {
+	start := 0
+	if s.SelectionCursor >= visibleRows {
+		start = s.SelectionCursor - visibleRows + 1
+	}
+	end := spMin(len(options), start+visibleRows)
+	lines := make([]string, 0, visibleRows*3)
+	for i := start; i < end; i++ {
+		option := options[i]
+		if option.ConnectAccount && i > start {
+			lines = append(lines, "")
+		}
+		prefix := fmt.Sprintf("%d. ", i+1)
+		style := valueStyle
+		if i == s.SelectionCursor {
+			if option.ConnectAccount {
+				prefix = "▸ "
+			} else {
+				prefix = "▸ " + prefix
+			}
+			style = selectedStyle
+		} else {
+			if option.ConnectAccount {
+				prefix = "  "
+			} else {
+				prefix = "  " + prefix
+			}
+		}
+		lines = append(lines, style.Render(prefix+option.Label))
+		if option.Description != "" {
+			if strings.TrimSpace(option.Account.InstanceID) != "" {
+				lines = append(lines, renderServicePlanCustomerCloudAccountDescription(option.Account, metaStyle, "    "))
+			} else {
+				lines = append(lines, metaStyle.Render("    "+option.Description))
+			}
+		}
+		if buttons := s.customerCloudAccountActionButtons(option); len(buttons) > 0 {
+			lines = append(lines, "    "+s.renderCustomerCloudAccountActionButtons(buttons, i == s.SelectionCursor))
+		}
+		if i == s.SelectionCursor && servicePlanCustomerCloudAccountNeedsOnboarding(option.Account) {
+			lines = append(lines, servicePlanCustomerCloudAccountOnboardingLines(option.Account, "    ", metaStyle)...)
+		}
+	}
+	return lines
+}
+
+func (s servicePlanDeploymentFormState) renderCustomerCloudAccountActionButtons(buttons []servicePlanCustomerCloudAccountActionButton, selectedAccount bool) string {
+	activeStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(lipgloss.Color("230")).
+		Background(lipgloss.Color("62")).
+		Padding(0, 1)
+	inactiveStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("252")).
+		Background(lipgloss.Color("238")).
+		Padding(0, 1)
+
+	rendered := make([]string, 0, len(buttons))
+	for i, button := range buttons {
+		style := inactiveStyle
+		if selectedAccount && i == spClamp(s.AccountActionCursor, len(buttons)-1) {
+			style = activeStyle
+		}
+		rendered = append(rendered, style.Render(button.Label))
+	}
+	return strings.Join(rendered, " ")
+}
+
+func (s servicePlanDeploymentFormState) renderDeploymentOptionList(options []servicePlanDeploymentWizardOption, visibleRows int, selectedStyle, valueStyle, metaStyle lipgloss.Style) []string {
 	start := 0
 	if s.SelectionCursor >= visibleRows {
 		start = s.SelectionCursor - visibleRows + 1
@@ -2323,6 +3155,85 @@ func (s servicePlanDeploymentFormState) renderDeploymentParameterLines(height in
 		}
 	}
 	return lines
+}
+
+func (s servicePlanDeploymentFormState) deploymentHelpLine() string {
+	switch {
+	case s.currentStep() == servicePlanDeploymentStepComplete:
+		return "enter: close  esc: close"
+	case s.Launching || s.ConnectingAccount:
+		if strings.TrimSpace(s.selectedCloudFormationTemplateURL()) != "" {
+			return "c: copy template URL  esc: cancel"
+		}
+		return "esc: cancel"
+	case s.currentStepUsesFormFields() && len(s.ParamFields) > 1:
+		return "type/backspace: edit  tab/shift+tab: fields  enter: continue  esc: cancel"
+	case s.currentStepUsesFormFields():
+		return "type/backspace: edit  enter: continue  esc: cancel"
+	case s.currentStep() == servicePlanDeploymentStepCustomer:
+		return "type: search  ↑/↓: select  enter: continue  esc: cancel"
+	case s.currentStep() == servicePlanDeploymentStepCloudAccount:
+		copyHint := ""
+		if strings.TrimSpace(s.selectedCloudFormationTemplateURL()) != "" {
+			copyHint = "  c: copy template URL"
+		}
+		if len(s.selectedCustomerCloudAccountActionButtons()) == 0 {
+			return "enter: select" + copyHint + "  esc: cancel"
+		}
+		return "↑/↓: account  tab/shift+tab: action  enter: select" + copyHint + "  esc: cancel"
+	default:
+		return "↑/↓: select  enter: continue  esc: cancel"
+	}
+}
+
+func (s servicePlanDeploymentFormState) selectedCloudFormationTemplateURL() string {
+	account, ok := s.selectedCloudAccountForTemplateURL()
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(account.AWSCloudFormationURL)
+}
+
+func (s servicePlanDeploymentFormState) selectedCloudAccountForTemplateURL() (servicePlanCustomerCloudAccountRow, bool) {
+	if s.ConnectingAccount {
+		if strings.TrimSpace(s.PendingAccount.InstanceID) == "" {
+			return servicePlanCustomerCloudAccountRow{}, false
+		}
+		return s.PendingAccount, true
+	}
+	if s.currentStep() != servicePlanDeploymentStepCloudAccount {
+		return servicePlanCustomerCloudAccountRow{}, false
+	}
+	options := s.currentOptions()
+	if len(options) == 0 {
+		return servicePlanCustomerCloudAccountRow{}, false
+	}
+	option := options[spClamp(s.SelectionCursor, len(options)-1)]
+	if option.ConnectAccount || strings.TrimSpace(option.Account.InstanceID) == "" {
+		return servicePlanCustomerCloudAccountRow{}, false
+	}
+	return option.Account, true
+}
+
+func (s servicePlanDeploymentFormState) selectedCustomerCloudAccountForRefresh() (servicePlanCustomerCloudAccountRow, bool) {
+	if s.ConnectingAccount {
+		if servicePlanCustomerCloudAccountNeedsOnboarding(s.PendingAccount) {
+			return s.PendingAccount, true
+		}
+		return servicePlanCustomerCloudAccountRow{}, false
+	}
+	if s.currentStep() != servicePlanDeploymentStepCloudAccount {
+		return servicePlanCustomerCloudAccountRow{}, false
+	}
+	options := s.currentOptions()
+	if len(options) == 0 {
+		return servicePlanCustomerCloudAccountRow{}, false
+	}
+	option := options[spClamp(s.SelectionCursor, len(options)-1)]
+	if option.ConnectAccount || !servicePlanCustomerCloudAccountNeedsOnboarding(option.Account) {
+		return servicePlanCustomerCloudAccountRow{}, false
+	}
+	return option.Account, true
 }
 
 func servicePlanDeploymentParameterOptionsLine(field servicePlanDeploymentFormField) string {
@@ -2397,6 +3308,9 @@ func (s servicePlanDeploymentFormState) currentOptions() []servicePlanDeployment
 		customers := servicePlanDeploymentCustomerOptions(s.Form)
 		options := make([]servicePlanDeploymentWizardOption, 0, len(customers))
 		for _, customer := range customers {
+			if !servicePlanDeploymentCustomerMatchesSearch(customer, s.CustomerSearch.Value()) {
+				continue
+			}
 			options = append(options, servicePlanDeploymentWizardOption{
 				Label:       servicePlanDeploymentCustomerLabel(customer),
 				Description: servicePlanDeploymentCustomerDescription(customer),
@@ -2426,15 +3340,22 @@ func (s servicePlanDeploymentFormState) currentOptions() []servicePlanDeployment
 		return options
 	case servicePlanDeploymentStepCloudAccount:
 		accounts := s.filteredCloudAccounts()
-		options := make([]servicePlanDeploymentWizardOption, 0, len(accounts))
+		options := make([]servicePlanDeploymentWizardOption, 0, len(accounts)+1)
 		for _, account := range accounts {
-			label := account.InstanceID
-			descriptionParts := []string{account.CloudProvider, account.Region, account.Status, account.CustomerEmail}
 			options = append(options, servicePlanDeploymentWizardOption{
-				Label:       label,
-				Description: strings.Join(nonEmptyStrings(descriptionParts), " | "),
-				Value:       account.InstanceID,
-				Account:     account,
+				Label:         servicePlanCustomerCloudAccountLabel(account),
+				Description:   servicePlanCustomerCloudAccountDescription(account),
+				Value:         account.InstanceID,
+				Account:       account,
+				AccountAction: servicePlanCustomerCloudAccountDefaultAction(account),
+			})
+		}
+		if servicePlanCustomerAccountConnectSupported(s.CloudProvider) {
+			options = append(options, servicePlanDeploymentWizardOption{
+				Label:          servicePlanCustomerCloudAccountConnectOptionLabel(s.CloudProvider, len(accounts) > 0),
+				Value:          servicePlanCustomerAccountConnectOptionValue,
+				ConnectAccount: true,
+				AccountAction:  servicePlanCustomerCloudAccountActionConnect,
 			})
 		}
 		return options
@@ -2448,6 +3369,22 @@ func (s servicePlanDeploymentFormState) currentOptions() []servicePlanDeployment
 	default:
 		return nil
 	}
+}
+
+func servicePlanDeploymentCustomerMatchesSearch(customer servicePlanDeploymentCustomer, query string) bool {
+	query = strings.ToLower(strings.TrimSpace(query))
+	if query == "" {
+		return true
+	}
+	haystack := strings.ToLower(strings.Join(nonEmptyStrings([]string{
+		servicePlanDeploymentCustomerLabel(customer),
+		servicePlanDeploymentCustomerDescription(customer),
+		customer.Email,
+		customer.Name,
+		customer.OrgName,
+		customer.UserID,
+	}), " "))
+	return strings.Contains(haystack, query)
 }
 
 func (s servicePlanDeploymentFormState) selectedOptionIndex() int {
@@ -2478,6 +3415,65 @@ func (s servicePlanDeploymentFormState) selectedOptionIndex() int {
 	return 0
 }
 
+func (s servicePlanDeploymentFormState) selectedCustomerCloudAccountAction() (servicePlanDeploymentWizardOption, servicePlanCustomerCloudAccountAction, bool) {
+	if s.currentStep() != servicePlanDeploymentStepCloudAccount {
+		return servicePlanDeploymentWizardOption{}, servicePlanCustomerCloudAccountActionNone, false
+	}
+	options := s.currentOptions()
+	if len(options) == 0 {
+		return servicePlanDeploymentWizardOption{}, servicePlanCustomerCloudAccountActionNone, false
+	}
+	option := options[spClamp(s.SelectionCursor, len(options)-1)]
+	buttons := s.customerCloudAccountActionButtons(option)
+	if len(buttons) == 0 {
+		return option, option.AccountAction, true
+	}
+	action := buttons[spClamp(s.AccountActionCursor, len(buttons)-1)].Action
+	return option, action, true
+}
+
+func (s servicePlanDeploymentFormState) selectedCustomerCloudAccountActionButtons() []servicePlanCustomerCloudAccountActionButton {
+	if s.currentStep() != servicePlanDeploymentStepCloudAccount {
+		return nil
+	}
+	options := s.currentOptions()
+	if len(options) == 0 {
+		return nil
+	}
+	return s.customerCloudAccountActionButtons(options[spClamp(s.SelectionCursor, len(options)-1)])
+}
+
+func (s servicePlanDeploymentFormState) customerCloudAccountActionButtons(option servicePlanDeploymentWizardOption) []servicePlanCustomerCloudAccountActionButton {
+	if option.ConnectAccount || option.AccountAction == servicePlanCustomerCloudAccountActionConnect {
+		return nil
+	}
+
+	buttons := make([]servicePlanCustomerCloudAccountActionButton, 0, 2)
+	switch {
+	case servicePlanCustomerCloudAccountUsable(option.Account):
+		buttons = append(buttons,
+			servicePlanCustomerCloudAccountActionButton{Label: "Use", Action: servicePlanCustomerCloudAccountActionSelect},
+			servicePlanCustomerCloudAccountActionButton{Label: "Delete", Action: servicePlanCustomerCloudAccountActionDelete},
+		)
+	case strings.EqualFold(strings.TrimSpace(option.Account.Status), "FAILED"):
+		buttons = append(buttons,
+			servicePlanCustomerCloudAccountActionButton{Label: "Retry", Action: servicePlanCustomerCloudAccountActionRetry},
+			servicePlanCustomerCloudAccountActionButton{Label: "Delete", Action: servicePlanCustomerCloudAccountActionDelete},
+		)
+	default:
+		buttons = append(buttons, servicePlanCustomerCloudAccountActionButton{Label: "Waiting", Action: servicePlanCustomerCloudAccountActionUnavailable})
+	}
+	return buttons
+}
+
+func servicePlanCustomerCloudAccountConnectOptionLabel(cloudProvider string, hasAccounts bool) string {
+	cloud := strings.ToLower(strings.TrimSpace(cloudProvider))
+	if hasAccounts {
+		return "Connect new " + emptyValue(cloud) + " account"
+	}
+	return "Connect your " + emptyValue(cloud) + " account"
+}
+
 func (s servicePlanDeploymentFormState) filteredCloudAccounts() []servicePlanCustomerCloudAccountRow {
 	accounts := make([]servicePlanCustomerCloudAccountRow, 0, len(s.Form.CustomerCloudAccounts))
 	selectedSubscriptionID := servicePlanSubscriptionIDForCustomer(s.Form.Subscriptions, s.SelectedCustomer)
@@ -2485,6 +3481,12 @@ func (s servicePlanDeploymentFormState) filteredCloudAccounts() []servicePlanCus
 		if s.CloudProvider != "" && !strings.EqualFold(account.CloudProvider, s.CloudProvider) {
 			continue
 		}
+		account.CustomerEmail = firstString([]string{
+			account.CustomerEmail,
+			servicePlanEmailForSubscriptionRows(s.Form.Subscriptions, account.SubscriptionID),
+			s.SelectedCustomer.Email,
+		})
+		account.StatusMessage = servicePlanCustomerCloudAccountStatusMessage(account)
 		if !s.SelectedCustomer.Self {
 			switch {
 			case selectedSubscriptionID != "" && account.SubscriptionID != "":
@@ -2506,11 +3508,71 @@ func (s servicePlanDeploymentFormState) filteredCloudAccounts() []servicePlanCus
 
 func (s servicePlanDeploymentFormState) firstCloudAccountID() string {
 	for _, account := range s.filteredCloudAccounts() {
+		if !servicePlanCustomerCloudAccountUsable(account) {
+			continue
+		}
 		if strings.TrimSpace(account.InstanceID) != "" {
 			return strings.TrimSpace(account.InstanceID)
 		}
 	}
 	return ""
+}
+
+func (s *servicePlanDeploymentFormState) addConnectedCustomerAccount(account servicePlanCustomerCloudAccountRow) {
+	account.InstanceID = strings.TrimSpace(account.InstanceID)
+	if account.InstanceID == "" {
+		return
+	}
+	account.CustomerEmail = firstString([]string{
+		account.CustomerEmail,
+		servicePlanEmailForSubscriptionRows(s.Form.Subscriptions, account.SubscriptionID),
+		s.SelectedCustomer.Email,
+	})
+	account.StatusMessage = servicePlanCustomerCloudAccountStatusMessage(account)
+	if !servicePlanCustomerCloudAccountExists(s.Form.CustomerCloudAccounts, account.InstanceID) {
+		s.Form.CustomerCloudAccounts = append(s.Form.CustomerCloudAccounts, account)
+	} else {
+		for i := range s.Form.CustomerCloudAccounts {
+			if strings.EqualFold(s.Form.CustomerCloudAccounts[i].InstanceID, account.InstanceID) {
+				s.Form.CustomerCloudAccounts[i] = account
+				break
+			}
+		}
+	}
+	s.CustomerAccountID = account.InstanceID
+	s.SelectionCursor = s.selectedOptionIndex()
+
+	if s.SelectedCustomer.Self || strings.TrimSpace(account.SubscriptionID) == "" {
+		return
+	}
+	if servicePlanSubscriptionIDForCustomer(s.Form.Subscriptions, s.SelectedCustomer) != "" {
+		return
+	}
+	s.Form.Subscriptions = append(s.Form.Subscriptions, servicePlanSubscriptionRow{
+		ID:            strings.TrimSpace(account.SubscriptionID),
+		Status:        "ACTIVE",
+		RootUserEmail: s.SelectedCustomer.Email,
+		RootUserID:    s.SelectedCustomer.UserID,
+		RootUserName:  s.SelectedCustomer.Name,
+	})
+}
+
+func (s *servicePlanDeploymentFormState) removeCustomerAccount(instanceID string) {
+	instanceID = strings.TrimSpace(instanceID)
+	if instanceID == "" {
+		return
+	}
+	for i, account := range s.Form.CustomerCloudAccounts {
+		if !strings.EqualFold(account.InstanceID, instanceID) {
+			continue
+		}
+		s.Form.CustomerCloudAccounts = append(s.Form.CustomerCloudAccounts[:i], s.Form.CustomerCloudAccounts[i+1:]...)
+		break
+	}
+	if strings.EqualFold(s.CustomerAccountID, instanceID) {
+		s.CustomerAccountID = s.firstCloudAccountID()
+	}
+	s.SelectionCursor = s.selectedOptionIndex()
 }
 
 func servicePlanDeploymentCustomerOptions(form servicePlanDeploymentForm) []servicePlanDeploymentCustomer {
@@ -2559,6 +3621,8 @@ func servicePlanDeploymentStepTitle(step servicePlanDeploymentWizardStep) string
 		return "Cloud Provider"
 	case servicePlanDeploymentStepCloudAccount:
 		return "Customer Cloud Account"
+	case servicePlanDeploymentStepConnectAccount:
+		return "Connect Cloud Account"
 	case servicePlanDeploymentStepRegion:
 		return "Region"
 	case servicePlanDeploymentStepCustomParams:
@@ -2571,6 +3635,41 @@ func servicePlanDeploymentStepTitle(step servicePlanDeploymentWizardStep) string
 		return "Complete"
 	default:
 		return "Deploy"
+	}
+}
+
+func servicePlanCustomerAccountConnectSupported(cloudProvider string) bool {
+	switch strings.ToLower(strings.TrimSpace(cloudProvider)) {
+	case "aws", "gcp", "azure", "nebius":
+		return true
+	default:
+		return false
+	}
+}
+
+func servicePlanCustomerAccountFieldSpecs(cloudProvider string) []servicePlanCustomerAccountFieldSpec {
+	switch strings.ToLower(strings.TrimSpace(cloudProvider)) {
+	case "aws":
+		return []servicePlanCustomerAccountFieldSpec{
+			{Key: servicePlanCustomerAccountAWSAccountIDKey, Label: "AWS account ID"},
+		}
+	case "gcp":
+		return []servicePlanCustomerAccountFieldSpec{
+			{Key: servicePlanCustomerAccountGCPProjectIDKey, Label: "GCP project ID"},
+			{Key: servicePlanCustomerAccountGCPProjectNumberKey, Label: "GCP project number"},
+		}
+	case "azure":
+		return []servicePlanCustomerAccountFieldSpec{
+			{Key: servicePlanCustomerAccountAzureSubscriptionIDKey, Label: "Azure subscription ID"},
+			{Key: servicePlanCustomerAccountAzureTenantIDKey, Label: "Azure tenant ID"},
+		}
+	case "nebius":
+		return []servicePlanCustomerAccountFieldSpec{
+			{Key: servicePlanCustomerAccountNebiusTenantIDKey, Label: "Nebius tenant ID"},
+			{Key: servicePlanCustomerAccountNebiusBindingsFileKey, Label: "Nebius bindings file"},
+		}
+	default:
+		return nil
 	}
 }
 
@@ -2589,12 +3688,254 @@ func servicePlanDeploymentResourceOptions(resources []servicePlanDeploymentResou
 }
 
 func servicePlanCustomerCloudAccountExists(accounts []servicePlanCustomerCloudAccountRow, instanceID string) bool {
+	_, ok := servicePlanCustomerCloudAccountByID(accounts, instanceID)
+	return ok
+}
+
+func servicePlanCustomerCloudAccountByID(accounts []servicePlanCustomerCloudAccountRow, instanceID string) (servicePlanCustomerCloudAccountRow, bool) {
 	for _, account := range accounts {
 		if strings.EqualFold(strings.TrimSpace(account.InstanceID), strings.TrimSpace(instanceID)) {
-			return true
+			return account, true
 		}
 	}
-	return false
+	return servicePlanCustomerCloudAccountRow{}, false
+}
+
+func servicePlanCustomerCloudAccountUsable(account servicePlanCustomerCloudAccountRow) bool {
+	status := strings.ToUpper(strings.TrimSpace(account.Status))
+	return status == "" || status == "READY" || status == "RUNNING"
+}
+
+func servicePlanCustomerCloudAccountDefaultAction(account servicePlanCustomerCloudAccountRow) servicePlanCustomerCloudAccountAction {
+	switch {
+	case servicePlanCustomerCloudAccountUsable(account):
+		return servicePlanCustomerCloudAccountActionSelect
+	case strings.EqualFold(strings.TrimSpace(account.Status), "FAILED"):
+		return servicePlanCustomerCloudAccountActionRetry
+	default:
+		return servicePlanCustomerCloudAccountActionUnavailable
+	}
+}
+
+func servicePlanCustomerCloudAccountLabel(account servicePlanCustomerCloudAccountRow) string {
+	provider := strings.ToLower(strings.TrimSpace(account.CloudProvider))
+	switch provider {
+	case "aws":
+		if strings.TrimSpace(account.AWSAccountID) != "" {
+			return "AWS account " + strings.TrimSpace(account.AWSAccountID)
+		}
+	case "gcp":
+		projectID := strings.TrimSpace(account.GCPProjectID)
+		projectNumber := strings.TrimSpace(account.GCPProjectNumber)
+		if projectID != "" && projectNumber != "" {
+			return fmt.Sprintf("GCP project %s (%s)", projectID, projectNumber)
+		}
+		if projectID != "" {
+			return "GCP project " + projectID
+		}
+	case "azure":
+		subscriptionID := strings.TrimSpace(account.AzureSubscriptionID)
+		tenantID := strings.TrimSpace(account.AzureTenantID)
+		if subscriptionID != "" && tenantID != "" {
+			return fmt.Sprintf("Azure subscription %s (%s)", subscriptionID, tenantID)
+		}
+		if subscriptionID != "" {
+			return "Azure subscription " + subscriptionID
+		}
+	case "nebius":
+		tenantID := strings.TrimSpace(account.NebiusTenantID)
+		if tenantID != "" && account.NebiusBindingsCount > 0 {
+			return fmt.Sprintf("Nebius tenant %s (%d bindings)", tenantID, account.NebiusBindingsCount)
+		}
+		if tenantID != "" {
+			return "Nebius tenant " + tenantID
+		}
+	}
+
+	if provider != "" {
+		return strings.ToUpper(provider) + " account details unavailable"
+	}
+	return "Cloud account details unavailable"
+}
+
+func servicePlanCustomerCloudAccountDescription(account servicePlanCustomerCloudAccountRow) string {
+	parts := []string{
+		account.Status,
+		servicePlanCustomerCloudAccountStatusMessage(account),
+		account.Region,
+		account.CustomerEmail,
+		account.SubscriptionID,
+	}
+	return strings.Join(nonEmptyStrings(parts), " | ")
+}
+
+func renderServicePlanCustomerCloudAccountDescription(account servicePlanCustomerCloudAccountRow, metaStyle lipgloss.Style, indent string) string {
+	status := strings.TrimSpace(account.Status)
+	parts := nonEmptyStrings([]string{
+		servicePlanCustomerCloudAccountStatusMessage(account),
+		account.Region,
+		account.CustomerEmail,
+		account.SubscriptionID,
+	})
+	if status == "" {
+		return metaStyle.Render(indent + strings.Join(parts, " | "))
+	}
+
+	line := metaStyle.Render(indent) + servicePlanCustomerCloudAccountStatusStyle(status, metaStyle).Render(status)
+	if len(parts) > 0 {
+		line += metaStyle.Render(" | " + strings.Join(parts, " | "))
+	}
+	return line
+}
+
+func servicePlanCustomerCloudAccountStatusMessage(account servicePlanCustomerCloudAccountRow) string {
+	if strings.EqualFold(strings.TrimSpace(account.Status), "READY") {
+		return "account verified"
+	}
+	return strings.TrimSpace(account.StatusMessage)
+}
+
+func servicePlanCustomerCloudAccountStatusStyle(status string, base lipgloss.Style) lipgloss.Style {
+	style := base.Bold(true)
+	switch strings.ToUpper(strings.TrimSpace(status)) {
+	case "READY", "RUNNING":
+		return style.Foreground(lipgloss.Color("82"))
+	case "FAILED":
+		return style.Foreground(lipgloss.Color("196"))
+	case "DEPLOYING", "PENDING", "UPDATING":
+		return style.Foreground(lipgloss.Color("214"))
+	default:
+		return style.Foreground(lipgloss.Color("245"))
+	}
+}
+
+func servicePlanCustomerCloudAccountNeedsOnboarding(account servicePlanCustomerCloudAccountRow) bool {
+	if strings.TrimSpace(account.InstanceID) == "" {
+		return false
+	}
+	if servicePlanCustomerCloudAccountUsable(account) {
+		return false
+	}
+	return !strings.EqualFold(strings.TrimSpace(account.Status), "FAILED")
+}
+
+func servicePlanCustomerCloudAccountOnboardingLines(account servicePlanCustomerCloudAccountRow, indent string, metaStyle lipgloss.Style) []string {
+	titleStyle := metaStyle.Bold(true).Foreground(lipgloss.Color("117"))
+	keyStyle := metaStyle.Bold(true).Foreground(lipgloss.Color("111"))
+	valueStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("252"))
+	messageStyle := metaStyle.Foreground(lipgloss.Color("245"))
+
+	lines := []string{
+		titleStyle.Render(indent + "Account connection"),
+		servicePlanCustomerCloudAccountInstructionLine(indent, "Instance ID", emptyValue(account.InstanceID), keyStyle, valueStyle),
+	}
+	if strings.TrimSpace(account.AccountConfigID) != "" {
+		lines = append(lines, servicePlanCustomerCloudAccountInstructionLine(indent, "Account config ID", strings.TrimSpace(account.AccountConfigID), keyStyle, valueStyle))
+	}
+
+	detailLines := servicePlanCustomerCloudAccountProviderInstructionLines(account, indent, keyStyle, valueStyle)
+	if len(detailLines) == 0 {
+		lines = append(lines, messageStyle.Render(indent+"Account details are still being prepared."))
+		return lines
+	}
+	lines = append(lines, detailLines...)
+	if !servicePlanCustomerCloudAccountHasProviderInstructions(account) {
+		lines = append(lines, messageStyle.Render(indent+"Account details are still being prepared."))
+	}
+	return lines
+}
+
+func servicePlanCustomerCloudAccountHasProviderInstructions(account servicePlanCustomerCloudAccountRow) bool {
+	switch strings.ToLower(strings.TrimSpace(account.CloudProvider)) {
+	case "aws":
+		return strings.TrimSpace(account.AWSCloudFormationURL) != ""
+	case "gcp":
+		return strings.TrimSpace(account.GCPBootstrapShellCommand) != ""
+	case "azure":
+		return strings.TrimSpace(account.AzureBootstrapShellCommand) != ""
+	case "oci":
+		return strings.TrimSpace(account.OCIBootstrapShellCommand) != ""
+	case "nebius":
+		return account.NebiusBindingsCount > 0
+	default:
+		return false
+	}
+}
+
+func servicePlanCustomerCloudAccountProviderInstructionLines(account servicePlanCustomerCloudAccountRow, indent string, keyStyle lipgloss.Style, valueStyle lipgloss.Style) []string {
+	switch strings.ToLower(strings.TrimSpace(account.CloudProvider)) {
+	case "aws":
+		return nonEmptyStrings([]string{
+			servicePlanCustomerCloudAccountInstructionLine(indent, "AWS account ID", account.AWSAccountID, keyStyle, valueStyle),
+			servicePlanCustomerCloudAccountInstructionLine(indent, "Bootstrap role ARN", account.AWSBootstrapRoleARN, keyStyle, valueStyle),
+			servicePlanCustomerCloudAccountInstructionLine(indent, "CloudFormation template URL", account.AWSCloudFormationURL, keyStyle, valueStyle),
+		})
+	case "gcp":
+		return nonEmptyStrings([]string{
+			servicePlanCustomerCloudAccountInstructionLine(indent, "GCP project ID", account.GCPProjectID, keyStyle, valueStyle),
+			servicePlanCustomerCloudAccountInstructionLine(indent, "GCP project number", account.GCPProjectNumber, keyStyle, valueStyle),
+			servicePlanCustomerCloudAccountInstructionLine(indent, "Service account email", account.GCPServiceAccountEmail, keyStyle, valueStyle),
+			servicePlanCustomerCloudAccountInstructionLine(indent, "Bootstrap command", account.GCPBootstrapShellCommand, keyStyle, valueStyle),
+		})
+	case "azure":
+		return nonEmptyStrings([]string{
+			servicePlanCustomerCloudAccountInstructionLine(indent, "Azure subscription ID", account.AzureSubscriptionID, keyStyle, valueStyle),
+			servicePlanCustomerCloudAccountInstructionLine(indent, "Azure tenant ID", account.AzureTenantID, keyStyle, valueStyle),
+			servicePlanCustomerCloudAccountInstructionLine(indent, "Bootstrap command", account.AzureBootstrapShellCommand, keyStyle, valueStyle),
+		})
+	case "oci":
+		return nonEmptyStrings([]string{
+			servicePlanCustomerCloudAccountInstructionLine(indent, "Bootstrap command", account.OCIBootstrapShellCommand, keyStyle, valueStyle),
+		})
+	case "nebius":
+		return nonEmptyStrings([]string{
+			servicePlanCustomerCloudAccountInstructionLine(indent, "Nebius tenant ID", account.NebiusTenantID, keyStyle, valueStyle),
+			servicePlanCustomerCloudAccountInstructionLine(indent, "Bindings", fmt.Sprintf("%d", account.NebiusBindingsCount), keyStyle, valueStyle),
+		})
+	default:
+		return nil
+	}
+}
+
+func servicePlanCustomerCloudAccountInstructionLine(indent string, label string, value string, keyStyle lipgloss.Style, valueStyle lipgloss.Style) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	return indent + keyStyle.Render(label+":") + " " + valueStyle.Render(value)
+}
+
+func copyServicePlanBrowserTextCmd(text string, successMessage string) tea.Cmd {
+	return func() tea.Msg {
+		if err := servicePlanBrowserCopyToClipboard(text); err != nil {
+			return servicePlanBrowserClipboardResultMsg{err: fmt.Errorf("clipboard copy failed: %w", err)}
+		}
+		return servicePlanBrowserClipboardResultMsg{message: successMessage}
+	}
+}
+
+func copyServicePlanBrowserToClipboard(text string) error {
+	var cmd *exec.Cmd
+
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("pbcopy")
+	case "linux":
+		if _, err := exec.LookPath("xclip"); err == nil {
+			cmd = exec.Command("xclip", "-selection", "clipboard")
+		} else if _, err := exec.LookPath("xsel"); err == nil {
+			cmd = exec.Command("xsel", "--clipboard", "--input")
+		} else {
+			return fmt.Errorf("no clipboard tool found (install xclip or xsel)")
+		}
+	case "windows":
+		cmd = exec.Command("clip.exe")
+	default:
+		return fmt.Errorf("clipboard is not supported on %s", runtime.GOOS)
+	}
+
+	cmd.Stdin = strings.NewReader(text)
+	return cmd.Run()
 }
 
 func servicePlanDeploymentParametersForSelectedResource(form servicePlanDeploymentForm, resourceName string) []servicePlanDeploymentParameter {
@@ -2837,6 +4178,7 @@ func (productionServicePlanBrowserLoader) LoadDeploymentForm(ctx context.Context
 		return servicePlanDeploymentForm{}, err
 	}
 
+	accountResource := servicePlanCustomerAccountResource(offering.ResourceParameters)
 	resources := servicePlanDeploymentResources(offering.ResourceParameters)
 	if len(resources) == 0 {
 		return servicePlanDeploymentForm{}, fmt.Errorf("no deployable resources found for %s / %s", env.ServiceName, env.PlanName)
@@ -2846,6 +4188,10 @@ func (productionServicePlanBrowserLoader) LoadDeploymentForm(ctx context.Context
 	for _, resource := range resources {
 		parametersResult, err := dataaccess.ListInputParameters(ctx, token, env.ServiceID, resource.ID, env.PlanID, version)
 		if err != nil {
+			if servicePlanInputParametersNotFound(err) {
+				parametersByResource[resource.ID] = nil
+				continue
+			}
 			return servicePlanDeploymentForm{}, err
 		}
 		parametersByResource[resource.ID] = servicePlanDeploymentParameters(parametersResult.GetInputParameters())
@@ -2892,6 +4238,7 @@ func (productionServicePlanBrowserLoader) LoadDeploymentForm(ctx context.Context
 		ServiceEnvironmentURLKey: offering.ServiceEnvironmentURLKey,
 		ServiceModelURLKey:       offering.ServiceModelURLKey,
 		ProductTierURLKey:        offering.ProductTierURLKey,
+		AccountResource:          accountResource,
 		Resources:                resources,
 		CloudProviders:           cloudProviders,
 		RegionsByCloud:           regionsByCloud,
@@ -2971,6 +4318,389 @@ func (productionServicePlanBrowserLoader) LaunchDeployment(ctx context.Context, 
 	return instance.GetId(), nil
 }
 
+func (productionServicePlanBrowserLoader) CreateCustomerCloudAccount(ctx context.Context, token string, request servicePlanCustomerCloudAccountConnectRequest) (servicePlanCustomerCloudAccountRow, error) {
+	accountResource := request.Form.AccountResource
+	if strings.TrimSpace(accountResource.URLKey) == "" {
+		return servicePlanCustomerCloudAccountRow{}, fmt.Errorf("selected plan does not expose the injected cloud account resource")
+	}
+
+	params, err := servicePlanCustomerAccountRequestParams(ctx, token, request.CloudProvider, request.Values)
+	if err != nil {
+		return servicePlanCustomerCloudAccountRow{}, err
+	}
+
+	subscriptionID := servicePlanSubscriptionIDForCustomer(request.Form.Subscriptions, request.Customer)
+	if !request.Customer.Self && subscriptionID == "" {
+		createResp, err := dataaccess.CreateSubscriptionOnBehalf(ctx, token, request.Form.Environment.ServiceID, request.Form.Environment.ID, &dataaccess.CreateSubscriptionOnBehalfOptions{
+			ProductTierID:            request.Form.Environment.PlanID,
+			OnBehalfOfCustomerUserID: request.Customer.UserID,
+			OnBehalfOfCustomerEmail:  request.Customer.Email,
+		})
+		if err != nil {
+			return servicePlanCustomerCloudAccountRow{}, fmt.Errorf("failed to create subscription for %s: %w", servicePlanDeploymentCustomerLabel(request.Customer), err)
+		}
+		subscriptionID = strings.TrimSpace(createResp.GetId())
+		if subscriptionID == "" {
+			return servicePlanCustomerCloudAccountRow{}, fmt.Errorf("subscription creation for %s returned an empty subscription ID", servicePlanDeploymentCustomerLabel(request.Customer))
+		}
+	}
+
+	createRequest := openapiclientfleet.FleetCreateResourceInstanceRequest2{
+		ProductTierVersion: &request.Form.Version,
+		RequestParams:      params,
+	}
+	if subscriptionID != "" {
+		createRequest.SubscriptionId = &subscriptionID
+	}
+
+	instance, err := dataaccess.CreateResourceInstance(
+		ctx,
+		token,
+		request.Form.ServiceProviderID,
+		request.Form.ServiceURLKey,
+		request.Form.ServiceAPIVersion,
+		request.Form.ServiceEnvironmentURLKey,
+		request.Form.ServiceModelURLKey,
+		request.Form.ProductTierURLKey,
+		accountResource.URLKey,
+		createRequest,
+	)
+	if err != nil {
+		return servicePlanCustomerCloudAccountRow{}, err
+	}
+	if instance == nil || strings.TrimSpace(instance.GetId()) == "" {
+		return servicePlanCustomerCloudAccountRow{}, fmt.Errorf("customer account onboarding returned an empty resource instance ID")
+	}
+
+	instanceID := strings.TrimSpace(instance.GetId())
+	row := servicePlanCustomerCloudAccountRow{
+		InstanceID:     instanceID,
+		ServiceID:      request.Form.Environment.ServiceID,
+		EnvironmentID:  request.Form.Environment.ID,
+		ResourceID:     accountResource.ID,
+		CloudProvider:  strings.ToLower(strings.TrimSpace(request.CloudProvider)),
+		Status:         "DEPLOYING",
+		SubscriptionID: subscriptionID,
+		CustomerEmail:  request.Customer.Email,
+		Resource:       accountResource.Name,
+	}
+	instanceDetail, err := dataaccess.DescribeResourceInstance(ctx, token, request.Form.Environment.ServiceID, request.Form.Environment.ID, instanceID)
+	if err == nil {
+		row = servicePlanEnrichCustomerCloudAccountRow(ctx, token, row, instanceDetail)
+	}
+	return row, nil
+}
+
+func (productionServicePlanBrowserLoader) RefreshCustomerCloudAccount(ctx context.Context, token string, request servicePlanCustomerCloudAccountActionRequest) (servicePlanCustomerCloudAccountRow, error) {
+	account := request.Account
+	serviceID := firstString([]string{account.ServiceID, request.Form.Environment.ServiceID})
+	environmentID := firstString([]string{account.EnvironmentID, request.Form.Environment.ID})
+	if serviceID == "" || environmentID == "" || strings.TrimSpace(account.InstanceID) == "" {
+		return servicePlanCustomerCloudAccountRow{}, fmt.Errorf("cloud account refresh is missing required identifiers")
+	}
+	instanceDetail, err := dataaccess.DescribeResourceInstance(ctx, token, serviceID, environmentID, account.InstanceID)
+	if err != nil {
+		return servicePlanCustomerCloudAccountRow{}, err
+	}
+	account.ServiceID = serviceID
+	account.EnvironmentID = environmentID
+	return servicePlanEnrichCustomerCloudAccountRow(ctx, token, account, instanceDetail), nil
+}
+
+func (productionServicePlanBrowserLoader) DeleteCustomerCloudAccount(ctx context.Context, token string, request servicePlanCustomerCloudAccountActionRequest) error {
+	account := request.Account
+	serviceID := firstString([]string{account.ServiceID, request.Form.Environment.ServiceID})
+	environmentID := firstString([]string{account.EnvironmentID, request.Form.Environment.ID})
+	resourceID := firstString([]string{account.ResourceID, request.Form.AccountResource.ID})
+	if serviceID == "" || environmentID == "" || resourceID == "" || strings.TrimSpace(account.InstanceID) == "" {
+		return fmt.Errorf("cloud account delete is missing required identifiers")
+	}
+	return dataaccess.DeleteResourceInstance(ctx, token, serviceID, environmentID, resourceID, account.InstanceID)
+}
+
+func (productionServicePlanBrowserLoader) RetryCustomerCloudAccount(ctx context.Context, token string, request servicePlanCustomerCloudAccountActionRequest) (servicePlanCustomerCloudAccountRow, error) {
+	account := request.Account
+	serviceID := firstString([]string{account.ServiceID, request.Form.Environment.ServiceID})
+	environmentID := firstString([]string{account.EnvironmentID, request.Form.Environment.ID})
+	resourceID := firstString([]string{account.ResourceID, request.Form.AccountResource.ID})
+	if serviceID == "" || environmentID == "" || resourceID == "" || strings.TrimSpace(account.InstanceID) == "" {
+		return servicePlanCustomerCloudAccountRow{}, fmt.Errorf("cloud account retry is missing required identifiers")
+	}
+	if err := servicePlanRetryCustomerCloudAccountOnboarding(ctx, token, serviceID, environmentID, resourceID, account.InstanceID); err != nil {
+		return servicePlanCustomerCloudAccountRow{}, err
+	}
+	instanceDetail, err := waitForServicePlanCustomerAccountReady(ctx, token, serviceID, environmentID, account.InstanceID)
+	if err != nil {
+		return servicePlanCustomerCloudAccountRow{}, err
+	}
+	account.ServiceID = serviceID
+	account.EnvironmentID = environmentID
+	account.ResourceID = resourceID
+	return servicePlanEnrichCustomerCloudAccountRow(ctx, token, account, instanceDetail), nil
+}
+
+func servicePlanRetryCustomerCloudAccountOnboarding(ctx context.Context, token string, serviceID string, environmentID string, resourceID string, instanceID string) error {
+	workflows, err := dataaccess.ListWorkflows(ctx, token, serviceID, environmentID, &dataaccess.ListWorkflowsOptions{
+		InstanceID: instanceID,
+	})
+	if err == nil && workflows != nil {
+		for _, workflow := range workflows.Workflows {
+			if strings.TrimSpace(workflow.Id) == "" {
+				continue
+			}
+			if !strings.EqualFold(strings.TrimSpace(workflow.Status), "FAILED") {
+				continue
+			}
+			_, err = dataaccess.RetryWorkflow(ctx, token, serviceID, environmentID, workflow.Id)
+			return err
+		}
+	}
+
+	return dataaccess.RestartResourceInstance(ctx, token, serviceID, environmentID, resourceID, instanceID)
+}
+
+func servicePlanCustomerAccountRequestParams(ctx context.Context, token string, cloudProvider string, values map[string]string) (map[string]any, error) {
+	value := func(key string) string {
+		return strings.TrimSpace(values[key])
+	}
+	params := map[string]any{}
+
+	switch strings.ToLower(strings.TrimSpace(cloudProvider)) {
+	case "aws":
+		accountID := value(servicePlanCustomerAccountAWSAccountIDKey)
+		if accountID == "" {
+			return nil, fmt.Errorf("AWS account ID is required")
+		}
+		params[servicePlanCustomerAccountIacToolKey] = "CloudFormation"
+		params[servicePlanCustomerAccountAWSAccountIDKey] = accountID
+		params[servicePlanCustomerAccountAWSBootstrapRoleKey] = fmt.Sprintf("arn:aws:iam::%s:role/omnistrate-bootstrap-role", accountID)
+	case "gcp":
+		projectID := value(servicePlanCustomerAccountGCPProjectIDKey)
+		projectNumber := value(servicePlanCustomerAccountGCPProjectNumberKey)
+		if projectID == "" || projectNumber == "" {
+			return nil, fmt.Errorf("GCP project ID and project number are required")
+		}
+		user, err := dataaccess.DescribeUser(ctx, token)
+		if err != nil {
+			return nil, err
+		}
+		if user.OrgId == nil || strings.TrimSpace(*user.OrgId) == "" {
+			return nil, fmt.Errorf("describe user returned an empty org ID; cannot derive the GCP bootstrap service account email")
+		}
+		params[servicePlanCustomerAccountIacToolKey] = "Terraform"
+		params[servicePlanCustomerAccountGCPProjectIDKey] = projectID
+		params[servicePlanCustomerAccountGCPProjectNumberKey] = projectNumber
+		params[servicePlanCustomerAccountGCPServiceAccountKey] = fmt.Sprintf("bootstrap-%s@%s.iam.gserviceaccount.com", *user.OrgId, projectID)
+	case "azure":
+		subscriptionID := value(servicePlanCustomerAccountAzureSubscriptionIDKey)
+		tenantID := value(servicePlanCustomerAccountAzureTenantIDKey)
+		if subscriptionID == "" || tenantID == "" {
+			return nil, fmt.Errorf("azure subscription ID and tenant ID are required")
+		}
+		params[servicePlanCustomerAccountIacToolKey] = "AzureScript"
+		params[servicePlanCustomerAccountAzureSubscriptionIDKey] = subscriptionID
+		params[servicePlanCustomerAccountAzureTenantIDKey] = tenantID
+	case "nebius":
+		tenantID := value(servicePlanCustomerAccountNebiusTenantIDKey)
+		bindingsFile := value(servicePlanCustomerAccountNebiusBindingsFileKey)
+		if tenantID == "" || bindingsFile == "" {
+			return nil, fmt.Errorf("nebius tenant ID and bindings file are required")
+		}
+		bindings, err := servicePlanParseNebiusBindingsFile(bindingsFile)
+		if err != nil {
+			return nil, err
+		}
+		params[servicePlanCustomerAccountNebiusTenantIDKey] = tenantID
+		params[servicePlanCustomerAccountNebiusBindingsKey] = bindings
+	default:
+		return nil, fmt.Errorf("inline cloud account connection is not supported for %s", emptyValue(cloudProvider))
+	}
+
+	return params, nil
+}
+
+func waitForServicePlanCustomerAccountReady(ctx context.Context, token string, serviceID string, environmentID string, instanceID string) (*openapiclientfleet.ResourceInstance, error) {
+	timeout := time.After(servicePlanCustomerAccountReadyTimeout)
+	ticker := time.NewTicker(servicePlanCustomerAccountReadyPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-timeout:
+			return nil, fmt.Errorf("customer account onboarding %s did not become READY after %s", instanceID, servicePlanCustomerAccountReadyTimeout)
+		case <-ticker.C:
+			instance, err := dataaccess.DescribeResourceInstance(ctx, token, serviceID, environmentID, instanceID)
+			if err != nil {
+				return nil, err
+			}
+			status := strings.ToUpper(strings.TrimSpace(utils.FromPtr(instance.ConsumptionResourceInstanceResult.Status)))
+			switch status {
+			case "READY":
+				return instance, nil
+			case "FAILED":
+				return nil, fmt.Errorf("customer account onboarding %s entered FAILED state", instanceID)
+			}
+		}
+	}
+}
+
+type servicePlanNebiusBindingsFile struct {
+	Bindings       []servicePlanNebiusBindingFileEntry `yaml:"bindings"`
+	NebiusBindings []servicePlanNebiusBindingFileEntry `yaml:"nebiusBindings"`
+}
+
+type servicePlanNebiusBindingFileEntry struct {
+	ProjectID          string `yaml:"projectID"`
+	ProjectId          string `yaml:"projectId"`
+	PublicKeyID        string `yaml:"publicKeyID"`
+	PublicKeyId        string `yaml:"publicKeyId"`
+	ServiceAccountID   string `yaml:"serviceAccountID"`
+	ServiceAccountId   string `yaml:"serviceAccountId"`
+	PrivateKeyPEM      string `yaml:"privateKeyPEM"`
+	PrivateKeyPem      string `yaml:"privateKeyPem"`
+	PrivateKeyPEMFile  string `yaml:"privateKeyPEMFile"`
+	PrivateKeyPemFile  string `yaml:"privateKeyPemFile"`
+	PrivateKeyFile     string `yaml:"privateKeyFile"`
+	PrivateKeyFilePath string `yaml:"privateKeyFilePath"`
+}
+
+func servicePlanParseNebiusBindingsFile(path string) ([]map[string]any, error) {
+	resolvedPath, err := servicePlanExpandPath(path, "")
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve Nebius bindings file path %q: %w", path, err)
+	}
+
+	data, err := os.ReadFile(resolvedPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read Nebius bindings file %q: %w", resolvedPath, err)
+	}
+
+	var wrapped servicePlanNebiusBindingsFile
+	if err := yaml.Unmarshal(data, &wrapped); err != nil {
+		return nil, fmt.Errorf("failed to parse Nebius bindings file %q: %w", resolvedPath, err)
+	}
+
+	entries := wrapped.Bindings
+	if len(entries) == 0 {
+		entries = wrapped.NebiusBindings
+	}
+	if len(entries) == 0 {
+		var directEntries []servicePlanNebiusBindingFileEntry
+		if err := yaml.Unmarshal(data, &directEntries); err == nil && len(directEntries) > 0 {
+			entries = directEntries
+		}
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("nebius bindings file %q must contain at least one binding", resolvedPath)
+	}
+
+	baseDir := filepath.Dir(resolvedPath)
+	bindings := make([]map[string]any, 0, len(entries))
+	seenProjectIDs := make(map[string]struct{}, len(entries))
+	for index, entry := range entries {
+		binding, err := entry.toRequestParam(baseDir)
+		if err != nil {
+			return nil, fmt.Errorf("invalid Nebius binding at index %d: %w", index, err)
+		}
+		projectID := strings.ToLower(strings.TrimSpace(fmt.Sprint(binding["projectID"])))
+		if _, exists := seenProjectIDs[projectID]; exists {
+			return nil, fmt.Errorf("duplicate Nebius binding for project %q", projectID)
+		}
+		seenProjectIDs[projectID] = struct{}{}
+		bindings = append(bindings, binding)
+	}
+	return bindings, nil
+}
+
+func (entry servicePlanNebiusBindingFileEntry) toRequestParam(baseDir string) (map[string]any, error) {
+	projectID := servicePlanFirstNonEmpty(entry.ProjectID, entry.ProjectId)
+	publicKeyID := servicePlanFirstNonEmpty(entry.PublicKeyID, entry.PublicKeyId)
+	serviceAccountID := servicePlanFirstNonEmpty(entry.ServiceAccountID, entry.ServiceAccountId)
+	privateKeyPEM := strings.TrimSpace(servicePlanFirstNonEmpty(entry.PrivateKeyPEM, entry.PrivateKeyPem))
+	privateKeyPEMFile := servicePlanFirstNonEmpty(
+		entry.PrivateKeyPEMFile,
+		entry.PrivateKeyPemFile,
+		entry.PrivateKeyFile,
+		entry.PrivateKeyFilePath,
+	)
+
+	if privateKeyPEM != "" && privateKeyPEMFile != "" {
+		return nil, fmt.Errorf("specify only one of privateKeyPEM or privateKeyPEMFile")
+	}
+	if privateKeyPEM == "" {
+		if privateKeyPEMFile == "" {
+			return nil, fmt.Errorf("privateKeyPEMFile is required")
+		}
+		resolvedKeyPath, err := servicePlanExpandPath(privateKeyPEMFile, baseDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve private key path %q: %w", privateKeyPEMFile, err)
+		}
+		keyData, err := os.ReadFile(resolvedKeyPath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read private key file %q: %w", resolvedKeyPath, err)
+		}
+		privateKeyPEM = strings.TrimSpace(string(keyData))
+		if privateKeyPEM == "" {
+			return nil, fmt.Errorf("private key file %q is empty", resolvedKeyPath)
+		}
+	}
+
+	switch {
+	case strings.TrimSpace(projectID) == "":
+		return nil, fmt.Errorf("projectID is required")
+	case strings.TrimSpace(publicKeyID) == "":
+		return nil, fmt.Errorf("publicKeyID is required")
+	case strings.TrimSpace(serviceAccountID) == "":
+		return nil, fmt.Errorf("serviceAccountID is required")
+	}
+
+	return map[string]any{
+		"projectID":        strings.TrimSpace(projectID),
+		"serviceAccountID": strings.TrimSpace(serviceAccountID),
+		"publicKeyID":      strings.TrimSpace(publicKeyID),
+		"privateKeyPEM":    privateKeyPEM,
+	}, nil
+}
+
+func servicePlanExpandPath(path string, baseDir string) (string, error) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", fmt.Errorf("path cannot be empty")
+	}
+
+	if strings.HasPrefix(trimmed, "~/") || trimmed == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		if trimmed == "~" {
+			trimmed = home
+		} else {
+			trimmed = filepath.Join(home, strings.TrimPrefix(trimmed, "~/"))
+		}
+	}
+
+	if !filepath.IsAbs(trimmed) {
+		if baseDir == "" {
+			baseDir = "."
+		}
+		trimmed = filepath.Join(baseDir, trimmed)
+	}
+
+	return filepath.Clean(trimmed), nil
+}
+
+func servicePlanFirstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
 func selectServicePlanOffering(result *openapiclientfleet.InventoryDescribeServiceOfferingResult, env servicePlanBrowserEnvironment) (*openapiclientfleet.ServiceOffering, error) {
 	if result == nil || result.ConsumptionDescribeServiceOfferingResult == nil {
 		return nil, fmt.Errorf("service offering response is empty for %s / %s", env.ServiceName, env.PlanName)
@@ -2998,16 +4728,52 @@ func selectServicePlanOffering(result *openapiclientfleet.InventoryDescribeServi
 func servicePlanDeploymentResources(resources []openapiclientfleet.ResourceEntity) []servicePlanDeploymentResource {
 	result := make([]servicePlanDeploymentResource, 0, len(resources))
 	for _, resource := range resources {
-		if resource.IsDeprecated {
+		resourceID := strings.TrimSpace(resource.ResourceId)
+		resourceName := strings.TrimSpace(resource.Name)
+		resourceURLKey := strings.TrimSpace(resource.UrlKey)
+		if resource.IsDeprecated || resourceID == "" || resourceURLKey == "" || servicePlanIsInjectedCustomerAccountResource(resourceID, resourceURLKey) {
 			continue
 		}
+		if resourceName == "" {
+			resourceName = resourceID
+		}
 		result = append(result, servicePlanDeploymentResource{
-			ID:     strings.TrimSpace(resource.ResourceId),
-			Name:   strings.TrimSpace(resource.Name),
-			URLKey: strings.TrimSpace(resource.UrlKey),
+			ID:     resourceID,
+			Name:   resourceName,
+			URLKey: resourceURLKey,
 		})
 	}
 	return result
+}
+
+func servicePlanCustomerAccountResource(resources []openapiclientfleet.ResourceEntity) servicePlanDeploymentResource {
+	for _, resource := range resources {
+		resourceID := strings.TrimSpace(resource.ResourceId)
+		resourceURLKey := strings.TrimSpace(resource.UrlKey)
+		if resource.IsDeprecated || resourceID == "" || resourceURLKey == "" || !servicePlanIsInjectedCustomerAccountResource(resourceID, resourceURLKey) {
+			continue
+		}
+		name := strings.TrimSpace(resource.Name)
+		if name == "" {
+			name = "Cloud Provider Account"
+		}
+		return servicePlanDeploymentResource{ID: resourceID, Name: name, URLKey: resourceURLKey}
+	}
+	return servicePlanDeploymentResource{}
+}
+
+func servicePlanIsInjectedCustomerAccountResource(resourceID, resourceURLKey string) bool {
+	return strings.HasPrefix(strings.TrimSpace(resourceID), servicePlanCustomerAccountResourcePrefix) ||
+		strings.EqualFold(strings.TrimSpace(resourceURLKey), servicePlanCustomerAccountResourceKey)
+}
+
+func servicePlanInputParametersNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "input parameter") &&
+		(strings.Contains(message, "not_found") || strings.Contains(message, "record not found"))
 }
 
 func servicePlanDeploymentParameters(parameters []openapiclient.DescribeInputParameterResult) []servicePlanDeploymentParameter {
@@ -3087,6 +4853,198 @@ func servicePlanOfferingCloudsAndRegions(offering *openapiclientfleet.ServiceOff
 	return sortedKeys(cloudSet), regionsByCloud
 }
 
+func servicePlanEnrichCustomerCloudAccountRow(ctx context.Context, token string, row servicePlanCustomerCloudAccountRow, instance *openapiclientfleet.ResourceInstance) servicePlanCustomerCloudAccountRow {
+	row = servicePlanCustomerCloudAccountRowWithInstanceDetails(row, instance)
+	if row.AccountConfigID == "" {
+		return row
+	}
+	account, err := dataaccess.DescribeAccount(ctx, token, row.AccountConfigID)
+	if err != nil {
+		return row
+	}
+	return servicePlanCustomerCloudAccountRowWithAccountConfig(row, account)
+}
+
+func servicePlanCustomerCloudAccountRowWithInstanceDetails(row servicePlanCustomerCloudAccountRow, instance *openapiclientfleet.ResourceInstance) servicePlanCustomerCloudAccountRow {
+	if instance == nil {
+		return row
+	}
+
+	result := instance.ConsumptionResourceInstanceResult
+	row.InstanceID = firstString([]string{row.InstanceID, utils.FromPtr(result.Id)})
+	row.ServiceID = firstString([]string{row.ServiceID, instance.ServiceId})
+	row.EnvironmentID = firstString([]string{row.EnvironmentID, instance.EnvironmentId})
+	row.ResourceID = firstString([]string{row.ResourceID, utils.FromPtr(result.ResourceID)})
+	row.AccountConfigID = firstString([]string{row.AccountConfigID, servicePlanCustomerAccountConfigIDFromInstance(instance)})
+	row.CloudProvider = firstString([]string{row.CloudProvider, utils.FromPtr(result.CloudProvider), instance.CloudProvider})
+	row.Status = firstString([]string{utils.FromPtr(result.Status), row.Status})
+	row.SubscriptionID = firstString([]string{utils.FromPtr(result.SubscriptionId), instance.SubscriptionId, row.SubscriptionID})
+	row.Region = firstString([]string{utils.FromPtr(result.Region), row.Region})
+	row.AWSAccountID = firstString([]string{row.AWSAccountID, utils.FromPtr(result.AwsAccountID), utils.FromPtr(instance.AwsAccountID)})
+	row.GCPProjectID = firstString([]string{row.GCPProjectID, utils.FromPtr(result.GcpProjectID), utils.FromPtr(instance.GcpProjectID)})
+	row.AzureSubscriptionID = firstString([]string{row.AzureSubscriptionID, utils.FromPtr(result.AzureSubscriptionID), utils.FromPtr(instance.AzureSubscriptionID)})
+
+	for _, params := range servicePlanCustomerCloudAccountParamMaps(instance) {
+		row.AccountConfigID = firstString([]string{row.AccountConfigID, servicePlanStringParam(params, servicePlanCustomerAccountConfigIDParamKey)})
+		row.AWSAccountID = firstString([]string{row.AWSAccountID, servicePlanStringParam(params, servicePlanCustomerAccountAWSAccountIDKey, "awsAccountID")})
+		row.GCPProjectID = firstString([]string{row.GCPProjectID, servicePlanStringParam(params, servicePlanCustomerAccountGCPProjectIDKey, "gcpProjectID")})
+		row.GCPProjectNumber = firstString([]string{row.GCPProjectNumber, servicePlanStringParam(params, servicePlanCustomerAccountGCPProjectNumberKey, "gcpProjectNumber")})
+		row.GCPServiceAccountEmail = firstString([]string{row.GCPServiceAccountEmail, servicePlanStringParam(params, servicePlanCustomerAccountGCPServiceAccountKey, "gcpServiceAccountEmail")})
+		row.AzureSubscriptionID = firstString([]string{row.AzureSubscriptionID, servicePlanStringParam(params, servicePlanCustomerAccountAzureSubscriptionIDKey, "azureSubscriptionID")})
+		row.AzureTenantID = firstString([]string{row.AzureTenantID, servicePlanStringParam(params, servicePlanCustomerAccountAzureTenantIDKey, "azureTenantID")})
+		row.NebiusTenantID = firstString([]string{row.NebiusTenantID, servicePlanStringParam(params, servicePlanCustomerAccountNebiusTenantIDKey, "nebiusTenantID")})
+		if row.NebiusBindingsCount == 0 {
+			row.NebiusBindingsCount = servicePlanSliceParamLen(params, servicePlanCustomerAccountNebiusBindingsKey, "nebiusBindings")
+		}
+	}
+	row.CloudProvider = servicePlanNormalizeCustomerCloudProvider(row.CloudProvider, row)
+	row.StatusMessage = servicePlanCustomerCloudAccountStatusMessage(row)
+	return row
+}
+
+func servicePlanCustomerCloudAccountRowWithAccountConfig(row servicePlanCustomerCloudAccountRow, account *openapiclient.DescribeAccountConfigResult) servicePlanCustomerCloudAccountRow {
+	if account == nil {
+		return row
+	}
+	row.AccountConfigID = firstString([]string{row.AccountConfigID, strings.TrimSpace(account.Id)})
+	row.Status = firstString([]string{row.Status, strings.TrimSpace(account.Status)})
+	row.StatusMessage = firstString([]string{row.StatusMessage, strings.TrimSpace(account.StatusMessage)})
+	row.AWSAccountID = firstString([]string{row.AWSAccountID, utils.FromPtr(account.AwsAccountID)})
+	row.AWSBootstrapRoleARN = firstString([]string{row.AWSBootstrapRoleARN, utils.FromPtr(account.AwsBootstrapRoleARN)})
+	row.AWSCloudFormationURL = firstString([]string{row.AWSCloudFormationURL, utils.FromPtr(account.AwsCloudFormationTemplateURL)})
+	row.AWSCloudFormationNoLBURL = firstString([]string{row.AWSCloudFormationNoLBURL, utils.FromPtr(account.AwsCloudFormationNoLBTemplateURL)})
+	row.GCPProjectID = firstString([]string{row.GCPProjectID, utils.FromPtr(account.GcpProjectID)})
+	row.GCPProjectNumber = firstString([]string{row.GCPProjectNumber, utils.FromPtr(account.GcpProjectNumber)})
+	row.GCPServiceAccountEmail = firstString([]string{row.GCPServiceAccountEmail, utils.FromPtr(account.GcpServiceAccountEmail)})
+	row.GCPBootstrapShellCommand = firstString([]string{row.GCPBootstrapShellCommand, utils.FromPtr(account.GcpBootstrapShellCommand)})
+	row.AzureSubscriptionID = firstString([]string{row.AzureSubscriptionID, utils.FromPtr(account.AzureSubscriptionID)})
+	row.AzureTenantID = firstString([]string{row.AzureTenantID, utils.FromPtr(account.AzureTenantID)})
+	row.AzureBootstrapShellCommand = firstString([]string{row.AzureBootstrapShellCommand, utils.FromPtr(account.AzureBootstrapShellCommand)})
+	row.NebiusTenantID = firstString([]string{row.NebiusTenantID, utils.FromPtr(account.NebiusTenantID)})
+	row.OCIBootstrapShellCommand = firstString([]string{row.OCIBootstrapShellCommand, utils.FromPtr(account.OciBootstrapShellCommand)})
+	if row.NebiusBindingsCount == 0 {
+		row.NebiusBindingsCount = len(account.NebiusBindings)
+	}
+	row.CloudProvider = servicePlanNormalizeCustomerCloudProvider(row.CloudProvider, row)
+	row.StatusMessage = servicePlanCustomerCloudAccountStatusMessage(row)
+	return row
+}
+
+func servicePlanCustomerAccountConfigIDFromInstance(instance *openapiclientfleet.ResourceInstance) string {
+	if instance == nil {
+		return ""
+	}
+	params := servicePlanAnyMap(instance.ConsumptionResourceInstanceResult.ResultParams)
+	return servicePlanStringParam(params, servicePlanCustomerAccountConfigIDParamKey)
+}
+
+func servicePlanCustomerCloudAccountParamMaps(instance *openapiclientfleet.ResourceInstance) []map[string]any {
+	if instance == nil {
+		return nil
+	}
+	result := instance.ConsumptionResourceInstanceResult
+	rawValues := []any{
+		result.ResultParams,
+		result.LaunchInputParams,
+		instance.InputParams,
+		instance.LaunchInputParams,
+	}
+	maps := make([]map[string]any, 0, len(rawValues))
+	for _, raw := range rawValues {
+		if params := servicePlanAnyMap(raw); len(params) > 0 {
+			maps = append(maps, params)
+		}
+	}
+	return maps
+}
+
+func servicePlanAnyMap(value any) map[string]any {
+	switch typed := value.(type) {
+	case nil:
+		return nil
+	case map[string]any:
+		return typed
+	case map[string]string:
+		result := make(map[string]any, len(typed))
+		for key, val := range typed {
+			result[key] = val
+		}
+		return result
+	default:
+		data, err := json.Marshal(typed)
+		if err != nil {
+			return nil
+		}
+		var result map[string]any
+		if err := json.Unmarshal(data, &result); err != nil {
+			return nil
+		}
+		return result
+	}
+}
+
+func servicePlanStringParam(params map[string]any, keys ...string) string {
+	for _, key := range keys {
+		value, ok := params[key]
+		if !ok {
+			continue
+		}
+		switch typed := value.(type) {
+		case string:
+			if strings.TrimSpace(typed) != "" {
+				return strings.TrimSpace(typed)
+			}
+		case fmt.Stringer:
+			if strings.TrimSpace(typed.String()) != "" {
+				return strings.TrimSpace(typed.String())
+			}
+		default:
+			text := strings.TrimSpace(fmt.Sprint(typed))
+			if text != "" && text != "<nil>" {
+				return text
+			}
+		}
+	}
+	return ""
+}
+
+func servicePlanSliceParamLen(params map[string]any, keys ...string) int {
+	for _, key := range keys {
+		value, ok := params[key]
+		if !ok {
+			continue
+		}
+		switch typed := value.(type) {
+		case []any:
+			return len(typed)
+		case []map[string]any:
+			return len(typed)
+		case []string:
+			return len(typed)
+		}
+	}
+	return 0
+}
+
+func servicePlanNormalizeCustomerCloudProvider(provider string, row servicePlanCustomerCloudAccountRow) string {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider != "" {
+		return provider
+	}
+	switch {
+	case row.AWSAccountID != "":
+		return "aws"
+	case row.GCPProjectID != "":
+		return "gcp"
+	case row.AzureSubscriptionID != "":
+		return "azure"
+	case row.NebiusTenantID != "":
+		return "nebius"
+	default:
+		return ""
+	}
+}
+
 func listServicePlanCustomerCloudAccounts(
 	ctx context.Context,
 	token string,
@@ -3116,15 +5074,25 @@ func listServicePlanCustomerCloudAccounts(
 		}
 
 		subscriptionID := strings.TrimSpace(utils.FromPtr(record.SubscriptionId))
-		rows = append(rows, servicePlanCustomerCloudAccountRow{
+		customerEmail := servicePlanCustomerCloudAccountEmailForSubscription(ctx, token, env, subscriptionID, emailsBySubscription)
+		row := servicePlanCustomerCloudAccountRow{
 			InstanceID:     strings.TrimSpace(record.Id),
+			ServiceID:      strings.TrimSpace(record.ServiceId),
+			EnvironmentID:  strings.TrimSpace(record.ServiceEnvironmentId),
+			ResourceID:     resourceID,
 			CloudProvider:  strings.TrimSpace(record.CloudProvider),
 			Status:         strings.TrimSpace(record.Status),
+			StatusMessage:  strings.TrimSpace(record.StatusDescription),
 			SubscriptionID: subscriptionID,
-			CustomerEmail:  emailsBySubscription[subscriptionID],
+			CustomerEmail:  customerEmail,
 			Resource:       strings.TrimSpace(record.ResourceName),
 			Region:         strings.TrimSpace(record.RegionCode),
-		})
+		}
+		if instance, describeErr := dataaccess.DescribeResourceInstance(ctx, token, row.ServiceID, row.EnvironmentID, row.InstanceID); describeErr == nil {
+			row = servicePlanEnrichCustomerCloudAccountRow(ctx, token, row, instance)
+		}
+		row.StatusMessage = servicePlanCustomerCloudAccountStatusMessage(row)
+		rows = append(rows, row)
 	}
 
 	sort.Slice(rows, func(i, j int) bool {
@@ -3178,6 +5146,38 @@ func servicePlanEmailsBySubscription(subscriptions []openapiclientfleet.FleetDes
 		}
 	}
 	return emails
+}
+
+func servicePlanCustomerCloudAccountEmailForSubscription(ctx context.Context, token string, env servicePlanBrowserEnvironment, subscriptionID string, emailsBySubscription map[string]string) string {
+	subscriptionID = strings.TrimSpace(subscriptionID)
+	if subscriptionID == "" {
+		return ""
+	}
+	if email := strings.TrimSpace(emailsBySubscription[subscriptionID]); email != "" {
+		return email
+	}
+	subscription, err := dataaccess.DescribeSubscription(ctx, token, env.ServiceID, env.ID, subscriptionID)
+	if err != nil || subscription == nil {
+		return ""
+	}
+	email := strings.TrimSpace(subscription.RootUserEmail)
+	if email != "" {
+		emailsBySubscription[subscriptionID] = email
+	}
+	return email
+}
+
+func servicePlanEmailForSubscriptionRows(subscriptions []servicePlanSubscriptionRow, subscriptionID string) string {
+	subscriptionID = strings.TrimSpace(subscriptionID)
+	if subscriptionID == "" {
+		return ""
+	}
+	for _, subscription := range subscriptions {
+		if strings.EqualFold(strings.TrimSpace(subscription.ID), subscriptionID) {
+			return strings.TrimSpace(subscription.RootUserEmail)
+		}
+	}
+	return ""
 }
 
 func servicePlanEnvironmentRequiresCustomerAccount(env servicePlanBrowserEnvironment) bool {

--- a/cmd/serviceplan/browser.go
+++ b/cmd/serviceplan/browser.go
@@ -28,6 +28,7 @@ const (
 	servicePlanBrowserListPreferredWidth = 42
 	servicePlanBrowserHelpHeight         = 2
 	servicePlanBrowserHeaderHeight       = 5
+	servicePlanBrowserTabsHeight         = 3
 
 	servicePlanBrowserFocusLeft servicePlanBrowserFocus = iota
 	servicePlanBrowserFocusDetails
@@ -125,6 +126,7 @@ type servicePlanBrowserModel struct {
 	expanded               map[int]bool
 	detailCache            map[string]servicePlanEnvironmentDetails
 	loadingDetails         map[string]bool
+	environmentTabs        []string
 	items                  []servicePlanBrowserLeftItem
 	list                   list.Model
 	viewport               viewport.Model
@@ -329,25 +331,23 @@ func newServicePlanBrowserModel(ctx context.Context, token string, catalog servi
 	detailSpinner.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("117"))
 
 	model := servicePlanBrowserModel{
-		catalog:        catalog,
-		expanded:       map[int]bool{},
-		detailCache:    map[string]servicePlanEnvironmentDetails{},
-		loadingDetails: map[string]bool{},
-		list:           planList,
-		viewport:       viewport.New(0, 0),
-		spinner:        detailSpinner,
-		focus:          servicePlanBrowserFocusLeft,
+		catalog:         catalog,
+		expanded:        map[int]bool{},
+		detailCache:     map[string]servicePlanEnvironmentDetails{},
+		loadingDetails:  map[string]bool{},
+		environmentTabs: servicePlanBrowserEnvironmentTabs(catalog),
+		list:            planList,
+		viewport:        viewport.New(0, 0),
+		spinner:         detailSpinner,
+		focus:           servicePlanBrowserFocusLeft,
 	}
 	if loader != nil {
 		model.loadEnvironmentDetails = func(env servicePlanBrowserEnvironment) (servicePlanEnvironmentDetails, error) {
 			return loader.LoadEnvironmentDetails(ctx, token, env)
 		}
 	}
-	if len(catalog.Services) > 0 {
-		model.expanded[0] = true
-	}
-
 	model.setSize(defaultServicePlanBrowserWidth, defaultServicePlanBrowserHeight)
+	model.ensureActiveEnvironmentExpanded()
 	model.rebuildVisibleItems(model.firstPlanKey())
 	if model.requestSelectedDetailsLoad() != nil {
 		model.syncViewportContent()
@@ -385,6 +385,10 @@ func (m servicePlanBrowserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "ctrl+c", "q":
 			return m, tea.Quit
+		case "tab":
+			return m, m.moveEnvironmentTab(1)
+		case "shift+tab":
+			return m, m.moveEnvironmentTab(-1)
 		}
 
 		if m.focus == servicePlanBrowserFocusDetails {
@@ -426,10 +430,6 @@ func (m servicePlanBrowserModel) updateDetails(msg tea.KeyMsg) (tea.Model, tea.C
 	case "esc", "left":
 		m.focus = servicePlanBrowserFocusLeft
 		m.syncViewportContent()
-	case "tab":
-		return m, m.moveTab(1)
-	case "shift+tab":
-		return m, m.moveTab(-1)
 	case "enter":
 		m.openSelectedModal()
 	case "down":
@@ -489,6 +489,7 @@ func (m servicePlanBrowserModel) View() string {
 	}
 
 	header := renderServicePlanBrowserHeader(m.catalog)
+	tabs := m.renderEnvironmentTabs(m.width)
 
 	listPanelStyle := servicePlanBrowserPanelStyle(m.focusBorderColor(servicePlanBrowserFocusLeft))
 	detailPanelStyle := servicePlanBrowserPanelStyle(m.focusBorderColor(servicePlanBrowserFocusDetails))
@@ -498,7 +499,7 @@ func (m servicePlanBrowserModel) View() string {
 
 	help := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render(m.helpLine())
 	status := lipgloss.NewStyle().Foreground(lipgloss.Color("111")).Render(m.statusLine())
-	return lipgloss.JoinVertical(lipgloss.Left, header, body, help, status)
+	return lipgloss.JoinVertical(lipgloss.Left, header, tabs, body, help, status)
 }
 
 func renderServicePlanBrowserSnapshot(model servicePlanBrowserModel) string {
@@ -517,7 +518,7 @@ func (m *servicePlanBrowserModel) setSize(width, height int) {
 	m.height = height
 
 	listPanelWidth := spMin(spMax(width/3, servicePlanBrowserListMinWidth), servicePlanBrowserListPreferredWidth)
-	bodyHeight := spMax(height-servicePlanBrowserHeaderHeight-servicePlanBrowserHelpHeight, 12)
+	bodyHeight := spMax(height-servicePlanBrowserHeaderHeight-servicePlanBrowserTabsHeight-servicePlanBrowserHelpHeight, 12)
 	detailPanelWidth := spMax(width-listPanelWidth-1, 40)
 	panelFrameWidth := servicePlanBrowserPanelStyle(lipgloss.Color("240")).GetHorizontalFrameSize()
 
@@ -549,28 +550,32 @@ func (m servicePlanBrowserModel) statusLine() string {
 		return m.statusMessage
 	}
 	if m.focus == servicePlanBrowserFocusDetails {
-		return "Use tab or shift+tab to cycle environments. Use esc or left to return to the plan list."
+		return "Use tab or shift+tab to switch environments. Use esc or left to return to the plan list."
 	}
-	return "Use enter on a plan to focus details. Plan details update as the selector moves."
+	return "Use tab or shift+tab to switch environments. Plan details update as the selector moves."
 }
 
 func (m servicePlanBrowserModel) helpLine() string {
 	if m.focus == servicePlanBrowserFocusDetails {
-		return "↑/↓: detail rows  enter: open row  tab/shift+tab: environment  esc/←: focus plans  q: quit"
+		return "tab/shift+tab: environment  ↑/↓: detail rows  enter: open row  esc/←: focus plans  q: quit"
 	}
-	return "↑/↓: navigate plans  enter/→: details/open  ←/→: expand/collapse services  q: quit"
+	return "tab/shift+tab: environment  ↑/↓: navigate plans  enter/→: details/open  ←/→: expand/collapse services  q: quit"
 }
 
 func (m *servicePlanBrowserModel) rebuildVisibleItems(selectedKey string) {
 	if selectedKey == "" {
 		selectedKey = m.selectedLeftItemKey()
 	}
-	if selectedKey == "" {
-		selectedKey = m.firstPlanKey()
-	}
 
 	m.items = m.leftItems()
 	listItems := make([]list.Item, len(m.items))
+	if selectedKey == "" || !servicePlanBrowserItemsContainKey(m.items, selectedKey) {
+		selectedKey = firstServicePlanBrowserPlanKey(m.items)
+	}
+	if selectedKey == "" && len(m.items) > 0 {
+		selectedKey = m.items[0].key
+	}
+
 	selectedIndex := 0
 	for index, item := range m.items {
 		listItems[index] = item
@@ -583,17 +588,119 @@ func (m *servicePlanBrowserModel) rebuildVisibleItems(selectedKey string) {
 	if len(listItems) > 0 {
 		m.list.Select(selectedIndex)
 	}
+	m.list.Title = "Service Plans"
+	if env := m.activeEnvironmentName(); env != "" {
+		m.list.Title = "Service Plans · " + env
+	}
 	m.syncSelectionFromList()
 	m.syncViewportContent()
 }
 
 func (m servicePlanBrowserModel) firstPlanKey() string {
-	for _, item := range m.leftItems() {
+	return firstServicePlanBrowserPlanKey(m.leftItems())
+}
+
+func servicePlanBrowserItemsContainKey(items []servicePlanBrowserLeftItem, key string) bool {
+	for _, item := range items {
+		if item.key == key {
+			return true
+		}
+	}
+	return false
+}
+
+func firstServicePlanBrowserPlanKey(items []servicePlanBrowserLeftItem) string {
+	for _, item := range items {
 		if !item.isService {
 			return item.key
 		}
 	}
 	return ""
+}
+
+func servicePlanBrowserEnvironmentTabs(catalog servicePlanBrowserCatalog) []string {
+	seen := map[string]bool{}
+	tabs := make([]string, 0)
+	for _, service := range catalog.Services {
+		for _, plan := range service.Plans {
+			for _, env := range plan.Environments {
+				name := strings.TrimSpace(env.Name)
+				key := servicePlanEnvironmentKey(name)
+				if name == "" {
+					name = "-"
+				}
+				if seen[key] {
+					continue
+				}
+				seen[key] = true
+				tabs = append(tabs, name)
+			}
+		}
+	}
+	return tabs
+}
+
+func servicePlanEnvironmentKey(environment string) string {
+	environment = strings.ToLower(strings.TrimSpace(environment))
+	if environment == "" {
+		return "-"
+	}
+	return environment
+}
+
+func (m servicePlanBrowserModel) activeEnvironmentName() string {
+	if len(m.environmentTabs) == 0 {
+		return ""
+	}
+	activeTab := spClamp(m.activeTab, len(m.environmentTabs)-1)
+	return m.environmentTabs[activeTab]
+}
+
+func (m servicePlanBrowserModel) environmentMatchesActive(env servicePlanBrowserEnvironment) bool {
+	if len(m.environmentTabs) == 0 {
+		return true
+	}
+	return servicePlanEnvironmentKey(env.Name) == servicePlanEnvironmentKey(m.activeEnvironmentName())
+}
+
+func (m servicePlanBrowserModel) planForActiveEnvironment(plan servicePlanBrowserPlan) (servicePlanBrowserPlan, bool) {
+	filtered := plan
+	filtered.Environments = make([]servicePlanBrowserEnvironment, 0, len(plan.Environments))
+	for _, env := range plan.Environments {
+		if m.environmentMatchesActive(env) {
+			filtered.Environments = append(filtered.Environments, env)
+		}
+	}
+	return filtered, len(filtered.Environments) > 0
+}
+
+func (m servicePlanBrowserModel) servicePlansForActiveEnvironment(service servicePlanBrowserService) []servicePlanBrowserPlan {
+	plans := make([]servicePlanBrowserPlan, 0, len(service.Plans))
+	for _, plan := range service.Plans {
+		filtered, ok := m.planForActiveEnvironment(plan)
+		if ok {
+			plans = append(plans, filtered)
+		}
+	}
+	return plans
+}
+
+func (m *servicePlanBrowserModel) ensureActiveEnvironmentExpanded() {
+	for serviceIndex, service := range m.catalog.Services {
+		if len(m.servicePlansForActiveEnvironment(service)) == 0 {
+			continue
+		}
+		if m.expanded[serviceIndex] {
+			return
+		}
+	}
+	for serviceIndex, service := range m.catalog.Services {
+		if len(m.servicePlansForActiveEnvironment(service)) == 0 {
+			continue
+		}
+		m.expanded[serviceIndex] = true
+		return
+	}
 }
 
 func (m servicePlanBrowserModel) selectedLeftItemKey() string {
@@ -627,7 +734,6 @@ func (m *servicePlanBrowserModel) syncSelectionFromList() {
 	m.serviceIndex = item.serviceIndex
 	m.planIndex = item.planIndex
 	if changed {
-		m.activeTab = 0
 		m.detailCursor = 0
 		m.detailViewportTop = false
 	}
@@ -661,6 +767,7 @@ func (m *servicePlanBrowserModel) syncViewportContent() {
 
 func (m servicePlanBrowserModel) renderServiceContent(item servicePlanBrowserLeftItem, width int) string {
 	service := m.catalog.Services[item.serviceIndex]
+	plans := m.servicePlansForActiveEnvironment(service)
 	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230"))
 	sectionStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("117"))
 	keyStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("111"))
@@ -672,10 +779,11 @@ func (m servicePlanBrowserModel) renderServiceContent(item servicePlanBrowserLef
 		sectionStyle.Render("Overview"),
 	}
 	lines = append(lines, renderServicePlanField("Service ID", emptyValue(service.ID), width, keyStyle, valueStyle)...)
-	lines = append(lines, renderServicePlanField("Plans", fmt.Sprintf("%d", len(service.Plans)), width, keyStyle, valueStyle)...)
-	lines = append(lines, "", sectionStyle.Render("Plan names"))
-	for _, plan := range service.Plans {
-		lines = append(lines, renderServicePlanBullet(fmt.Sprintf("%s: %s", plan.Name, servicePlanEnvironmentSummary(plan)), width, keyStyle, valueStyle)...)
+	lines = append(lines, renderServicePlanField("Environment", emptyValue(m.activeEnvironmentName()), width, keyStyle, valueStyle)...)
+	lines = append(lines, renderServicePlanField("Plans", fmt.Sprintf("%d", len(plans)), width, keyStyle, valueStyle)...)
+	lines = append(lines, "", sectionStyle.Render("Plans in environment"))
+	for _, plan := range plans {
+		lines = append(lines, renderServicePlanBullet(plan.Name, width, keyStyle, valueStyle)...)
 	}
 
 	return strings.Join(lines, "\n")
@@ -696,13 +804,12 @@ func (m servicePlanBrowserModel) renderPlanContentWithCursorLine(width int) (str
 
 	lines := []string{
 		titleStyle.Render(plan.ServiceName + " / " + plan.Name),
-		m.renderEnvironmentSelector(width),
 		"",
 		sectionStyle.Render("Overview"),
 	}
 	lines = append(lines, renderServicePlanField("Plan name", plan.Name, width, keyStyle, valueStyle)...)
 	lines = append(lines, renderServicePlanField("Service ID", emptyValue(plan.ServiceID), width, keyStyle, valueStyle)...)
-	lines = append(lines, renderServicePlanField("Environments", servicePlanEnvironmentSummary(*plan), width, keyStyle, valueStyle)...)
+	lines = append(lines, renderServicePlanField("Environment", emptyValue(m.activeEnvironmentName()), width, keyStyle, valueStyle)...)
 
 	env := m.selectedEnvironment()
 	if env == nil {
@@ -877,31 +984,67 @@ func renderServicePlanBrowserCheck(label string, ok bool) string {
 	return style.Render(fmt.Sprintf("%s %s", icon, label))
 }
 
-func (m servicePlanBrowserModel) renderEnvironmentSelector(width int) string {
-	plan := m.selectedPlan()
-	if plan == nil || len(plan.Environments) == 0 {
+func (m servicePlanBrowserModel) renderEnvironmentTabs(width int) string {
+	if len(m.environmentTabs) == 0 {
 		return lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render("No environments")
 	}
 
-	labelStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("111"))
-	items := []string{labelStyle.Render("Environment:")}
-	for i, env := range plan.Environments {
-		envColor := servicePlanEnvironmentColor(env.Name)
-		name := emptyValue(env.Name)
+	highlightColor := lipgloss.Color("62")
+	inactiveTabBorder := servicePlanTabBorderWithBottom("┴", "─", "┴")
+	activeTabBorder := servicePlanTabBorderWithBottom("┘", " ", "└")
+
+	inactiveTabStyle := lipgloss.NewStyle().
+		Border(inactiveTabBorder, true).
+		BorderForeground(highlightColor).
+		Padding(0, 1)
+	activeTabStyle := lipgloss.NewStyle().
+		Border(activeTabBorder, true).
+		BorderForeground(highlightColor).
+		Padding(0, 1).
+		Bold(true)
+
+	renderedTabs := make([]string, 0, len(m.environmentTabs))
+	for i, name := range m.environmentTabs {
+		envColor := servicePlanEnvironmentColor(name)
+		style := inactiveTabStyle.Foreground(envColor).Faint(true)
 		if i == m.activeTab {
-			items = append(items, lipgloss.NewStyle().
-				Bold(true).
-				Foreground(envColor).
-				Render("▸ "+name))
-		} else {
-			items = append(items, lipgloss.NewStyle().
-				Foreground(envColor).
-				Faint(true).
-				Render(name))
+			style = activeTabStyle.Foreground(envColor)
 		}
+
+		border, _, _, _, _ := style.GetBorder()
+		if i == 0 && i == m.activeTab {
+			border.BottomLeft = "│"
+		} else if i == 0 {
+			border.BottomLeft = "├"
+		}
+		style = style.Border(border)
+		renderedTabs = append(renderedTabs, style.Render(emptyValue(name)))
 	}
 
-	return lipgloss.NewStyle().MaxWidth(width).Render(strings.Join(items, "  "))
+	row := lipgloss.JoinHorizontal(lipgloss.Top, renderedTabs...)
+	rowWidth := lipgloss.Width(row)
+	gapWidth := width - rowWidth - 2
+	if gapWidth > 0 {
+		gapBorder := lipgloss.Border{
+			Bottom:      "─",
+			BottomLeft:  "┴",
+			BottomRight: "┐",
+		}
+		gapStyle := lipgloss.NewStyle().
+			Border(gapBorder, false, false, true, false).
+			BorderForeground(highlightColor)
+		row = lipgloss.JoinHorizontal(lipgloss.Bottom, row, gapStyle.Render(strings.Repeat(" ", gapWidth)))
+	}
+
+	return lipgloss.NewStyle().MaxWidth(width).Render(row)
+}
+
+func servicePlanTabBorderWithBottom(left, middle, right string) lipgloss.Border {
+	border := lipgloss.RoundedBorder()
+	border.BottomLeft = left
+	border.Bottom = middle
+	border.BottomRight = right
+	return border
 }
 
 func servicePlanEnvironmentColor(environment string) lipgloss.Color {
@@ -1044,20 +1187,17 @@ func (m *servicePlanBrowserModel) ensureViewportLineVisible(line, totalLines int
 	}
 }
 
-func (m *servicePlanBrowserModel) moveTab(delta int) tea.Cmd {
-	selected := m.selectedLeftItem()
-	if selected == nil || selected.isService {
+func (m *servicePlanBrowserModel) moveEnvironmentTab(delta int) tea.Cmd {
+	if len(m.environmentTabs) == 0 {
 		return nil
 	}
 
-	plan := m.selectedPlan()
-	if plan == nil || len(plan.Environments) == 0 {
-		m.activeTab = 0
-		return nil
-	}
-	m.activeTab = (m.activeTab + delta + len(plan.Environments)) % len(plan.Environments)
+	selectedKey := m.selectedLeftItemKey()
+	m.activeTab = (m.activeTab + delta + len(m.environmentTabs)) % len(m.environmentTabs)
 	m.detailCursor = -1
 	m.detailViewportTop = true
+	m.ensureActiveEnvironmentExpanded()
+	m.rebuildVisibleItems(selectedKey)
 	loadCmd := m.requestSelectedDetailsLoad()
 	m.syncViewportContent()
 	return loadCmd
@@ -1157,12 +1297,32 @@ func (m *servicePlanBrowserModel) openSelectedModal() {
 func (m servicePlanBrowserModel) leftItems() []servicePlanBrowserLeftItem {
 	items := make([]servicePlanBrowserLeftItem, 0)
 	for serviceIndex, service := range m.catalog.Services {
+		planItems := make([]servicePlanBrowserLeftItem, 0, len(service.Plans))
 		serviceKey := fmt.Sprintf("service:%d", serviceIndex)
+		for planIndex, plan := range service.Plans {
+			filteredPlan, ok := m.planForActiveEnvironment(plan)
+			if !ok {
+				continue
+			}
+			planItems = append(planItems, servicePlanBrowserLeftItem{
+				key:          fmt.Sprintf("%s/plan:%d", serviceKey, planIndex),
+				parentKey:    serviceKey,
+				title:        plan.Name,
+				level:        1,
+				hostingBadge: servicePlanHostingBadgeForPlan(filteredPlan),
+				serviceIndex: serviceIndex,
+				planIndex:    planIndex,
+			})
+		}
+		if len(planItems) == 0 {
+			continue
+		}
+
 		items = append(items, servicePlanBrowserLeftItem{
 			key:          serviceKey,
 			title:        service.Name,
-			description:  fmt.Sprintf("%d plan name(s)", len(service.Plans)),
-			expandable:   len(service.Plans) > 0,
+			description:  fmt.Sprintf("%d plan name(s)", len(planItems)),
+			expandable:   true,
 			expanded:     m.expanded[serviceIndex],
 			isService:    true,
 			serviceIndex: serviceIndex,
@@ -1170,18 +1330,7 @@ func (m servicePlanBrowserModel) leftItems() []servicePlanBrowserLeftItem {
 		if !m.expanded[serviceIndex] {
 			continue
 		}
-		for planIndex, plan := range service.Plans {
-			items = append(items, servicePlanBrowserLeftItem{
-				key:          fmt.Sprintf("%s/plan:%d", serviceKey, planIndex),
-				parentKey:    serviceKey,
-				title:        plan.Name,
-				description:  servicePlanEnvironmentSummary(plan),
-				level:        1,
-				hostingBadge: servicePlanHostingBadgeForPlan(plan),
-				serviceIndex: serviceIndex,
-				planIndex:    planIndex,
-			})
-		}
+		items = append(items, planItems...)
 	}
 	return items
 }
@@ -1273,8 +1422,12 @@ func (m servicePlanBrowserModel) selectedEnvironment() *servicePlanBrowserEnviro
 	if plan == nil || len(plan.Environments) == 0 {
 		return nil
 	}
-	activeTab := spClamp(m.activeTab, len(plan.Environments)-1)
-	return &plan.Environments[activeTab]
+	for i := range plan.Environments {
+		if m.environmentMatchesActive(plan.Environments[i]) {
+			return &plan.Environments[i]
+		}
+	}
+	return nil
 }
 
 func (m servicePlanBrowserModel) selectedDetails() (servicePlanEnvironmentDetails, bool) {

--- a/cmd/serviceplan/browser_test.go
+++ b/cmd/serviceplan/browser_test.go
@@ -13,14 +13,35 @@ import (
 )
 
 type fakeServicePlanBrowserLoader struct {
-	details map[string]servicePlanEnvironmentDetails
-	calls   []string
+	details     map[string]servicePlanEnvironmentDetails
+	calls       []string
+	form        servicePlanDeploymentForm
+	formErr     error
+	formCalls   []string
+	launchID    string
+	launchErr   error
+	launchReq   *servicePlanDeploymentLaunchRequest
+	launchCalls int
 }
 
 func (f *fakeServicePlanBrowserLoader) LoadEnvironmentDetails(_ context.Context, _ string, env servicePlanBrowserEnvironment) (servicePlanEnvironmentDetails, error) {
 	key := env.cacheKey()
 	f.calls = append(f.calls, key)
 	return f.details[key], nil
+}
+
+func (f *fakeServicePlanBrowserLoader) LoadDeploymentForm(_ context.Context, _ string, env servicePlanBrowserEnvironment) (servicePlanDeploymentForm, error) {
+	f.formCalls = append(f.formCalls, env.cacheKey())
+	return f.form, f.formErr
+}
+
+func (f *fakeServicePlanBrowserLoader) LaunchDeployment(_ context.Context, _ string, request servicePlanDeploymentLaunchRequest) (string, error) {
+	f.launchCalls++
+	f.launchReq = &request
+	if f.launchID == "" {
+		f.launchID = "inst-created"
+	}
+	return f.launchID, f.launchErr
 }
 
 func loadSelectedTestDetails(t *testing.T, model servicePlanBrowserModel) servicePlanBrowserModel {
@@ -76,6 +97,18 @@ func TestServicePlanBrowserAccordionAndTabSwitching(t *testing.T) {
 
 	model.list.Select(0)
 	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRight})
+	model = updated.(servicePlanBrowserModel)
+	require.Len(t, model.leftItems(), 2)
+
+	model.list.Select(0)
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.Len(t, model.leftItems(), 1)
+
+	model.list.Select(0)
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Nil(t, cmd)
 	model = updated.(servicePlanBrowserModel)
 	require.Len(t, model.leftItems(), 2)
 
@@ -171,6 +204,34 @@ func TestServicePlanBrowserEnvironmentTabsFilterServiceAccordion(t *testing.T) {
 	require.Empty(t, model.leftItems()[1].description)
 	require.Equal(t, "Standard", model.selectedPlan().Name)
 	require.Equal(t, "prod", model.selectedEnvironment().Name)
+	require.Equal(t, "Service Plans", model.list.Title)
+}
+
+func TestServicePlanBrowserLeftPaneUsesTreeAccordion(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServicesWithTwoPlans(), nil)
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, nil)
+
+	items := model.leftItems()
+
+	require.True(t, items[0].isService)
+	require.True(t, items[0].expanded)
+	require.Empty(t, items[0].description)
+	require.Equal(t, "- ", servicePlanBrowserLeftItemTreePrefix(items[0]))
+	require.Equal(t, "  ├─ ", servicePlanBrowserLeftItemTreePrefix(items[1]))
+	require.Equal(t, "  └─ ", servicePlanBrowserLeftItemTreePrefix(items[2]))
+	require.NotContains(t, model.View(), "plan name(s)")
+	require.NotContains(t, model.View(), "Service Plans ·")
+}
+
+func TestServicePlanBrowserHeaderOmitsCatalogChecks(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, nil)
+
+	view := model.View()
+
+	require.Contains(t, view, "Service Plan Browser")
+	require.NotContains(t, view, "Service catalog loaded")
+	require.NotContains(t, view, "Plan details available")
 }
 
 func TestServicePlanBrowserServiceSummaryOmitsEnvironmentCountsFromPlanBullets(t *testing.T) {
@@ -351,6 +412,274 @@ func TestServicePlanBrowserModalFiltering(t *testing.T) {
 	require.Contains(t, filtered[0].Text, "aws")
 }
 
+func TestServicePlanBrowserBYOCDetailsShowCloudAccounts(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServicesWithHostingModels(), nil)
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, nil)
+	model.list.Select(2)
+	model.syncSelectionFromList()
+	env := model.selectedEnvironment()
+	require.NotNil(t, env)
+	model.detailCache[env.cacheKey()] = servicePlanEnvironmentDetails{
+		DeploymentModel:            "DEDICATED / BYOA",
+		CustomerCloudAccountsCount: 1,
+		CustomerCloudAccounts: []servicePlanCustomerCloudAccountRow{
+			{InstanceID: "acct-1", CloudProvider: "aws", Status: "RUNNING", Region: "us-west-2", CustomerEmail: "alice@example.com", SubscriptionID: "sub-1"},
+		},
+	}
+
+	rows := model.detailRows()
+	require.Equal(t, "Cloud accounts", rows[len(rows)-1].Label)
+	require.Equal(t, "1 connected", rows[len(rows)-1].Value)
+
+	model.focus = servicePlanBrowserFocusDetails
+	model.detailCursor = len(rows) - 1
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.NotNil(t, model.modal)
+	require.Equal(t, servicePlanBrowserModalCloudAccounts, model.modal.Kind)
+	require.Contains(t, model.modal.Rows[0].Text, "acct-1")
+	require.Contains(t, model.modal.Rows[0].Text, "alice@example.com")
+}
+
+func TestServicePlanBrowserDeploymentHotkeyLoadsFormAndLaunchesWithDefaults(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServicesWithHostingModels(), nil)
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, nil)
+	model.list.Select(2)
+	model.syncSelectionFromList()
+	env := *model.selectedEnvironment()
+	parameter := servicePlanDeploymentParameter{
+		Key:          "instance_type",
+		DisplayName:  "Instance type",
+		Type:         "string",
+		Required:     true,
+		DefaultValue: "small",
+	}
+	loader := &fakeServicePlanBrowserLoader{
+		form: servicePlanDeploymentForm{
+			Environment: env,
+			Version:     "1.0",
+			Resources: []servicePlanDeploymentResource{
+				{ID: "res-1", Name: "API", URLKey: "api"},
+			},
+			CloudProviders: []string{"aws"},
+			RegionsByCloud: map[string][]string{"aws": []string{"us-west-2"}},
+			Parameters:     []servicePlanDeploymentParameter{parameter},
+			ParametersByResource: map[string][]servicePlanDeploymentParameter{
+				"res-1": []servicePlanDeploymentParameter{parameter},
+			},
+			CustomerCloudAccounts: []servicePlanCustomerCloudAccountRow{
+				{InstanceID: "acct-1", CloudProvider: "aws", Status: "RUNNING"},
+			},
+			RequiresCustomerAccount: true,
+		},
+		launchID: "inst-1",
+	}
+	model.loadDeploymentForm = func(env servicePlanBrowserEnvironment) (servicePlanDeploymentForm, error) {
+		return loader.LoadDeploymentForm(context.Background(), "token", env)
+	}
+	model.launchDeployment = func(request servicePlanDeploymentLaunchRequest) (string, error) {
+		return loader.LaunchDeployment(context.Background(), "token", request)
+	}
+
+	updated, cmd := model.Update(tea.KeyMsg{Runes: []rune{'d'}, Type: tea.KeyRunes})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.True(t, model.loadingDeploymentForm)
+	require.Len(t, loader.formCalls, 0)
+
+	form, err := loader.LoadDeploymentForm(context.Background(), "token", env)
+	require.NoError(t, err)
+	updated, cmd = model.Update(servicePlanDeploymentFormLoadedMsg{form: form})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.NotNil(t, model.deploymentForm)
+	require.Contains(t, model.renderDeploymentForm(), "Resource")
+
+	for i := 0; i < 4; i++ {
+		updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		require.Nil(t, cmd)
+		model = updated.(servicePlanBrowserModel)
+	}
+	require.Contains(t, model.renderDeploymentForm(), "small")
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.Contains(t, model.renderDeploymentForm(), "Review")
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.True(t, model.deploymentForm.Launching)
+	updated, cmd = model.Update(cmd())
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.False(t, model.deploymentForm.Launching)
+	require.Equal(t, 1, loader.launchCalls)
+	require.Equal(t, "API", loader.launchReq.ResourceName)
+	require.Equal(t, "aws", loader.launchReq.CloudProvider)
+	require.Equal(t, "us-west-2", loader.launchReq.Region)
+	require.Equal(t, "acct-1", loader.launchReq.CustomerAccountID)
+	require.Equal(t, "small", loader.launchReq.Params["instance_type"])
+	require.Contains(t, model.renderDeploymentForm(), "Deployment launched: inst-1")
+	require.Contains(t, model.renderDeploymentForm(), "omnistrate-ctl instance describe inst-1")
+	require.Contains(t, model.renderDeploymentForm(), "omnistrate-ctl instance list-endpoints inst-1")
+	require.Contains(t, model.renderDeploymentForm(), "omnistrate-ctl instance debug inst-1")
+}
+
+func TestServicePlanDeploymentFormRefreshesParametersWhenResourceChanges(t *testing.T) {
+	form := servicePlanDeploymentForm{
+		Resources: []servicePlanDeploymentResource{
+			{ID: "res-api", Name: "API", URLKey: "api"},
+			{ID: "res-worker", Name: "Worker", URLKey: "worker"},
+		},
+		CloudProviders: []string{"aws"},
+		RegionsByCloud: map[string][]string{"aws": []string{"us-west-2"}},
+		Parameters: []servicePlanDeploymentParameter{
+			{Key: "api_size", DisplayName: "API size", Type: "string", DefaultValue: "small"},
+		},
+		ParametersByResource: map[string][]servicePlanDeploymentParameter{
+			"res-api": []servicePlanDeploymentParameter{
+				{Key: "api_size", DisplayName: "API size", Type: "string", DefaultValue: "small"},
+			},
+			"res-worker": []servicePlanDeploymentParameter{
+				{Key: "worker_size", DisplayName: "Worker size", Type: "string", DefaultValue: "medium"},
+			},
+		},
+	}
+
+	state := newServicePlanDeploymentFormState(form, 80)
+	require.Equal(t, servicePlanDeploymentStepResource, state.currentStep())
+
+	state.SelectionCursor = 1
+	require.NoError(t, state.advanceStep(80))
+	require.NoError(t, state.advanceStep(80))
+	require.NoError(t, state.advanceStep(80))
+
+	require.Equal(t, servicePlanDeploymentStepSystemParams, state.currentStep())
+	require.Equal(t, "res-worker", state.ParameterResourceID)
+	require.Contains(t, servicePlanDeploymentFormFieldLabels(state.ParamFields), "Worker size")
+	require.NotContains(t, servicePlanDeploymentFormFieldLabels(state.ParamFields), "API size")
+}
+
+func TestServicePlanDeploymentWizardKeepsParameterStepForNonDefaultResource(t *testing.T) {
+	form := servicePlanDeploymentForm{
+		Resources: []servicePlanDeploymentResource{
+			{ID: "res-api", Name: "API", URLKey: "api"},
+			{ID: "res-worker", Name: "Worker", URLKey: "worker"},
+		},
+		CloudProviders: []string{"aws"},
+		RegionsByCloud: map[string][]string{"aws": []string{"us-west-2"}},
+		ParametersByResource: map[string][]servicePlanDeploymentParameter{
+			"res-api": []servicePlanDeploymentParameter{},
+			"res-worker": []servicePlanDeploymentParameter{
+				{Key: "worker_size", DisplayName: "Worker size", Type: "string", DefaultValue: "medium"},
+			},
+		},
+	}
+
+	state := newServicePlanDeploymentFormState(form, 80)
+
+	require.Contains(t, state.Steps, servicePlanDeploymentStepSystemParams)
+	state.SelectionCursor = 1
+	require.NoError(t, state.advanceStep(80))
+	require.NoError(t, state.advanceStep(80))
+	require.NoError(t, state.advanceStep(80))
+	require.Equal(t, servicePlanDeploymentStepSystemParams, state.currentStep())
+	require.Contains(t, servicePlanDeploymentFormFieldLabels(state.ParamFields), "Worker size")
+}
+
+func TestServicePlanDeploymentParameterOptionsUseSelectableValues(t *testing.T) {
+	form := servicePlanDeploymentForm{
+		Resources: []servicePlanDeploymentResource{
+			{ID: "res-api", Name: "API", URLKey: "api"},
+		},
+		CloudProviders: []string{"aws"},
+		RegionsByCloud: map[string][]string{"aws": []string{"us-west-2"}},
+		ParametersByResource: map[string][]servicePlanDeploymentParameter{
+			"res-api": []servicePlanDeploymentParameter{
+				{Key: "size", DisplayName: "Size", Type: "string", Required: true, Options: []string{"small", "large"}},
+			},
+		},
+	}
+
+	state := newServicePlanDeploymentFormState(form, 80)
+	require.NoError(t, state.advanceStep(80))
+	require.NoError(t, state.advanceStep(80))
+	require.NoError(t, state.advanceStep(80))
+	require.Equal(t, servicePlanDeploymentStepSystemParams, state.currentStep())
+	require.True(t, state.moveCurrentParameterOption(1))
+	require.Equal(t, "small", state.ParamFields[0].Input.Value())
+	require.True(t, state.moveCurrentParameterOption(1))
+	require.Equal(t, "large", state.ParamFields[0].Input.Value())
+}
+
+func TestServicePlanDeploymentWizardPromptsForCustomerInProd(t *testing.T) {
+	form := servicePlanDeploymentForm{
+		Environment: servicePlanBrowserEnvironment{Name: "PROD"},
+		Resources: []servicePlanDeploymentResource{
+			{ID: "res-1", Name: "API", URLKey: "api"},
+		},
+		CloudProviders: []string{"aws"},
+		RegionsByCloud: map[string][]string{"aws": []string{"us-west-2"}},
+		Customers: []servicePlanDeploymentCustomer{
+			{UserID: "user-1", Email: "alice@example.com", Name: "Alice", OrgName: "Acme"},
+		},
+	}
+
+	state := newServicePlanDeploymentFormState(form, 80)
+
+	require.Equal(t, servicePlanDeploymentStepCustomer, state.currentStep())
+	options := state.currentOptions()
+	require.Len(t, options, 2)
+	require.Equal(t, "Self", options[0].Label)
+	state.SelectionCursor = 1
+	require.NoError(t, state.advanceStep(80))
+	require.Equal(t, "alice@example.com", state.SelectedCustomer.Email)
+}
+
+func TestServicePlanDeploymentCloudAccountsFilterBySelectedCustomer(t *testing.T) {
+	state := newServicePlanDeploymentFormState(servicePlanDeploymentForm{
+		Resources:               []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
+		CloudProviders:          []string{"aws"},
+		RegionsByCloud:          map[string][]string{"aws": []string{"us-west-2"}},
+		RequiresCustomerAccount: true,
+		Customers:               []servicePlanDeploymentCustomer{{UserID: "user-1", Email: "alice@example.com", Name: "Alice"}},
+		Subscriptions:           []servicePlanSubscriptionRow{{ID: "sub-1", RootUserID: "user-1", RootUserEmail: "alice@example.com"}},
+		CustomerCloudAccounts:   []servicePlanCustomerCloudAccountRow{{InstanceID: "acct-1", CloudProvider: "aws", SubscriptionID: "sub-1", CustomerEmail: "alice@example.com"}, {InstanceID: "acct-2", CloudProvider: "aws", SubscriptionID: "sub-2", CustomerEmail: "bob@example.com"}},
+	}, 80)
+
+	state.SelectedCustomer = servicePlanDeploymentCustomer{UserID: "user-1", Email: "alice@example.com", Name: "Alice"}
+
+	accounts := state.filteredCloudAccounts()
+	require.Len(t, accounts, 1)
+	require.Equal(t, "acct-1", accounts[0].InstanceID)
+}
+
+func TestServicePlanBrowserRefreshHotkeyReloadsRightPane(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
+	details := testBrowserDetails(catalog)
+	loader := &fakeServicePlanBrowserLoader{details: details}
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
+	model = loadSelectedTestDetails(t, model)
+	env := model.selectedEnvironment()
+	require.NotNil(t, env)
+	require.Contains(t, model.viewport.View(), "OMNISTRATE_HOSTED")
+
+	updatedDetail := details[env.cacheKey()]
+	updatedDetail.DeploymentModel = "UPDATED_MODEL"
+	loader.details[env.cacheKey()] = updatedDetail
+
+	updated, cmd := model.Update(tea.KeyMsg{Runes: []rune{'r'}, Type: tea.KeyRunes})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.Contains(t, model.viewport.View(), "Loading details")
+
+	model = loadSelectedTestDetails(t, model)
+	require.Contains(t, model.viewport.View(), "UPDATED_MODEL")
+}
+
 func TestDedupeServicePlanUsersUsesUserIDThenEmail(t *testing.T) {
 	users := []openapiclientfleet.User{
 		{UserId: "user-1", Email: "first@example.com"},
@@ -366,6 +695,14 @@ func TestDedupeServicePlanUsersUsesUserIDThenEmail(t *testing.T) {
 	require.Equal(t, "user-1", unique[0].UserId)
 	require.Equal(t, "shared@example.com", unique[1].Email)
 	require.Equal(t, "unique@example.com", unique[2].Email)
+}
+
+func servicePlanDeploymentFormFieldLabels(fields []servicePlanDeploymentFormField) []string {
+	labels := make([]string, 0, len(fields))
+	for _, field := range fields {
+		labels = append(labels, field.Label)
+	}
+	return labels
 }
 
 func TestProductTierSummaryHelpers(t *testing.T) {

--- a/cmd/serviceplan/browser_test.go
+++ b/cmd/serviceplan/browser_test.go
@@ -112,28 +112,31 @@ func TestServicePlanBrowserSelectionUpdatesPlanDetailsWithoutEnter(t *testing.T)
 	require.Len(t, loader.calls, 2)
 }
 
-func TestServicePlanBrowserTabOnlySwitchesEnvironmentInDetailsPane(t *testing.T) {
+func TestServicePlanBrowserTabSwitchesTopEnvironmentFromAnyPane(t *testing.T) {
 	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
 	loader := &fakeServicePlanBrowserLoader{details: testBrowserDetails(catalog)}
 	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
 	model = loadSelectedTestDetails(t, model)
 
 	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyTab})
-	require.Nil(t, cmd)
-	model = updated.(servicePlanBrowserModel)
-	require.Equal(t, 0, model.activeTab)
-
-	model.focus = servicePlanBrowserFocusDetails
-	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyTab})
 	require.NotNil(t, cmd)
 	model = updated.(servicePlanBrowserModel)
 	require.Equal(t, 1, model.activeTab)
+	require.Equal(t, "prod", model.activeEnvironmentName())
+	require.Equal(t, "prod", model.selectedEnvironment().Name)
+	model = loadSelectedTestDetails(t, model)
+
+	model.focus = servicePlanBrowserFocusDetails
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.Equal(t, 0, model.activeTab)
+	require.Equal(t, "dev", model.activeEnvironmentName())
 }
 
-func TestServicePlanBrowserTabCyclesEnvironmentsInDetailsPane(t *testing.T) {
+func TestServicePlanBrowserTabCyclesTopEnvironments(t *testing.T) {
 	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
 	model := newServicePlanBrowserModel(context.Background(), "token", catalog, nil)
-	model.focus = servicePlanBrowserFocusDetails
 
 	model.activeTab = 1
 	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyTab})
@@ -145,6 +148,41 @@ func TestServicePlanBrowserTabCyclesEnvironmentsInDetailsPane(t *testing.T) {
 	require.Nil(t, cmd)
 	model = updated.(servicePlanBrowserModel)
 	require.Equal(t, 1, model.activeTab)
+}
+
+func TestServicePlanBrowserEnvironmentTabsFilterServiceAccordion(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServicesWithTwoPlans(), nil)
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, nil)
+
+	require.Equal(t, "dev", model.activeEnvironmentName())
+	require.Len(t, model.leftItems(), 3)
+	require.Equal(t, "Standard", model.leftItems()[1].title)
+	require.Empty(t, model.leftItems()[1].description)
+	require.Equal(t, "Premium", model.leftItems()[2].title)
+	require.Empty(t, model.leftItems()[2].description)
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+
+	require.Equal(t, "prod", model.activeEnvironmentName())
+	require.Len(t, model.leftItems(), 2)
+	require.Equal(t, "Standard", model.leftItems()[1].title)
+	require.Empty(t, model.leftItems()[1].description)
+	require.Equal(t, "Standard", model.selectedPlan().Name)
+	require.Equal(t, "prod", model.selectedEnvironment().Name)
+}
+
+func TestServicePlanBrowserServiceSummaryOmitsEnvironmentCountsFromPlanBullets(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServicesWithTwoPlans(), nil)
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, nil)
+
+	content := model.renderServiceContent(model.leftItems()[0], 80)
+
+	require.Contains(t, content, "Standard")
+	require.Contains(t, content, "Premium")
+	require.NotContains(t, content, "environment(s)")
+	require.NotContains(t, content, "Standard:")
 }
 
 func TestServicePlanBrowserEscapeMovesFocusBackToPlans(t *testing.T) {
@@ -185,19 +223,18 @@ func TestServicePlanBrowserEnterFocusesDetailsPane(t *testing.T) {
 	require.Equal(t, servicePlanBrowserFocusDetails, model.focus)
 }
 
-func TestServicePlanBrowserEnvironmentSelectorIsInlineAndColored(t *testing.T) {
+func TestServicePlanBrowserEnvironmentTabsUseDebugTabStyle(t *testing.T) {
 	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
 	model := newServicePlanBrowserModel(context.Background(), "token", catalog, nil)
 
-	selector := model.renderEnvironmentSelector(80)
+	tabs := model.renderEnvironmentTabs(80)
 
-	require.NotContains(t, selector, "╭")
-	require.NotContains(t, selector, "╰")
-	require.NotContains(t, selector, "┘")
-	require.NotContains(t, selector, "┴")
-	require.Contains(t, selector, "Environment:")
-	require.Contains(t, selector, "▸ dev")
-	require.Contains(t, selector, "prod")
+	require.Contains(t, tabs, "╭")
+	require.Contains(t, tabs, "┴")
+	require.Contains(t, tabs, "dev")
+	require.Contains(t, tabs, "prod")
+	model.activeTab = 1
+	require.Contains(t, model.renderEnvironmentTabs(80), "┘")
 	require.Equal(t, "82", string(servicePlanEnvironmentColor("Dev")))
 	require.Equal(t, "160", string(servicePlanEnvironmentColor("Prod")))
 }
@@ -216,7 +253,7 @@ func TestServicePlanBrowserDetailCursorAutoScrollsViewport(t *testing.T) {
 	require.Contains(t, model.viewport.View(), "Users")
 }
 
-func TestServicePlanBrowserDetailCursorCanReturnToEnvironmentSelector(t *testing.T) {
+func TestServicePlanBrowserDetailCursorCanReturnToTopOfPlanDetails(t *testing.T) {
 	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
 	loader := &fakeServicePlanBrowserLoader{details: testBrowserDetails(catalog)}
 	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
@@ -233,7 +270,7 @@ func TestServicePlanBrowserDetailCursorCanReturnToEnvironmentSelector(t *testing
 
 	require.Equal(t, -1, model.detailCursor)
 	require.Equal(t, 0, model.viewport.YOffset)
-	require.Contains(t, model.viewport.View(), "Environment:")
+	require.Contains(t, model.viewport.View(), "Postgres / Standard")
 
 	model.moveDetailCursor(1)
 
@@ -242,7 +279,7 @@ func TestServicePlanBrowserDetailCursorCanReturnToEnvironmentSelector(t *testing
 	require.Contains(t, model.viewport.View(), "Deployment model")
 }
 
-func TestServicePlanBrowserEnvironmentSwitchReturnsViewportToSelector(t *testing.T) {
+func TestServicePlanBrowserEnvironmentSwitchReturnsViewportToTop(t *testing.T) {
 	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
 	loader := &fakeServicePlanBrowserLoader{details: testBrowserDetails(catalog)}
 	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
@@ -258,7 +295,8 @@ func TestServicePlanBrowserEnvironmentSwitchReturnsViewportToSelector(t *testing
 
 	require.Equal(t, -1, model.detailCursor)
 	require.Equal(t, 0, model.viewport.YOffset)
-	require.Contains(t, model.viewport.View(), "Environment:")
+	require.Equal(t, "prod", model.activeEnvironmentName())
+	require.Contains(t, model.viewport.View(), "Postgres / Standard")
 }
 
 func TestServicePlanBrowserPlanItemsIncludeHostingBadges(t *testing.T) {

--- a/cmd/serviceplan/browser_test.go
+++ b/cmd/serviceplan/browser_test.go
@@ -2,9 +2,12 @@ package serviceplan
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	displaymodel "github.com/omnistrate-oss/omnistrate-ctl/internal/model"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
 	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
@@ -13,15 +16,30 @@ import (
 )
 
 type fakeServicePlanBrowserLoader struct {
-	details     map[string]servicePlanEnvironmentDetails
-	calls       []string
-	form        servicePlanDeploymentForm
-	formErr     error
-	formCalls   []string
-	launchID    string
-	launchErr   error
-	launchReq   *servicePlanDeploymentLaunchRequest
-	launchCalls int
+	details        map[string]servicePlanEnvironmentDetails
+	calls          []string
+	form           servicePlanDeploymentForm
+	formErr        error
+	formCalls      []string
+	launchID       string
+	launchErr      error
+	launchReq      *servicePlanDeploymentLaunchRequest
+	launchCalls    int
+	connectAccount servicePlanCustomerCloudAccountRow
+	connectErr     error
+	connectReq     *servicePlanCustomerCloudAccountConnectRequest
+	connectCalls   int
+	refreshAccount servicePlanCustomerCloudAccountRow
+	refreshErr     error
+	refreshReq     *servicePlanCustomerCloudAccountActionRequest
+	refreshCalls   int
+	deleteErr      error
+	deleteReq      *servicePlanCustomerCloudAccountActionRequest
+	deleteCalls    int
+	retryAccount   servicePlanCustomerCloudAccountRow
+	retryErr       error
+	retryReq       *servicePlanCustomerCloudAccountActionRequest
+	retryCalls     int
 }
 
 func (f *fakeServicePlanBrowserLoader) LoadEnvironmentDetails(_ context.Context, _ string, env servicePlanBrowserEnvironment) (servicePlanEnvironmentDetails, error) {
@@ -42,6 +60,41 @@ func (f *fakeServicePlanBrowserLoader) LaunchDeployment(_ context.Context, _ str
 		f.launchID = "inst-created"
 	}
 	return f.launchID, f.launchErr
+}
+
+func (f *fakeServicePlanBrowserLoader) CreateCustomerCloudAccount(_ context.Context, _ string, request servicePlanCustomerCloudAccountConnectRequest) (servicePlanCustomerCloudAccountRow, error) {
+	f.connectCalls++
+	f.connectReq = &request
+	if f.connectAccount.InstanceID == "" {
+		f.connectAccount = servicePlanCustomerCloudAccountRow{InstanceID: "acct-created", CloudProvider: request.CloudProvider, Status: "READY"}
+	}
+	return f.connectAccount, f.connectErr
+}
+
+func (f *fakeServicePlanBrowserLoader) RefreshCustomerCloudAccount(_ context.Context, _ string, request servicePlanCustomerCloudAccountActionRequest) (servicePlanCustomerCloudAccountRow, error) {
+	f.refreshCalls++
+	f.refreshReq = &request
+	if f.refreshAccount.InstanceID == "" {
+		f.refreshAccount = request.Account
+		f.refreshAccount.Status = "READY"
+	}
+	return f.refreshAccount, f.refreshErr
+}
+
+func (f *fakeServicePlanBrowserLoader) DeleteCustomerCloudAccount(_ context.Context, _ string, request servicePlanCustomerCloudAccountActionRequest) error {
+	f.deleteCalls++
+	f.deleteReq = &request
+	return f.deleteErr
+}
+
+func (f *fakeServicePlanBrowserLoader) RetryCustomerCloudAccount(_ context.Context, _ string, request servicePlanCustomerCloudAccountActionRequest) (servicePlanCustomerCloudAccountRow, error) {
+	f.retryCalls++
+	f.retryReq = &request
+	if f.retryAccount.InstanceID == "" {
+		f.retryAccount = request.Account
+		f.retryAccount.Status = "READY"
+	}
+	return f.retryAccount, f.retryErr
 }
 
 func loadSelectedTestDetails(t *testing.T, model servicePlanBrowserModel) servicePlanBrowserModel {
@@ -234,6 +287,19 @@ func TestServicePlanBrowserHeaderOmitsCatalogChecks(t *testing.T) {
 	require.NotContains(t, view, "Plan details available")
 }
 
+func TestServicePlanBrowserTabbedBodyDoesNotWrapPaneBorders(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServicesWithTwoPlans(), nil)
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, nil)
+	model.setSize(120, 32)
+
+	view := model.renderEnvironmentTabsWithBody(model.width, model.renderBrowserBody())
+
+	require.NotContains(t, view, "╰")
+	for _, line := range strings.Split(view, "\n") {
+		require.LessOrEqual(t, lipgloss.Width(line), model.width)
+	}
+}
+
 func TestServicePlanBrowserServiceSummaryOmitsEnvironmentCountsFromPlanBullets(t *testing.T) {
 	catalog := buildServicePlanBrowserCatalog(testBrowserServicesWithTwoPlans(), nil)
 	model := newServicePlanBrowserModel(context.Background(), "token", catalog, nil)
@@ -296,8 +362,12 @@ func TestServicePlanBrowserEnvironmentTabsUseDebugTabStyle(t *testing.T) {
 	require.Contains(t, tabs, "prod")
 	model.activeTab = 1
 	require.Contains(t, model.renderEnvironmentTabs(80), "┘")
-	require.Equal(t, "82", string(servicePlanEnvironmentColor("Dev")))
-	require.Equal(t, "160", string(servicePlanEnvironmentColor("Prod")))
+	activeStyle := servicePlanEnvironmentTabStyle(true, servicePlanTabBorderWithBottom("┘", " ", "└"))
+	inactiveStyle := servicePlanEnvironmentTabStyle(false, servicePlanTabBorderWithBottom("┴", "─", "┴"))
+	require.Equal(t, lipgloss.Color("230"), activeStyle.GetForeground())
+	require.True(t, activeStyle.GetBold())
+	require.Equal(t, lipgloss.Color("245"), inactiveStyle.GetForeground())
+	require.False(t, inactiveStyle.GetFaint())
 }
 
 func TestServicePlanBrowserDetailCursorAutoScrollsViewport(t *testing.T) {
@@ -423,7 +493,7 @@ func TestServicePlanBrowserBYOCDetailsShowCloudAccounts(t *testing.T) {
 		DeploymentModel:            "DEDICATED / BYOA",
 		CustomerCloudAccountsCount: 1,
 		CustomerCloudAccounts: []servicePlanCustomerCloudAccountRow{
-			{InstanceID: "acct-1", CloudProvider: "aws", Status: "RUNNING", Region: "us-west-2", CustomerEmail: "alice@example.com", SubscriptionID: "sub-1"},
+			{InstanceID: "acct-1", CloudProvider: "aws", Status: "RUNNING", Region: "us-west-2", CustomerEmail: "alice@example.com", SubscriptionID: "sub-1", AWSAccountID: "123456789012"},
 		},
 	}
 
@@ -438,8 +508,33 @@ func TestServicePlanBrowserBYOCDetailsShowCloudAccounts(t *testing.T) {
 	model = updated.(servicePlanBrowserModel)
 	require.NotNil(t, model.modal)
 	require.Equal(t, servicePlanBrowserModalCloudAccounts, model.modal.Kind)
-	require.Contains(t, model.modal.Rows[0].Text, "acct-1")
+	require.Contains(t, model.modal.Rows[0].Text, "AWS account 123456789012")
+	require.NotContains(t, model.modal.Rows[0].Text, "acct-1")
 	require.Contains(t, model.modal.Rows[0].Text, "alice@example.com")
+}
+
+func TestServicePlanDeploymentResourcesSkipInjectedCustomerAccountResource(t *testing.T) {
+	resources := servicePlanDeploymentResources([]openapiclientfleet.ResourceEntity{
+		{ResourceId: "r-injectedaccountconfigpt123", Name: "Cloud Provider Account", UrlKey: "omnistrateCloudAccountConfig"},
+		{ResourceId: "r-api", Name: "API", UrlKey: "api"},
+		{ResourceId: "r-worker", UrlKey: "worker"},
+		{ResourceId: "r-missing-key", Name: "Missing URL key"},
+		{ResourceId: "r-old", Name: "Old", UrlKey: "old", IsDeprecated: true},
+	})
+
+	require.Len(t, resources, 2)
+	require.Equal(t, "r-api", resources[0].ID)
+	require.Equal(t, "API", resources[0].Name)
+	require.Equal(t, "api", resources[0].URLKey)
+	require.Equal(t, "r-worker", resources[1].Name)
+}
+
+func TestServicePlanInputParametersNotFoundIsEmptyParameterMetadata(t *testing.T) {
+	require.True(t, servicePlanInputParametersNotFound(errors.New("not_found\nDetail: Invalid request: failed to query input parameter: record not found")))
+	require.True(t, servicePlanInputParametersNotFound(errors.New("NOT_FOUND: input parameter record not found")))
+	require.False(t, servicePlanInputParametersNotFound(errors.New("not_found\nDetail: service offering record not found")))
+	require.False(t, servicePlanInputParametersNotFound(errors.New("internal error: failed to query input parameter")))
+	require.False(t, servicePlanInputParametersNotFound(nil))
 }
 
 func TestServicePlanBrowserDeploymentHotkeyLoadsFormAndLaunchesWithDefaults(t *testing.T) {
@@ -494,9 +589,13 @@ func TestServicePlanBrowserDeploymentHotkeyLoadsFormAndLaunchesWithDefaults(t *t
 	require.Nil(t, cmd)
 	model = updated.(servicePlanBrowserModel)
 	require.NotNil(t, model.deploymentForm)
-	require.Contains(t, model.renderDeploymentForm(), "Resource")
+	require.Equal(t, servicePlanDeploymentStepCloud, model.deploymentForm.currentStep())
+	require.NotContains(t, model.deploymentForm.Steps, servicePlanDeploymentStepResource)
+	require.Contains(t, model.renderDeploymentForm(), "Step 1/5: Cloud Provider")
+	require.NotContains(t, model.renderDeploymentForm(), "Back")
+	require.NotContains(t, model.renderDeploymentForm(), "Next")
 
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 3; i++ {
 		updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 		require.Nil(t, cmd)
 		model = updated.(servicePlanBrowserModel)
@@ -526,6 +625,19 @@ func TestServicePlanBrowserDeploymentHotkeyLoadsFormAndLaunchesWithDefaults(t *t
 	require.Contains(t, model.renderDeploymentForm(), "omnistrate-ctl instance describe inst-1")
 	require.Contains(t, model.renderDeploymentForm(), "omnistrate-ctl instance list-endpoints inst-1")
 	require.Contains(t, model.renderDeploymentForm(), "omnistrate-ctl instance debug inst-1")
+}
+
+func TestServicePlanDeploymentWizardSkipsResourceStepForSingleResource(t *testing.T) {
+	state := newServicePlanDeploymentFormState(servicePlanDeploymentForm{
+		Resources:      []servicePlanDeploymentResource{{ID: "res-api", Name: "API", URLKey: "api"}},
+		CloudProviders: []string{"aws"},
+		RegionsByCloud: map[string][]string{"aws": []string{"us-west-2"}},
+	}, 80)
+
+	require.Equal(t, "API", state.ResourceName)
+	require.NotContains(t, state.Steps, servicePlanDeploymentStepResource)
+	require.Equal(t, servicePlanDeploymentStepCloud, state.currentStep())
+	require.Equal(t, 3, len(state.Steps))
 }
 
 func TestServicePlanDeploymentFormRefreshesParametersWhenResourceChanges(t *testing.T) {
@@ -607,7 +719,6 @@ func TestServicePlanDeploymentParameterOptionsUseSelectableValues(t *testing.T) 
 	state := newServicePlanDeploymentFormState(form, 80)
 	require.NoError(t, state.advanceStep(80))
 	require.NoError(t, state.advanceStep(80))
-	require.NoError(t, state.advanceStep(80))
 	require.Equal(t, servicePlanDeploymentStepSystemParams, state.currentStep())
 	require.True(t, state.moveCurrentParameterOption(1))
 	require.Equal(t, "small", state.ParamFields[0].Input.Value())
@@ -639,6 +750,55 @@ func TestServicePlanDeploymentWizardPromptsForCustomerInProd(t *testing.T) {
 	require.Equal(t, "alice@example.com", state.SelectedCustomer.Email)
 }
 
+func TestServicePlanDeploymentCustomerStepIsSearchable(t *testing.T) {
+	form := servicePlanDeploymentForm{
+		Environment: servicePlanBrowserEnvironment{Name: "PROD"},
+		Resources:   []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
+		Customers: []servicePlanDeploymentCustomer{
+			{UserID: "user-1", Email: "alice@example.com", Name: "Alice", OrgName: "Acme"},
+			{UserID: "user-2", Email: "bob@example.com", Name: "Bob", OrgName: "Beta"},
+		},
+	}
+
+	state := newServicePlanDeploymentFormState(form, 80)
+	for _, r := range "bob" {
+		_, handled := state.updateActiveTextInput(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		require.True(t, handled)
+	}
+
+	options := state.currentOptions()
+	require.Len(t, options, 1)
+	require.Equal(t, "bob@example.com", options[0].Customer.Email)
+	require.NoError(t, state.advanceStep(80))
+	require.Equal(t, "bob@example.com", state.SelectedCustomer.Email)
+}
+
+func TestServicePlanDeploymentFreeformCloudAndRegionWhenOptionsMissing(t *testing.T) {
+	form := servicePlanDeploymentForm{
+		Resources: []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
+	}
+
+	state := newServicePlanDeploymentFormState(form, 80)
+	require.Equal(t, servicePlanDeploymentStepCloud, state.currentStep())
+	require.True(t, state.currentStepUsesFreeformInput())
+	require.Contains(t, strings.Join(state.renderDeploymentOptionLines(20, lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle()), "\n"), "No fixed options")
+
+	state.OptionInput.SetValue("custom-cloud")
+	require.NoError(t, state.advanceStep(80))
+	require.Equal(t, "custom-cloud", state.CloudProvider)
+	require.Equal(t, servicePlanDeploymentStepRegion, state.currentStep())
+	require.True(t, state.currentStepUsesFreeformInput())
+
+	state.OptionInput.SetValue("custom-region")
+	require.NoError(t, state.advanceStep(80))
+	require.Equal(t, "custom-region", state.Region)
+
+	request, err := state.launchRequest()
+	require.NoError(t, err)
+	require.Equal(t, "custom-cloud", request.CloudProvider)
+	require.Equal(t, "custom-region", request.Region)
+}
+
 func TestServicePlanDeploymentCloudAccountsFilterBySelectedCustomer(t *testing.T) {
 	state := newServicePlanDeploymentFormState(servicePlanDeploymentForm{
 		Resources:               []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
@@ -655,6 +815,571 @@ func TestServicePlanDeploymentCloudAccountsFilterBySelectedCustomer(t *testing.T
 	accounts := state.filteredCloudAccounts()
 	require.Len(t, accounts, 1)
 	require.Equal(t, "acct-1", accounts[0].InstanceID)
+}
+
+func TestServicePlanDeploymentCloudAccountStepOffersInlineConnectWhenNoAccountMatches(t *testing.T) {
+	state := newServicePlanDeploymentFormState(servicePlanDeploymentForm{
+		AccountResource:         servicePlanDeploymentResource{ID: "r-injectedaccountconfig", Name: "Cloud Provider Account", URLKey: "omnistrateCloudAccountConfig"},
+		Resources:               []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
+		CloudProviders:          []string{"aws"},
+		RegionsByCloud:          map[string][]string{"aws": []string{"us-west-2"}},
+		RequiresCustomerAccount: true,
+	}, 80)
+
+	require.Equal(t, servicePlanDeploymentStepCloud, state.currentStep())
+	require.NoError(t, state.advanceStep(80))
+	require.Equal(t, servicePlanDeploymentStepCloudAccount, state.currentStep())
+
+	options := state.currentOptions()
+	require.Len(t, options, 1)
+	require.True(t, options[0].ConnectAccount)
+	require.Equal(t, "Connect your aws account", options[0].Label)
+	require.Empty(t, state.customerCloudAccountActionButtons(options[0]))
+	require.Equal(t, []string{"▸ Connect your aws account"}, state.renderDeploymentOptionLines(20, lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle()))
+	require.Equal(t, "enter: select  esc: cancel", state.deploymentHelpLine())
+
+	require.NoError(t, state.advanceStep(80))
+	require.Equal(t, servicePlanDeploymentStepConnectAccount, state.currentStep())
+	require.Contains(t, servicePlanDeploymentFormFieldLabels(state.ParamFields), "AWS account ID")
+
+	state.ParamFields[0].Input.SetValue("123456789012")
+	request, err := state.customerAccountConnectRequest()
+	require.NoError(t, err)
+	require.Equal(t, "aws", request.CloudProvider)
+	require.Equal(t, "123456789012", request.Values[servicePlanCustomerAccountAWSAccountIDKey])
+
+	params, err := servicePlanCustomerAccountRequestParams(context.Background(), "token", "aws", request.Values)
+	require.NoError(t, err)
+	require.Equal(t, "CloudFormation", params[servicePlanCustomerAccountIacToolKey])
+	require.Equal(t, "123456789012", params[servicePlanCustomerAccountAWSAccountIDKey])
+	require.Equal(t, "arn:aws:iam::123456789012:role/omnistrate-bootstrap-role", params[servicePlanCustomerAccountAWSBootstrapRoleKey])
+}
+
+func TestServicePlanDeploymentCloudAccountStepUsesCloudIdentityAndFailedActions(t *testing.T) {
+	state := newServicePlanDeploymentFormState(servicePlanDeploymentForm{
+		AccountResource:         servicePlanDeploymentResource{ID: "r-injectedaccountconfig", Name: "Cloud Provider Account", URLKey: "omnistrateCloudAccountConfig"},
+		Resources:               []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
+		CloudProviders:          []string{"aws"},
+		RegionsByCloud:          map[string][]string{"aws": []string{"us-west-2"}},
+		RequiresCustomerAccount: true,
+		CustomerCloudAccounts: []servicePlanCustomerCloudAccountRow{
+			{InstanceID: "instance-qu9xnfp2x", CloudProvider: "aws", Status: "FAILED", AWSAccountID: "123456789012", CustomerEmail: "alok@nistro.ai"},
+		},
+	}, 80)
+	require.NoError(t, state.advanceStep(80))
+	require.Equal(t, servicePlanDeploymentStepCloudAccount, state.currentStep())
+
+	options := state.currentOptions()
+	require.Len(t, options, 2)
+	require.Equal(t, "AWS account 123456789012", options[0].Label)
+	require.Equal(t, servicePlanCustomerCloudAccountActionRetry, options[0].AccountAction)
+	require.True(t, options[1].ConnectAccount)
+	require.Equal(t, "Connect new aws account", options[1].Label)
+	buttons := state.customerCloudAccountActionButtons(options[0])
+	require.Len(t, buttons, 2)
+	require.Equal(t, "Retry", buttons[0].Label)
+	require.Equal(t, "Delete", buttons[1].Label)
+	rendered := strings.Join(state.renderDeploymentOptionLines(20, lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle()), "\n")
+	require.Contains(t, rendered, "1. AWS account 123456789012")
+	require.Contains(t, rendered, "Retry")
+	require.Contains(t, rendered, "Delete")
+	require.Contains(t, rendered, "\n\n  Connect new aws account")
+	require.NotContains(t, rendered, "instance-qu9xnfp2x")
+
+	_, action, ok := state.selectedCustomerCloudAccountAction()
+	require.True(t, ok)
+	require.Equal(t, servicePlanCustomerCloudAccountActionRetry, action)
+	state.moveCustomerCloudAccountActionCursor(1)
+	_, action, ok = state.selectedCustomerCloudAccountAction()
+	require.True(t, ok)
+	require.Equal(t, servicePlanCustomerCloudAccountActionDelete, action)
+}
+
+func TestServicePlanDeploymentCloudAccountActionTabSwitchesAccountButtons(t *testing.T) {
+	state := newServicePlanDeploymentFormState(servicePlanDeploymentForm{
+		AccountResource:         servicePlanDeploymentResource{ID: "r-injectedaccountconfig", Name: "Cloud Provider Account", URLKey: "omnistrateCloudAccountConfig"},
+		Resources:               []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
+		CloudProviders:          []string{"aws"},
+		RegionsByCloud:          map[string][]string{"aws": []string{"us-west-2"}},
+		RequiresCustomerAccount: true,
+		CustomerCloudAccounts: []servicePlanCustomerCloudAccountRow{
+			{InstanceID: "acct-failed", CloudProvider: "aws", Status: "FAILED", AWSAccountID: "123456789012"},
+		},
+	}, 80)
+	require.NoError(t, state.advanceStep(80))
+	model := servicePlanBrowserModel{deploymentForm: &state, detailPanelWidth: 80}
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	_, action, ok := model.deploymentForm.selectedCustomerCloudAccountAction()
+	require.True(t, ok)
+	require.Equal(t, servicePlanCustomerCloudAccountActionDelete, action)
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	_, action, ok = model.deploymentForm.selectedCustomerCloudAccountAction()
+	require.True(t, ok)
+	require.Equal(t, servicePlanCustomerCloudAccountActionRetry, action)
+}
+
+func TestServicePlanDeploymentPendingCloudAccountShowsConnectionInstructions(t *testing.T) {
+	state := newServicePlanDeploymentFormState(servicePlanDeploymentForm{
+		AccountResource:         servicePlanDeploymentResource{ID: "r-injectedaccountconfig", Name: "Cloud Provider Account", URLKey: "omnistrateCloudAccountConfig"},
+		Resources:               []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
+		CloudProviders:          []string{"aws"},
+		RegionsByCloud:          map[string][]string{"aws": []string{"us-west-2"}},
+		RequiresCustomerAccount: true,
+		CustomerCloudAccounts: []servicePlanCustomerCloudAccountRow{
+			{
+				InstanceID:               "acct-pending",
+				AccountConfigID:          "ac-123",
+				CloudProvider:            "aws",
+				Status:                   "DEPLOYING",
+				StatusMessage:            "reconciling instance",
+				AWSAccountID:             "767925118737",
+				AWSCloudFormationURL:     "https://example.com/template.yml",
+				AWSCloudFormationNoLBURL: "https://example.com/template-no-lb.yml",
+				CustomerEmail:            "alok@nistro.ai",
+				SubscriptionID:           "sub-KImOLdo2ke",
+			},
+		},
+	}, 80)
+	require.NoError(t, state.advanceStep(80))
+
+	rendered := strings.Join(state.renderDeploymentOptionLines(30, lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle()), "\n")
+	require.Contains(t, rendered, "1. AWS account 767925118737")
+	require.Contains(t, rendered, "Waiting")
+	require.Contains(t, rendered, "Account config ID: ac-123")
+	require.Contains(t, rendered, "CloudFormation template URL: https://example.com/template.yml")
+	require.NotContains(t, rendered, "CloudFormation no-LB template URL")
+	require.Contains(t, state.deploymentHelpLine(), "c: copy template URL")
+}
+
+func TestServicePlanDeploymentCloudAccountStatusIsStyled(t *testing.T) {
+	rendered := renderServicePlanCustomerCloudAccountDescription(servicePlanCustomerCloudAccountRow{
+		Status:         "READY",
+		StatusMessage:  "Instance deployed",
+		CustomerEmail:  "alok@nistro.ai",
+		SubscriptionID: "sub-KImOLdo2ke",
+	}, lipgloss.NewStyle().Foreground(lipgloss.Color("245")), "    ")
+
+	require.Contains(t, rendered, "READY")
+	require.Contains(t, rendered, "account verified")
+	require.NotContains(t, rendered, "Instance deployed")
+	require.Contains(t, rendered, "alok@nistro.ai")
+	require.Equal(t, lipgloss.Color("82"), servicePlanCustomerCloudAccountStatusStyle("READY", lipgloss.NewStyle()).GetForeground())
+}
+
+func TestServicePlanDeploymentCloudAccountBackfillsEmailFromSubscription(t *testing.T) {
+	state := newServicePlanDeploymentFormState(servicePlanDeploymentForm{
+		Resources:               []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
+		CloudProviders:          []string{"aws"},
+		RegionsByCloud:          map[string][]string{"aws": []string{"us-west-2"}},
+		RequiresCustomerAccount: true,
+		Subscriptions:           []servicePlanSubscriptionRow{{ID: "sub-KImOLdo2ke", RootUserEmail: "alok@nistro.ai"}},
+		CustomerCloudAccounts: []servicePlanCustomerCloudAccountRow{
+			{InstanceID: "acct-1", CloudProvider: "aws", Status: "READY", StatusMessage: "account verified", AWSAccountID: "767925118737", SubscriptionID: "sub-KImOLdo2ke"},
+		},
+	}, 80)
+	require.NoError(t, state.advanceStep(80))
+
+	accounts := state.filteredCloudAccounts()
+	require.Len(t, accounts, 1)
+	require.Equal(t, "alok@nistro.ai", accounts[0].CustomerEmail)
+
+	rendered := strings.Join(state.renderDeploymentOptionLines(20, lipgloss.NewStyle(), lipgloss.NewStyle(), lipgloss.NewStyle()), "\n")
+	require.Contains(t, rendered, "READY")
+	require.Contains(t, rendered, "account verified")
+	require.Contains(t, rendered, "alok@nistro.ai")
+}
+
+func TestServicePlanDeploymentExistingPendingCloudAccountPollsOnCloudAccountStep(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServicesWithHostingModels(), nil)
+	loader := &fakeServicePlanBrowserLoader{
+		details: testBrowserDetails(catalog),
+		refreshAccount: servicePlanCustomerCloudAccountRow{
+			InstanceID:           "acct-pending",
+			AccountConfigID:      "ac-123",
+			CloudProvider:        "aws",
+			Status:               "DEPLOYING",
+			StatusMessage:        "still reconciling",
+			AWSAccountID:         "767925118737",
+			AWSCloudFormationURL: "https://example.com/template.yml",
+		},
+	}
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
+	state := newServicePlanDeploymentFormState(servicePlanDeploymentForm{
+		Environment:             catalog.Services[0].Plans[0].Environments[0],
+		AccountResource:         servicePlanDeploymentResource{ID: "r-injectedaccountconfig", Name: "Cloud Provider Account", URLKey: "omnistrateCloudAccountConfig"},
+		Resources:               []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
+		CloudProviders:          []string{"aws"},
+		RegionsByCloud:          map[string][]string{"aws": []string{"us-west-2"}},
+		RequiresCustomerAccount: true,
+		CustomerCloudAccounts: []servicePlanCustomerCloudAccountRow{
+			{
+				InstanceID:           "acct-pending",
+				AccountConfigID:      "ac-123",
+				CloudProvider:        "aws",
+				Status:               "DEPLOYING",
+				StatusMessage:        "reconciling instance",
+				AWSAccountID:         "767925118737",
+				AWSCloudFormationURL: "https://example.com/template.yml",
+			},
+		},
+	}, 80)
+	model.deploymentForm = &state
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.Equal(t, servicePlanDeploymentStepCloudAccount, model.deploymentForm.currentStep())
+	require.True(t, model.deploymentForm.CustomerAccountPollScheduled)
+
+	updated, cmd = model.Update(servicePlanCustomerCloudAccountPollTickMsg{})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.False(t, model.deploymentForm.CustomerAccountPollScheduled)
+
+	updated, cmd = model.Update(cmd())
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.Equal(t, 1, loader.refreshCalls)
+	require.True(t, model.deploymentForm.CustomerAccountPollScheduled)
+	require.Equal(t, "still reconciling", model.deploymentForm.Form.CustomerCloudAccounts[0].StatusMessage)
+	require.Equal(t, servicePlanDeploymentStepCloudAccount, model.deploymentForm.currentStep())
+}
+
+func TestServicePlanDeploymentCopiesCloudFormationTemplateURL(t *testing.T) {
+	state := newServicePlanDeploymentFormState(servicePlanDeploymentForm{
+		AccountResource:         servicePlanDeploymentResource{ID: "r-injectedaccountconfig", Name: "Cloud Provider Account", URLKey: "omnistrateCloudAccountConfig"},
+		Resources:               []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
+		CloudProviders:          []string{"aws"},
+		RegionsByCloud:          map[string][]string{"aws": []string{"us-west-2"}},
+		RequiresCustomerAccount: true,
+		CustomerCloudAccounts: []servicePlanCustomerCloudAccountRow{
+			{
+				InstanceID:               "acct-pending",
+				CloudProvider:            "aws",
+				Status:                   "DEPLOYING",
+				AWSAccountID:             "767925118737",
+				AWSCloudFormationURL:     "https://example.com/template.yml",
+				AWSCloudFormationNoLBURL: "https://example.com/template-no-lb.yml",
+			},
+		},
+	}, 80)
+	require.NoError(t, state.advanceStep(80))
+
+	originalCopy := servicePlanBrowserCopyToClipboard
+	var copied string
+	servicePlanBrowserCopyToClipboard = func(text string) error {
+		copied = text
+		return nil
+	}
+	t.Cleanup(func() {
+		servicePlanBrowserCopyToClipboard = originalCopy
+	})
+
+	model := servicePlanBrowserModel{deploymentForm: &state, detailPanelWidth: 80}
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'c'}})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	msg := cmd()
+	require.Equal(t, "https://example.com/template.yml", copied)
+
+	updated, cmd = model.Update(msg)
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.Equal(t, "Copied CloudFormation template URL", model.deploymentForm.Notice)
+}
+
+func TestServicePlanDeploymentConnectProgressShowsOnboardingInstructions(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServicesWithHostingModels(), nil)
+	loader := &fakeServicePlanBrowserLoader{
+		details: testBrowserDetails(catalog),
+		connectAccount: servicePlanCustomerCloudAccountRow{
+			InstanceID:           "acct-pending",
+			AccountConfigID:      "ac-123",
+			CloudProvider:        "aws",
+			Status:               "DEPLOYING",
+			AWSAccountID:         "767925118737",
+			AWSCloudFormationURL: "https://example.com/template.yml",
+			SubscriptionID:       "sub-new",
+		},
+		refreshAccount: servicePlanCustomerCloudAccountRow{
+			InstanceID:           "acct-pending",
+			AccountConfigID:      "ac-123",
+			CloudProvider:        "aws",
+			Status:               "READY",
+			AWSAccountID:         "767925118737",
+			AWSCloudFormationURL: "https://example.com/template.yml",
+			SubscriptionID:       "sub-new",
+		},
+	}
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
+	model.detailPanelWidth = 80
+	env := catalog.Services[0].Plans[0].Environments[0]
+	state := newServicePlanDeploymentFormState(servicePlanDeploymentForm{
+		Environment:             env,
+		AccountResource:         servicePlanDeploymentResource{ID: "r-injectedaccountconfig", Name: "Cloud Provider Account", URLKey: "omnistrateCloudAccountConfig"},
+		Resources:               []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
+		CloudProviders:          []string{"aws"},
+		RegionsByCloud:          map[string][]string{"aws": []string{"us-west-2"}},
+		RequiresCustomerAccount: true,
+	}, 80)
+	require.NoError(t, state.advanceStep(80))
+	require.NoError(t, state.advanceStep(80))
+	state.ParamFields[0].Input.SetValue("767925118737")
+	model.deploymentForm = &state
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	batch, ok := cmd().(tea.BatchMsg)
+	require.True(t, ok)
+	require.Len(t, batch, 2)
+
+	updated, cmd = model.Update(batch[1]())
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.True(t, model.deploymentForm.ConnectingAccount)
+	rendered := model.renderDeploymentForm()
+	require.Contains(t, rendered, "Waiting for account to become READY")
+	require.NotContains(t, rendered, "Connecting aws account and waiting for READY")
+	require.Contains(t, rendered, "Account config ID: ac-123")
+	require.Contains(t, rendered, "CloudFormation template URL: https://example.com/template.yml")
+	require.Contains(t, model.deploymentForm.deploymentHelpLine(), "c: copy template URL")
+
+	updated, cmd = model.Update(servicePlanCustomerCloudAccountPollTickMsg{})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	updated, cmd = model.Update(cmd())
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.False(t, model.deploymentForm.ConnectingAccount)
+	require.Equal(t, servicePlanDeploymentStepRegion, model.deploymentForm.currentStep())
+	require.Equal(t, 1, loader.refreshCalls)
+}
+
+func TestServicePlanCustomerCloudAccountRowExtractsCloudIdentityFromInstance(t *testing.T) {
+	row := servicePlanCustomerCloudAccountRowWithInstanceDetails(servicePlanCustomerCloudAccountRow{
+		InstanceID: "instance-qu9xnfp2x",
+		Status:     "FAILED",
+	}, &openapiclientfleet.ResourceInstance{
+		CloudProvider: "aws",
+		ConsumptionResourceInstanceResult: openapiclientfleet.DescribeResourceInstanceResult{
+			LaunchInputParams: map[string]any{
+				servicePlanCustomerAccountAWSAccountIDKey: "123456789012",
+			},
+		},
+	})
+
+	require.Equal(t, "aws", row.CloudProvider)
+	require.Equal(t, "123456789012", row.AWSAccountID)
+	require.Equal(t, "AWS account 123456789012", servicePlanCustomerCloudAccountLabel(row))
+}
+
+func TestServicePlanDeploymentFormFieldEditsDirectlyAndEnterContinues(t *testing.T) {
+	state := newServicePlanDeploymentFormState(servicePlanDeploymentForm{
+		AccountResource:         servicePlanDeploymentResource{ID: "r-injectedaccountconfig", Name: "Cloud Provider Account", URLKey: "omnistrateCloudAccountConfig"},
+		Resources:               []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
+		CloudProviders:          []string{"aws"},
+		RegionsByCloud:          map[string][]string{"aws": []string{"us-west-2"}},
+		RequiresCustomerAccount: true,
+	}, 80)
+	require.NoError(t, state.advanceStep(80))
+	require.NoError(t, state.advanceStep(80))
+	state.ParamFields[0].Input.SetValue("123")
+
+	model := servicePlanBrowserModel{deploymentForm: &state, detailPanelWidth: 80}
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyBackspace})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.Equal(t, servicePlanDeploymentStepConnectAccount, model.deploymentForm.currentStep())
+	require.Equal(t, "12", model.deploymentForm.ParamFields[0].Input.Value())
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'4'}})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.Equal(t, "124", model.deploymentForm.ParamFields[0].Input.Value())
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.Equal(t, "customer cloud account connection is not available", model.deploymentForm.Err)
+}
+
+func TestServicePlanDeploymentInlineConnectSelectsNewAccountAndContinues(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServicesWithHostingModels(), nil)
+	loader := &fakeServicePlanBrowserLoader{
+		details:        testBrowserDetails(catalog),
+		connectAccount: servicePlanCustomerCloudAccountRow{InstanceID: "acct-new", CloudProvider: "aws", Status: "READY", SubscriptionID: "sub-new"},
+	}
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
+	model.list.Select(2)
+	model.syncSelectionFromList()
+	env := model.selectedEnvironment()
+	require.NotNil(t, env)
+
+	state := newServicePlanDeploymentFormState(servicePlanDeploymentForm{
+		Environment:             *env,
+		AccountResource:         servicePlanDeploymentResource{ID: "r-injectedaccountconfig", Name: "Cloud Provider Account", URLKey: "omnistrateCloudAccountConfig"},
+		Resources:               []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
+		CloudProviders:          []string{"aws"},
+		RegionsByCloud:          map[string][]string{"aws": []string{"us-west-2"}},
+		RequiresCustomerAccount: true,
+		Customers:               []servicePlanDeploymentCustomer{{UserID: "user-1", Email: "alice@example.com", Name: "Alice"}},
+	}, 80)
+	require.NoError(t, state.advanceStep(80))
+	require.NoError(t, state.advanceStep(80))
+	state.ParamFields[0].Input.SetValue("123456789012")
+	model.deploymentForm = &state
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.True(t, model.deploymentForm.ConnectingAccount)
+
+	batch, ok := cmd().(tea.BatchMsg)
+	require.True(t, ok)
+	require.Len(t, batch, 2)
+	connected := batch[1]()
+	updated, cmd = model.Update(connected)
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+
+	require.Equal(t, 1, loader.connectCalls)
+	require.Equal(t, "123456789012", loader.connectReq.Values[servicePlanCustomerAccountAWSAccountIDKey])
+	require.False(t, model.deploymentForm.ConnectingAccount)
+	require.Equal(t, "acct-new", model.deploymentForm.CustomerAccountID)
+	require.Equal(t, servicePlanDeploymentStepRegion, model.deploymentForm.currentStep())
+	require.Len(t, model.deploymentForm.Form.CustomerCloudAccounts, 1)
+	require.Equal(t, "acct-new", model.deploymentForm.Form.CustomerCloudAccounts[0].InstanceID)
+}
+
+func TestServicePlanDeploymentFailedCloudAccountRetryAction(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServicesWithHostingModels(), nil)
+	loader := &fakeServicePlanBrowserLoader{
+		details:      testBrowserDetails(catalog),
+		retryAccount: servicePlanCustomerCloudAccountRow{InstanceID: "acct-failed", CloudProvider: "aws", Status: "READY", AWSAccountID: "123456789012"},
+	}
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
+	model.detailPanelWidth = 80
+	state := newServicePlanDeploymentFormState(servicePlanDeploymentForm{
+		AccountResource:         servicePlanDeploymentResource{ID: "r-injectedaccountconfig", Name: "Cloud Provider Account", URLKey: "omnistrateCloudAccountConfig"},
+		Resources:               []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
+		CloudProviders:          []string{"aws"},
+		RegionsByCloud:          map[string][]string{"aws": []string{"us-west-2"}},
+		RequiresCustomerAccount: true,
+		CustomerCloudAccounts: []servicePlanCustomerCloudAccountRow{
+			{InstanceID: "acct-failed", CloudProvider: "aws", Status: "FAILED", AWSAccountID: "123456789012"},
+		},
+	}, 80)
+	require.NoError(t, state.advanceStep(80))
+	model.deploymentForm = &state
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.True(t, model.deploymentForm.AccountActionRunning)
+
+	batch, ok := cmd().(tea.BatchMsg)
+	require.True(t, ok)
+	require.Len(t, batch, 2)
+	updated, cmd = model.Update(batch[1]())
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+
+	require.Equal(t, 1, loader.retryCalls)
+	require.Equal(t, "acct-failed", loader.retryReq.Account.InstanceID)
+	require.False(t, model.deploymentForm.AccountActionRunning)
+	require.Equal(t, "acct-failed", model.deploymentForm.CustomerAccountID)
+	require.Equal(t, servicePlanDeploymentStepRegion, model.deploymentForm.currentStep())
+}
+
+func TestServicePlanDeploymentFailedCloudAccountDeleteAction(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServicesWithHostingModels(), nil)
+	loader := &fakeServicePlanBrowserLoader{details: testBrowserDetails(catalog)}
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
+	model.detailPanelWidth = 80
+	state := newServicePlanDeploymentFormState(servicePlanDeploymentForm{
+		AccountResource:         servicePlanDeploymentResource{ID: "r-injectedaccountconfig", Name: "Cloud Provider Account", URLKey: "omnistrateCloudAccountConfig"},
+		Resources:               []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
+		CloudProviders:          []string{"aws"},
+		RegionsByCloud:          map[string][]string{"aws": []string{"us-west-2"}},
+		RequiresCustomerAccount: true,
+		CustomerCloudAccounts: []servicePlanCustomerCloudAccountRow{
+			{InstanceID: "acct-failed", CloudProvider: "aws", Status: "FAILED", AWSAccountID: "123456789012"},
+		},
+	}, 80)
+	require.NoError(t, state.advanceStep(80))
+	state.AccountActionCursor = 1
+	model.deploymentForm = &state
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.True(t, model.deploymentForm.AccountActionRunning)
+
+	batch, ok := cmd().(tea.BatchMsg)
+	require.True(t, ok)
+	require.Len(t, batch, 2)
+	updated, cmd = model.Update(batch[1]())
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+
+	require.Equal(t, 1, loader.deleteCalls)
+	require.Equal(t, "acct-failed", loader.deleteReq.Account.InstanceID)
+	require.False(t, model.deploymentForm.AccountActionRunning)
+	require.Empty(t, model.deploymentForm.Form.CustomerCloudAccounts)
+	require.Equal(t, servicePlanDeploymentStepCloudAccount, model.deploymentForm.currentStep())
+}
+
+func TestServicePlanDeploymentReadyCloudAccountDeleteAction(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServicesWithHostingModels(), nil)
+	loader := &fakeServicePlanBrowserLoader{details: testBrowserDetails(catalog)}
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
+	model.detailPanelWidth = 80
+	state := newServicePlanDeploymentFormState(servicePlanDeploymentForm{
+		AccountResource:         servicePlanDeploymentResource{ID: "r-injectedaccountconfig", Name: "Cloud Provider Account", URLKey: "omnistrateCloudAccountConfig"},
+		Resources:               []servicePlanDeploymentResource{{ID: "res-1", Name: "API", URLKey: "api"}},
+		CloudProviders:          []string{"aws"},
+		RegionsByCloud:          map[string][]string{"aws": []string{"us-west-2"}},
+		RequiresCustomerAccount: true,
+		CustomerCloudAccounts: []servicePlanCustomerCloudAccountRow{
+			{InstanceID: "acct-ready", CloudProvider: "aws", Status: "READY", AWSAccountID: "123456789012"},
+		},
+	}, 80)
+	require.NoError(t, state.advanceStep(80))
+
+	options := state.currentOptions()
+	require.Len(t, options, 2)
+	buttons := state.customerCloudAccountActionButtons(options[0])
+	require.Len(t, buttons, 2)
+	require.Equal(t, "Use", buttons[0].Label)
+	require.Equal(t, "Delete", buttons[1].Label)
+
+	state.AccountActionCursor = 1
+	model.deploymentForm = &state
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.True(t, model.deploymentForm.AccountActionRunning)
+
+	batch, ok := cmd().(tea.BatchMsg)
+	require.True(t, ok)
+	require.Len(t, batch, 2)
+	updated, cmd = model.Update(batch[1]())
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+
+	require.Equal(t, 1, loader.deleteCalls)
+	require.Equal(t, "acct-ready", loader.deleteReq.Account.InstanceID)
+	require.False(t, model.deploymentForm.AccountActionRunning)
+	require.Empty(t, model.deploymentForm.Form.CustomerCloudAccounts)
+	require.Equal(t, servicePlanDeploymentStepCloudAccount, model.deploymentForm.currentStep())
 }
 
 func TestServicePlanBrowserRefreshHotkeyReloadsRightPane(t *testing.T) {

--- a/cmd/serviceplan/browser_test.go
+++ b/cmd/serviceplan/browser_test.go
@@ -1,0 +1,463 @@
+package serviceplan
+
+import (
+	"context"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	displaymodel "github.com/omnistrate-oss/omnistrate-ctl/internal/model"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
+	openapiclient "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeServicePlanBrowserLoader struct {
+	details map[string]servicePlanEnvironmentDetails
+	calls   []string
+}
+
+func (f *fakeServicePlanBrowserLoader) LoadEnvironmentDetails(_ context.Context, _ string, env servicePlanBrowserEnvironment) (servicePlanEnvironmentDetails, error) {
+	key := env.cacheKey()
+	f.calls = append(f.calls, key)
+	return f.details[key], nil
+}
+
+func loadSelectedTestDetails(t *testing.T, model servicePlanBrowserModel) servicePlanBrowserModel {
+	t.Helper()
+
+	cmd := model.selectedDetailsLoadCmd()
+	require.NotNil(t, cmd)
+
+	updated, nextCmd := model.Update(cmd())
+	require.Nil(t, nextCmd)
+	return updated.(servicePlanBrowserModel)
+}
+
+func TestBuildServicePlanBrowserCatalogGroupsPlanNamesByService(t *testing.T) {
+	services := testBrowserServices()
+
+	catalog := buildServicePlanBrowserCatalog(services, nil)
+
+	require.Len(t, catalog.Services, 1)
+	require.Equal(t, "Postgres", catalog.Services[0].Name)
+	require.Len(t, catalog.Services[0].Plans, 1)
+	require.Equal(t, "Standard", catalog.Services[0].Plans[0].Name)
+	require.Len(t, catalog.Services[0].Plans[0].Environments, 2)
+	require.Equal(t, "dev", catalog.Services[0].Plans[0].Environments[0].Name)
+	require.Equal(t, "prod", catalog.Services[0].Plans[0].Environments[1].Name)
+}
+
+func TestBuildServicePlanBrowserCatalogAppliesFilters(t *testing.T) {
+	services := testBrowserServices()
+
+	catalog := buildServicePlanBrowserCatalog(services, []map[string]string{{"environment": "prod"}})
+
+	require.Len(t, catalog.Services, 1)
+	require.Len(t, catalog.Services[0].Plans, 1)
+	require.Len(t, catalog.Services[0].Plans[0].Environments, 1)
+	require.Equal(t, "prod", catalog.Services[0].Plans[0].Environments[0].Name)
+}
+
+func TestServicePlanBrowserAccordionAndTabSwitching(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
+	loader := &fakeServicePlanBrowserLoader{details: testBrowserDetails(catalog)}
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
+	model = loadSelectedTestDetails(t, model)
+
+	require.Len(t, model.leftItems(), 2)
+	require.Len(t, loader.calls, 1)
+
+	model.list.Select(0)
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.Len(t, model.leftItems(), 1)
+
+	model.list.Select(0)
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRight})
+	model = updated.(servicePlanBrowserModel)
+	require.Len(t, model.leftItems(), 2)
+
+	model.list.Select(1)
+	model.syncSelectionFromList()
+	model.focus = servicePlanBrowserFocusDetails
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	model = updated.(servicePlanBrowserModel)
+	require.Equal(t, 1, model.activeTab)
+	model = loadSelectedTestDetails(t, model)
+	require.Len(t, loader.calls, 2)
+}
+
+func TestServicePlanBrowserSelectionUpdatesPlanDetailsWithoutEnter(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServicesWithTwoPlans(), nil)
+	loader := &fakeServicePlanBrowserLoader{details: testBrowserDetails(catalog)}
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
+	model = loadSelectedTestDetails(t, model)
+
+	require.Equal(t, "Standard", model.selectedPlan().Name)
+	require.Contains(t, model.viewport.View(), "Postgres / Standard")
+	require.Len(t, loader.calls, 1)
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+
+	require.Equal(t, "Premium", model.selectedPlan().Name)
+	require.Contains(t, model.viewport.View(), "Postgres / Premium")
+	require.Contains(t, model.viewport.View(), "Loading details")
+	require.Len(t, loader.calls, 1)
+
+	model = loadSelectedTestDetails(t, model)
+	require.Len(t, loader.calls, 2)
+}
+
+func TestServicePlanBrowserTabOnlySwitchesEnvironmentInDetailsPane(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
+	loader := &fakeServicePlanBrowserLoader{details: testBrowserDetails(catalog)}
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
+	model = loadSelectedTestDetails(t, model)
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.Equal(t, 0, model.activeTab)
+
+	model.focus = servicePlanBrowserFocusDetails
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.Equal(t, 1, model.activeTab)
+}
+
+func TestServicePlanBrowserTabCyclesEnvironmentsInDetailsPane(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, nil)
+	model.focus = servicePlanBrowserFocusDetails
+
+	model.activeTab = 1
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.Equal(t, 0, model.activeTab)
+
+	updated, cmd = model.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.Equal(t, 1, model.activeTab)
+}
+
+func TestServicePlanBrowserEscapeMovesFocusBackToPlans(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
+	loader := &fakeServicePlanBrowserLoader{details: testBrowserDetails(catalog)}
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
+	model.focus = servicePlanBrowserFocusDetails
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+
+	require.Equal(t, servicePlanBrowserFocusLeft, model.focus)
+}
+
+func TestServicePlanBrowserLeftArrowMovesFocusBackToPlans(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
+	loader := &fakeServicePlanBrowserLoader{details: testBrowserDetails(catalog)}
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
+	model.focus = servicePlanBrowserFocusDetails
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyLeft})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+
+	require.Equal(t, servicePlanBrowserFocusLeft, model.focus)
+}
+
+func TestServicePlanBrowserEnterFocusesDetailsPane(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, nil)
+	model.list.Select(1)
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+
+	require.Equal(t, servicePlanBrowserFocusDetails, model.focus)
+}
+
+func TestServicePlanBrowserEnvironmentSelectorIsInlineAndColored(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, nil)
+
+	selector := model.renderEnvironmentSelector(80)
+
+	require.NotContains(t, selector, "╭")
+	require.NotContains(t, selector, "╰")
+	require.NotContains(t, selector, "┘")
+	require.NotContains(t, selector, "┴")
+	require.Contains(t, selector, "Environment:")
+	require.Contains(t, selector, "▸ dev")
+	require.Contains(t, selector, "prod")
+	require.Equal(t, "82", string(servicePlanEnvironmentColor("Dev")))
+	require.Equal(t, "160", string(servicePlanEnvironmentColor("Prod")))
+}
+
+func TestServicePlanBrowserDetailCursorAutoScrollsViewport(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
+	loader := &fakeServicePlanBrowserLoader{details: testBrowserDetails(catalog)}
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
+	model = loadSelectedTestDetails(t, model)
+	model.focus = servicePlanBrowserFocusDetails
+	model.viewport.Height = 4
+
+	model.moveDetailCursor(6)
+
+	require.Greater(t, model.viewport.YOffset, 0)
+	require.Contains(t, model.viewport.View(), "Users")
+}
+
+func TestServicePlanBrowserDetailCursorCanReturnToEnvironmentSelector(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
+	loader := &fakeServicePlanBrowserLoader{details: testBrowserDetails(catalog)}
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
+	model = loadSelectedTestDetails(t, model)
+	model.focus = servicePlanBrowserFocusDetails
+	model.viewport.Height = 4
+
+	model.moveDetailCursor(6)
+	require.Greater(t, model.viewport.YOffset, 0)
+
+	for i := 0; i < 7; i++ {
+		model.moveDetailCursor(-1)
+	}
+
+	require.Equal(t, -1, model.detailCursor)
+	require.Equal(t, 0, model.viewport.YOffset)
+	require.Contains(t, model.viewport.View(), "Environment:")
+
+	model.moveDetailCursor(1)
+
+	require.Equal(t, 0, model.detailCursor)
+	require.Greater(t, model.viewport.YOffset, 0)
+	require.Contains(t, model.viewport.View(), "Deployment model")
+}
+
+func TestServicePlanBrowserEnvironmentSwitchReturnsViewportToSelector(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
+	loader := &fakeServicePlanBrowserLoader{details: testBrowserDetails(catalog)}
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
+	model = loadSelectedTestDetails(t, model)
+	model.focus = servicePlanBrowserFocusDetails
+	model.viewport.Height = 4
+	model.moveDetailCursor(6)
+	require.Greater(t, model.viewport.YOffset, 0)
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	require.NotNil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+
+	require.Equal(t, -1, model.detailCursor)
+	require.Equal(t, 0, model.viewport.YOffset)
+	require.Contains(t, model.viewport.View(), "Environment:")
+}
+
+func TestServicePlanBrowserPlanItemsIncludeHostingBadges(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServicesWithHostingModels(), nil)
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, nil)
+
+	items := model.leftItems()
+
+	require.Equal(t, "Omnistrate Hosted", items[1].hostingBadge.Label)
+	require.Equal(t, "BYOC", items[2].hostingBadge.Label)
+	require.Equal(t, "Hosted", items[3].hostingBadge.Label)
+	require.Equal(t, "Hosted", items[4].hostingBadge.Label)
+}
+
+func TestServicePlanHostingBadgeMapping(t *testing.T) {
+	tests := []struct {
+		name      string
+		modelType string
+		tierType  string
+		want      string
+	}{
+		{name: "omnistrate hosted model type", modelType: "OMNISTRATE_HOSTED", tierType: "SHARED", want: "Omnistrate Hosted"},
+		{name: "omnistrate hosted tier type", modelType: "OMNISTRATE_MULTI_TENANCY", tierType: "OMNISTRATE_HOSTED", want: "Omnistrate Hosted"},
+		{name: "customer hosted model type", modelType: "CUSTOMER_HOSTED", tierType: "CUSTOM_TENANCY", want: "Hosted"},
+		{name: "byoa alias", modelType: "BYOA", tierType: "DEDICATED", want: "BYOC"},
+		{name: "hosted fallback", modelType: "", tierType: "DEDICATED", want: "Hosted"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, servicePlanHostingBadgeForValues(tt.modelType, tt.tierType).Label)
+		})
+	}
+}
+
+func TestServicePlanBrowserModalFiltering(t *testing.T) {
+	catalog := buildServicePlanBrowserCatalog(testBrowserServices(), nil)
+	loader := &fakeServicePlanBrowserLoader{details: testBrowserDetails(catalog)}
+	model := newServicePlanBrowserModel(context.Background(), "token", catalog, loader)
+	model = loadSelectedTestDetails(t, model)
+	model.focus = servicePlanBrowserFocusDetails
+	model.detailCursor = 4
+
+	updated, cmd := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	require.Nil(t, cmd)
+	model = updated.(servicePlanBrowserModel)
+	require.NotNil(t, model.modal)
+	require.Equal(t, servicePlanBrowserModalDeployments, model.modal.Kind)
+
+	filtered := filterServicePlanModalRows(model.modal.Rows, "aws")
+	require.Len(t, filtered, 1)
+	require.Contains(t, filtered[0].Text, "aws")
+}
+
+func TestDedupeServicePlanUsersUsesUserIDThenEmail(t *testing.T) {
+	users := []openapiclientfleet.User{
+		{UserId: "user-1", Email: "first@example.com"},
+		{UserId: "user-1", Email: "second@example.com"},
+		{Email: "shared@example.com"},
+		{Email: "SHARED@example.com"},
+		{Email: "unique@example.com"},
+	}
+
+	unique := dedupeServicePlanUsers(users)
+
+	require.Len(t, unique, 3)
+	require.Equal(t, "user-1", unique[0].UserId)
+	require.Equal(t, "shared@example.com", unique[1].Email)
+	require.Equal(t, "unique@example.com", unique[2].Email)
+}
+
+func TestProductTierSummaryHelpers(t *testing.T) {
+	featureName := "CUSTOM_TERRAFORM_POLICY"
+	scope := "service"
+	features := map[string]bool{"AUDIT": true, "DISABLED": false}
+	readiness := map[string]map[string]string{"aws": {"us-east-1": "ready"}}
+	productTier := &openapiclient.DescribeProductTierResult{
+		AwsRegions:                    []string{"us-west-2"},
+		GcpRegions:                    []string{"us-central1"},
+		CloudProvidersConfigReadiness: &readiness,
+		EnabledFeatures: []openapiclient.ProductTierFeatureDetail{
+			{Feature: &featureName, Scope: &scope},
+		},
+		Features: &features,
+	}
+
+	clouds, regions := productTierCloudsAndRegions(productTier)
+	enabled := productTierEnabledFeatures(productTier)
+
+	require.ElementsMatch(t, []string{"aws", "gcp"}, clouds)
+	require.ElementsMatch(t, []string{"us-east-1", "us-west-2", "us-central1"}, regions)
+	require.ElementsMatch(t, []string{"AUDIT", "CUSTOM_TERRAFORM_POLICY (service)"}, enabled)
+}
+
+func TestFormatServicePlansFromServicesSupportsJSONParityPath(t *testing.T) {
+	filterMaps, err := utils.ParseFilters([]string{"environment:dev"}, utils.GetSupportedFilterKeys(displaymodel.ServicePlanVersion{}))
+	require.NoError(t, err)
+
+	plans, err := formatServicePlansFromServices(testBrowserServices(), filterMaps, false)
+
+	require.NoError(t, err)
+	require.Len(t, plans, 1)
+	require.Equal(t, "plan-dev", plans[0].PlanID)
+	require.Equal(t, "Standard", plans[0].PlanName)
+}
+
+func testBrowserServices() []openapiclient.DescribeServiceResult {
+	return []openapiclient.DescribeServiceResult{
+		{
+			Id:   "svc-1",
+			Name: "Postgres",
+			ServiceEnvironments: []openapiclient.ServiceEnvironment{
+				{
+					Id:   "env-dev",
+					Name: "dev",
+					ServicePlans: []openapiclient.ServicePlan{
+						{
+							Name:          "Standard",
+							ProductTierID: "plan-dev",
+							TierType:      "OMNISTRATE_HOSTED",
+							ModelType:     "OMNISTRATE_MULTI_TENANCY",
+						},
+					},
+				},
+				{
+					Id:   "env-prod",
+					Name: "prod",
+					ServicePlans: []openapiclient.ServicePlan{
+						{
+							Name:          "Standard",
+							ProductTierID: "plan-prod",
+							TierType:      "OMNISTRATE_HOSTED",
+							ModelType:     "OMNISTRATE_MULTI_TENANCY",
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testBrowserServicesWithTwoPlans() []openapiclient.DescribeServiceResult {
+	services := testBrowserServices()
+	services[0].ServiceEnvironments[0].ServicePlans = append(services[0].ServiceEnvironments[0].ServicePlans, openapiclient.ServicePlan{
+		Name:          "Premium",
+		ProductTierID: "plan-premium",
+		TierType:      "OMNISTRATE_HOSTED",
+		ModelType:     "OMNISTRATE_DEDICATED_TENANCY",
+	})
+	return services
+}
+
+func testBrowserServicesWithHostingModels() []openapiclient.DescribeServiceResult {
+	return []openapiclient.DescribeServiceResult{
+		{
+			Id:   "svc-1",
+			Name: "Postgres",
+			ServiceEnvironments: []openapiclient.ServiceEnvironment{
+				{
+					Id:   "env-dev",
+					Name: "dev",
+					ServicePlans: []openapiclient.ServicePlan{
+						{Name: "Omni", ProductTierID: "plan-omni", ModelType: "OMNISTRATE_HOSTED", TierType: "SHARED"},
+						{Name: "Byoc", ProductTierID: "plan-byoc", ModelType: "BYOA", TierType: "DEDICATED"},
+						{Name: "Hosted", ProductTierID: "plan-hosted", ModelType: "", TierType: "DEDICATED"},
+						{Name: "Customer Hosted", ProductTierID: "plan-customer-hosted", ModelType: "CUSTOMER_HOSTED", TierType: "CUSTOM_TENANCY"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func testBrowserDetails(catalog servicePlanBrowserCatalog) map[string]servicePlanEnvironmentDetails {
+	details := map[string]servicePlanEnvironmentDetails{}
+	for _, service := range catalog.Services {
+		for _, plan := range service.Plans {
+			for _, env := range plan.Environments {
+				details[env.cacheKey()] = servicePlanEnvironmentDetails{
+					DeploymentModel:          "OMNISTRATE_HOSTED / OMNISTRATE_MULTI_TENANCY",
+					EnabledFeatures:          []string{"AUDIT"},
+					Clouds:                   []string{"aws"},
+					Regions:                  []string{"us-west-2"},
+					DeploymentsCount:         2,
+					ActiveSubscriptionsCount: 1,
+					UniqueUsersCount:         1,
+					Deployments: []servicePlanDeploymentRow{
+						{ID: "inst-1", Status: "RUNNING", Cloud: "aws", Region: "us-west-2", Owner: "Alice"},
+						{ID: "inst-2", Status: "RUNNING", Cloud: "gcp", Region: "us-central1", Owner: "Bob"},
+					},
+					Subscriptions: []servicePlanSubscriptionRow{
+						{ID: "sub-1", Status: "ACTIVE", RootUserEmail: "alice@example.com", RootUserName: "Alice", InstanceCount: 2},
+					},
+					Users: []servicePlanUserRow{
+						{ID: "user-1", Email: "alice@example.com", Name: "Alice", Status: "ACTIVE", OrgName: "Acme"},
+					},
+				}
+			}
+		}
+	}
+	return details
+}

--- a/cmd/serviceplan/delete.go
+++ b/cmd/serviceplan/delete.go
@@ -20,19 +20,20 @@ omnistrate-ctl service-plan delete [service-name] [plan-name]
 omnistrate-ctl service-plan delete --service-id=[service-id] --plan-id=[plan-id]`
 )
 
-var deleteCmd = &cobra.Command{
-	Use:          "delete [service-name] [plan-name] [flags]",
-	Short:        "Delete a Service Plan",
-	Long:         `This command helps you delete a Service Plan from your service.`,
-	Example:      deleteExample,
-	RunE:         runDelete,
-	SilenceUsage: true,
-}
+func newDeleteCmd(commandPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "delete [service-name] [plan-name] [flags]",
+		Short:        "Delete a Service Plan",
+		Long:         `This command helps you delete a Service Plan from your service.`,
+		Example:      servicePlanExample(commandPath, deleteExample),
+		RunE:         runDelete,
+		SilenceUsage: true,
+	}
 
-func init() {
-	deleteCmd.Flags().StringP("environment", "", "", "Environment name. Use this flag with service name and plan name to delete the service plan in a specific environment")
-	deleteCmd.Flags().StringP("service-id", "", "", "Service ID. Required if service name is not provided")
-	deleteCmd.Flags().StringP("plan-id", "", "", "Plan ID. Required if plan name is not provided")
+	cmd.Flags().StringP("environment", "", "", "Environment name. Use this flag with service name and plan name to delete the service plan in a specific environment")
+	cmd.Flags().StringP("service-id", "", "", "Service ID. Required if service name is not provided")
+	cmd.Flags().StringP("plan-id", "", "", "Plan ID. Required if plan name is not provided")
+	return cmd
 }
 
 func runDelete(cmd *cobra.Command, args []string) error {

--- a/cmd/serviceplan/describe.go
+++ b/cmd/serviceplan/describe.go
@@ -24,20 +24,21 @@ omnistrate-ctl service-plan describe [service-name] [plan-name]
 omnistrate-ctl service-plan describe --service-id [service-id] --plan-id [plan-id]`
 )
 
-var describeCmd = &cobra.Command{
-	Use:          "describe [service-name] [plan-name] [flags]",
-	Short:        "Describe a Service Plan",
-	Long:         `This command helps you get details of a Service Plan for your service.`,
-	Example:      describeExample,
-	RunE:         runDescribe,
-	SilenceUsage: true,
-}
+func newDescribeCmd(commandPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "describe [service-name] [plan-name] [flags]",
+		Short:        "Describe a Service Plan",
+		Long:         `This command helps you get details of a Service Plan for your service.`,
+		Example:      servicePlanExample(commandPath, describeExample),
+		RunE:         runDescribe,
+		SilenceUsage: true,
+	}
 
-func init() {
-	describeCmd.Flags().StringP("environment", "", "", "Environment name. Use this flag with service name and plan name to describe the service plan in a specific environment")
-	describeCmd.Flags().StringP("output", "o", "json", "Output format. Only json is supported")
-	describeCmd.Flags().StringP("service-id", "", "", "Service ID. Required if service name is not provided")
-	describeCmd.Flags().StringP("plan-id", "", "", "Plan ID. Required if plan name is not provided")
+	cmd.Flags().StringP("environment", "", "", "Environment name. Use this flag with service name and plan name to describe the service plan in a specific environment")
+	cmd.Flags().StringP("output", "o", "json", "Output format. Only json is supported")
+	cmd.Flags().StringP("service-id", "", "", "Service ID. Required if service name is not provided")
+	cmd.Flags().StringP("plan-id", "", "", "Plan ID. Required if plan name is not provided")
+	return cmd
 }
 
 func runDescribe(cmd *cobra.Command, args []string) error {

--- a/cmd/serviceplan/describe_version.go
+++ b/cmd/serviceplan/describe_version.go
@@ -23,26 +23,27 @@ omnistrate-ctl service-plan describe-version [service-name] [plan-name] --versio
 omnistrate-ctl service-plan describe-version --service-id [service-id] --plan-id [plan-id] --version [version]`
 )
 
-var describeVersionCmd = &cobra.Command{
-	Use:          "describe-version [service-name] [plan-name] [flags]",
-	Short:        "Describe a specific version of a Service Plan",
-	Long:         `This command helps you get details of a specific version of a Service Plan for your service. You can get environment, enabled features, and resource configuration details for the version.`,
-	Example:      describeVersionExample,
-	RunE:         runDescribeVersion,
-	SilenceUsage: true,
-}
-
-func init() {
-	describeVersionCmd.Flags().StringP("version", "v", "", "Service plan version (latest|preferred|1.0 etc.)")
-	describeVersionCmd.Flags().StringP("environment", "", "", "Environment name. Use this flag with service name and plan name to describe the version in a specific environment")
-	describeVersionCmd.Flags().StringP("service-id", "", "", "Service ID. Required if service name is not provided")
-	describeVersionCmd.Flags().StringP("plan-id", "", "", "Plan ID. Required if plan name is not provided")
-	describeVersionCmd.Flags().StringP("output", "o", "json", "Output format. Only json is supported")
-
-	err := describeVersionCmd.MarkFlagRequired("version")
-	if err != nil {
-		return
+func newDescribeVersionCmd(commandPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "describe-version [service-name] [plan-name] [flags]",
+		Short:        "Describe a specific version of a Service Plan",
+		Long:         `This command helps you get details of a specific version of a Service Plan for your service. You can get environment, enabled features, and resource configuration details for the version.`,
+		Example:      servicePlanExample(commandPath, describeVersionExample),
+		RunE:         runDescribeVersion,
+		SilenceUsage: true,
 	}
+
+	cmd.Flags().StringP("version", "v", "", "Service plan version (latest|preferred|1.0 etc.)")
+	cmd.Flags().StringP("environment", "", "", "Environment name. Use this flag with service name and plan name to describe the version in a specific environment")
+	cmd.Flags().StringP("service-id", "", "", "Service ID. Required if service name is not provided")
+	cmd.Flags().StringP("plan-id", "", "", "Plan ID. Required if plan name is not provided")
+	cmd.Flags().StringP("output", "o", "json", "Output format. Only json is supported")
+
+	err := cmd.MarkFlagRequired("version")
+	if err != nil {
+		return cmd
+	}
+	return cmd
 }
 
 func runDescribeVersion(cmd *cobra.Command, args []string) error {

--- a/cmd/serviceplan/disable-feature.go
+++ b/cmd/serviceplan/disable-feature.go
@@ -20,21 +20,22 @@ omnistrate-ctl service-plan disable-feature [service-name] [plan-name] --feature
 omnistrate-ctl service-plan enable-feature --service-id [service-id] --plan-id [plan-id] --feature [feature-name]`
 )
 
-var disableCmd = &cobra.Command{
-	Use:          "disable-feature [service-name] [plan-name] [flags]",
-	Short:        "Disable feature for a service plan",
-	Long:         `This command helps you disable active service plan feature.`,
-	Example:      disableFeatureExample,
-	RunE:         runDisableFeature,
-	SilenceUsage: true,
-}
+func newDisableCmd(commandPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "disable-feature [service-name] [plan-name] [flags]",
+		Short:        "Disable feature for a service plan",
+		Long:         `This command helps you disable active service plan feature.`,
+		Example:      servicePlanExample(commandPath, disableFeatureExample),
+		RunE:         runDisableFeature,
+		SilenceUsage: true,
+	}
 
-func init() {
-	disableCmd.Flags().StringP(EnvironmentFlag, "", "", "Environment name. Use this flag with service name and plan name to describe the service plan in a specific environment")
-	disableCmd.Flags().StringP(ServiceIDFlag, "", "", "Service ID. Required if service name is not provided")
-	disableCmd.Flags().StringP(PlanIDFlag, "", "", "Plan ID. Required if plan name is not provided")
+	cmd.Flags().StringP(EnvironmentFlag, "", "", "Environment name. Use this flag with service name and plan name to describe the service plan in a specific environment")
+	cmd.Flags().StringP(ServiceIDFlag, "", "", "Service ID. Required if service name is not provided")
+	cmd.Flags().StringP(PlanIDFlag, "", "", "Plan ID. Required if plan name is not provided")
 
-	disableCmd.Flags().String(FeatureNameFlag, "", "Name / identifier of the feature to disable")
+	cmd.Flags().String(FeatureNameFlag, "", "Name / identifier of the feature to disable")
+	return cmd
 }
 
 func runDisableFeature(cmd *cobra.Command, args []string) error {

--- a/cmd/serviceplan/enable-feature.go
+++ b/cmd/serviceplan/enable-feature.go
@@ -19,26 +19,27 @@ omnistrate-ctl service-plan enable-feature [service-name] [plan-name] --feature 
 omnistrate-ctl service-plan enable-feature --service-id [service-id] --plan-id [plan-id] --feature [feature-name] --feature-configuration-file /path/to/feature-config-file.json`
 )
 
-var enableCmd = &cobra.Command{
-	Use:          "enable-feature [service-name] [plan-name] [flags]",
-	Short:        "Enable feature for a service plan",
-	Long:         `This command helps you enable & configure service plan features such as CUSTOM_TERRAFORM_POLICY.`,
-	Example:      enableFeatureExample,
-	RunE:         runEnableFeature,
-	SilenceUsage: true,
-}
-
-func init() {
-	enableCmd.Flags().StringP(EnvironmentFlag, "", "", "Environment name. Use this flag with service name and plan name to describe the service plan in a specific environment")
-	enableCmd.Flags().StringP(ServiceIDFlag, "", "", "Service ID. Required if service name is not provided")
-	enableCmd.Flags().StringP(PlanIDFlag, "", "", "Plan ID. Required if plan name is not provided")
-
-	enableCmd.Flags().String(FeatureNameFlag, "", "Name / identifier of the feature to enable")
-	enableCmd.Flags().String(FeatureConfigurationFlag, "", "Configuration of the feature")
-	enableCmd.Flags().String(FeatureConfigurationFileFlag, "", "Json file containing feature configuration")
-	if err := enableCmd.MarkFlagFilename(FeatureConfigurationFileFlag); err != nil {
-		return
+func newEnableCmd(commandPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "enable-feature [service-name] [plan-name] [flags]",
+		Short:        "Enable feature for a service plan",
+		Long:         `This command helps you enable & configure service plan features such as CUSTOM_TERRAFORM_POLICY.`,
+		Example:      servicePlanExample(commandPath, enableFeatureExample),
+		RunE:         runEnableFeature,
+		SilenceUsage: true,
 	}
+
+	cmd.Flags().StringP(EnvironmentFlag, "", "", "Environment name. Use this flag with service name and plan name to describe the service plan in a specific environment")
+	cmd.Flags().StringP(ServiceIDFlag, "", "", "Service ID. Required if service name is not provided")
+	cmd.Flags().StringP(PlanIDFlag, "", "", "Plan ID. Required if plan name is not provided")
+
+	cmd.Flags().String(FeatureNameFlag, "", "Name / identifier of the feature to enable")
+	cmd.Flags().String(FeatureConfigurationFlag, "", "Configuration of the feature")
+	cmd.Flags().String(FeatureConfigurationFileFlag, "", "Json file containing feature configuration")
+	if err := cmd.MarkFlagFilename(FeatureConfigurationFileFlag); err != nil {
+		return cmd
+	}
+	return cmd
 }
 
 func runEnableFeature(cmd *cobra.Command, args []string) error {

--- a/cmd/serviceplan/list.go
+++ b/cmd/serviceplan/list.go
@@ -21,22 +21,30 @@ omnistrate-ctl service-plan list -f="service_name:postgres,environment:prod" -f=
 	defaultMaxNameLength = 30 // Maximum length of the name column in the table
 )
 
-var listCmd = &cobra.Command{
-	Use:   "list [flags]",
-	Short: "List Service Plans for your service",
-	Long: `This command helps you list Service Plans for your service.
+func newListCmd(cfg servicePlanCommandConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list [flags]",
+		Short: "List Service Plans for your service",
+		Long: `This command helps you list Service Plans for your service.
 You can filter for specific service plans by using the filter flag.`,
-	Example:      listExample,
-	RunE:         runList,
-	SilenceUsage: true,
-}
+		Example:      servicePlanExample(cfg.commandPath, listExample),
+		RunE:         runList,
+		SilenceUsage: true,
+	}
 
-func init() {
+	if cfg.listBrowserDefault {
+		cmd.Annotations = map[string]string{"serviceplan-list-browser-default": "true"}
+	}
 
-	listCmd.Flags().StringArrayP("filter", "f", []string{}, "Filter to apply to the list of service plans. E.g.: key1:value1,key2:value2, which filters service plans where key1 equals value1 and key2 equals value2. Allow use of multiple filters to form the logical OR operation. Supported keys: "+strings.Join(utils.GetSupportedFilterKeys(model.ServicePlanVersion{}), ",")+". Check the examples for more details.")
-	listCmd.Flags().Bool("truncate", false, "Truncate long names in the output")
-	listCmd.Flags().BoolP("interactive", "i", false, "Launch interactive list with fuzzy search and selection")
-	listCmd.Args = cobra.NoArgs
+	cmd.Flags().StringArrayP("filter", "f", []string{}, "Filter to apply to the list of service plans. E.g.: key1:value1,key2:value2, which filters service plans where key1 equals value1 and key2 equals value2. Allow use of multiple filters to form the logical OR operation. Supported keys: "+strings.Join(utils.GetSupportedFilterKeys(model.ServicePlanVersion{}), ",")+". Check the examples for more details.")
+	cmd.Flags().Bool("truncate", false, "Truncate long names in the output")
+	interactiveDescription := "Launch interactive list with fuzzy search and selection"
+	if cfg.listBrowserDefault {
+		interactiveDescription = "Launch interactive plan browser"
+	}
+	cmd.Flags().BoolP("interactive", "i", false, interactiveDescription)
+	cmd.Args = cobra.NoArgs
+	return cmd
 }
 
 func runList(cmd *cobra.Command, args []string) error {
@@ -65,7 +73,7 @@ func runList(cmd *cobra.Command, args []string) error {
 	// Initialize spinner if output is not JSON and not interactive
 	var sm utils.SpinnerManager
 	var spinner *utils.Spinner
-	if output != "json" && !interactive {
+	if output != "json" && !shouldRunPlanBrowser(cmd, output, interactive) {
 		sm = utils.NewSpinnerManager()
 		spinner = sm.AddSpinner("Listing service plans...")
 		sm.Start()
@@ -78,25 +86,10 @@ func runList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var formattedServicePlans []model.ServicePlan
-
-	// Process and filter service plans
-	for _, service := range listRes.Services {
-		for _, env := range service.ServiceEnvironments {
-			for _, servicePlan := range env.ServicePlans {
-				formattedServicePlan := formatServicePlan(service.Id, service.Name, env.Name, servicePlan, truncateNames)
-
-				match, err := utils.MatchesFilters(formattedServicePlan, filterMaps)
-				if err != nil {
-					utils.HandleSpinnerError(spinner, sm, err)
-					return err
-				}
-
-				if match {
-					formattedServicePlans = append(formattedServicePlans, formattedServicePlan)
-				}
-			}
-		}
+	formattedServicePlans, err := formatServicePlansFromServices(listRes.Services, filterMaps, truncateNames)
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
 	}
 
 	// Handle case when no service plans match
@@ -104,6 +97,11 @@ func runList(cmd *cobra.Command, args []string) error {
 		utils.HandleSpinnerSuccess(spinner, sm, "No service plans found.")
 	} else {
 		utils.HandleSpinnerSuccess(spinner, sm, "Service plans retrieved successfully.")
+	}
+
+	if shouldRunPlanBrowser(cmd, output, interactive) {
+		catalog := buildServicePlanBrowserCatalog(listRes.Services, filterMaps)
+		return runServicePlanBrowser(cmd.Context(), token, catalog)
 	}
 
 	// Interactive mode
@@ -154,6 +152,33 @@ func runInteractiveServicePlanList(plans []model.ServicePlan) error {
 }
 
 // Helper functions
+
+func shouldRunPlanBrowser(cmd *cobra.Command, output string, interactive bool) bool {
+	return output != "json" && (interactive || cmd.Annotations["serviceplan-list-browser-default"] == "true")
+}
+
+func formatServicePlansFromServices(services []openapiclient.DescribeServiceResult, filterMaps []map[string]string, truncateNames bool) ([]model.ServicePlan, error) {
+	var formattedServicePlans []model.ServicePlan
+
+	for _, service := range services {
+		for _, env := range service.ServiceEnvironments {
+			for _, servicePlan := range env.ServicePlans {
+				formattedServicePlan := formatServicePlan(service.Id, service.Name, env.Name, servicePlan, truncateNames)
+
+				match, err := utils.MatchesFilters(formattedServicePlan, filterMaps)
+				if err != nil {
+					return nil, err
+				}
+
+				if match {
+					formattedServicePlans = append(formattedServicePlans, formattedServicePlan)
+				}
+			}
+		}
+	}
+
+	return formattedServicePlans, nil
+}
 
 func formatServicePlan(serviceID, serviceName, envName string, servicePlan openapiclient.ServicePlan, truncateNames bool) model.ServicePlan {
 	planName := servicePlan.Name

--- a/cmd/serviceplan/list_versions.go
+++ b/cmd/serviceplan/list_versions.go
@@ -21,29 +21,30 @@ const (
 omnistrate-ctl service-plan list-versions postgres postgres -f="service_name:postgres,environment:prod" -f="service:postgres,environment:dev"`
 )
 
-var listVersionsCmd = &cobra.Command{
-	Use:   "list-versions [service-name] [plan-name] [flags]",
-	Short: "List Versions of a specific Service Plan",
-	Long: `This command helps you list Versions of a specific Service Plan.
+func newListVersionsCmd(commandPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "list-versions [service-name] [plan-name] [flags]",
+		Short: "List Versions of a specific Service Plan",
+		Long: `This command helps you list Versions of a specific Service Plan.
 You can filter for specific service plan versions by using the filter flag.`,
-	Example:      listVersionsExample,
-	RunE:         runListVersions,
-	SilenceUsage: true,
-}
-
-func init() {
-	listVersionsCmd.Flags().StringP("service-id", "", "", "Service ID. Required if service name is not provided")
-	listVersionsCmd.Flags().StringP("plan-id", "", "", "Plan ID. Required if plan name is not provided")
-	listVersionsCmd.Flags().IntP("limit", "", -1, "List only the latest N service plan versions")
-	listVersionsCmd.Flags().IntP("latest-n", "", -1, "List only the latest N service plan versions")
-	listVersionsCmd.Flags().StringP("environment", "", "", "Environment name. Use this flag with service name and plan name to describe the version in a specific environment")
-
-	listVersionsCmd.Flags().StringArrayP("filter", "f", []string{}, "Filter to apply to the list of service plan versions. E.g.: key1:value1,key2:value2, which filters service plans where key1 equals value1 and key2 equals value2. Allow use of multiple filters to form the logical OR operation. Supported keys: "+strings.Join(utils.GetSupportedFilterKeys(model.ServicePlanVersion{}), ",")+". Check the examples for more details.")
-	listVersionsCmd.Flags().Bool("truncate", false, "Truncate long names in the output")
-	err := listVersionsCmd.Flags().MarkHidden("latest-n")
-	if err != nil {
-		return
+		Example:      servicePlanExample(commandPath, listVersionsExample),
+		RunE:         runListVersions,
+		SilenceUsage: true,
 	}
+
+	cmd.Flags().StringP("service-id", "", "", "Service ID. Required if service name is not provided")
+	cmd.Flags().StringP("plan-id", "", "", "Plan ID. Required if plan name is not provided")
+	cmd.Flags().IntP("limit", "", -1, "List only the latest N service plan versions")
+	cmd.Flags().IntP("latest-n", "", -1, "List only the latest N service plan versions")
+	cmd.Flags().StringP("environment", "", "", "Environment name. Use this flag with service name and plan name to describe the version in a specific environment")
+
+	cmd.Flags().StringArrayP("filter", "f", []string{}, "Filter to apply to the list of service plan versions. E.g.: key1:value1,key2:value2, which filters service plans where key1 equals value1 and key2 equals value2. Allow use of multiple filters to form the logical OR operation. Supported keys: "+strings.Join(utils.GetSupportedFilterKeys(model.ServicePlanVersion{}), ",")+". Check the examples for more details.")
+	cmd.Flags().Bool("truncate", false, "Truncate long names in the output")
+	err := cmd.Flags().MarkHidden("latest-n")
+	if err != nil {
+		return cmd
+	}
+	return cmd
 }
 
 func runListVersions(cmd *cobra.Command, args []string) error {

--- a/cmd/serviceplan/release.go
+++ b/cmd/serviceplan/release.go
@@ -21,23 +21,24 @@ omnistrate-ctl service-plan release [service-name] [plan-name]
 omnistrate-ctl service-plan release --service-id=[service-id] --plan-id=[plan-id]`
 )
 
-var releaseCmd = &cobra.Command{
-	Use:          "release [service-name] [plan-name] [flags]",
-	Short:        "Release a Service Plan",
-	Long:         `This command helps you release a Service Plan for your service. You can specify a custom release description and set the service plan as preferred if needed.`,
-	Example:      releaseExample,
-	RunE:         runRelease,
-	SilenceUsage: true,
-}
+func newReleaseCmd(commandPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "release [service-name] [plan-name] [flags]",
+		Short:        "Release a Service Plan",
+		Long:         `This command helps you release a Service Plan for your service. You can specify a custom release description and set the service plan as preferred if needed.`,
+		Example:      servicePlanExample(commandPath, releaseExample),
+		RunE:         runRelease,
+		SilenceUsage: true,
+	}
 
-func init() {
-	releaseCmd.Flags().String("release-description", "", "Set custom release description for this release version")
-	releaseCmd.Flags().Bool("release-as-preferred", false, "Release the service plan as preferred")
-	releaseCmd.Flags().Bool("dryrun", false, "Perform a dry run without making any changes")
-	releaseCmd.Flags().StringP("environment", "", "", "Environment name. Use this flag with service name and plan name to release the service plan in a specific environment")
+	cmd.Flags().String("release-description", "", "Set custom release description for this release version")
+	cmd.Flags().Bool("release-as-preferred", false, "Release the service plan as preferred")
+	cmd.Flags().Bool("dryrun", false, "Perform a dry run without making any changes")
+	cmd.Flags().StringP("environment", "", "", "Environment name. Use this flag with service name and plan name to release the service plan in a specific environment")
 
-	releaseCmd.Flags().StringP("service-id", "", "", "Service ID. Required if service name is not provided")
-	releaseCmd.Flags().StringP("plan-id", "", "", "Plan ID. Required if plan name is not provided")
+	cmd.Flags().StringP("service-id", "", "", "Service ID. Required if service name is not provided")
+	cmd.Flags().StringP("plan-id", "", "", "Plan ID. Required if plan name is not provided")
+	return cmd
 }
 
 func runRelease(cmd *cobra.Command, args []string) error {

--- a/cmd/serviceplan/serviceplan.go
+++ b/cmd/serviceplan/serviceplan.go
@@ -1,28 +1,68 @@
 package serviceplan
 
 import (
+	"strings"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
 	"github.com/spf13/cobra"
 )
 
-var Cmd = &cobra.Command{
-	Use:          "service-plan [operation] [flags]",
-	Short:        "Manage Service Plans for your service",
-	Long:         `This command helps you manage the service plans for your service.`,
-	Run:          run,
-	SilenceUsage: true,
+const (
+	legacyServicePlanCommandPath = "service-plan"
+	nestedServicePlanCommandPath = "service plan"
+	servicePlanDeprecationNotice = "`service-plan` is deprecated; use `service plan` instead."
+)
+
+type servicePlanCommandConfig struct {
+	commandPath        string
+	use                string
+	legacyNotice       bool
+	listBrowserDefault bool
 }
 
-func init() {
-	Cmd.AddCommand(deleteCmd)
-	Cmd.AddCommand(releaseCmd)
-	Cmd.AddCommand(setDefaultCmd)
-	Cmd.AddCommand(describeCmd)
-	Cmd.AddCommand(describeVersionCmd)
-	Cmd.AddCommand(listCmd)
-	Cmd.AddCommand(listVersionsCmd)
-	Cmd.AddCommand(enableCmd)
-	Cmd.AddCommand(disableCmd)
-	Cmd.AddCommand(updateCmd)
+var Cmd = NewLegacyCommand()
+
+func NewLegacyCommand() *cobra.Command {
+	return newCommand(servicePlanCommandConfig{
+		commandPath:  legacyServicePlanCommandPath,
+		use:          "service-plan [operation] [flags]",
+		legacyNotice: true,
+	})
+}
+
+func NewNestedCommand() *cobra.Command {
+	return newCommand(servicePlanCommandConfig{
+		commandPath:        nestedServicePlanCommandPath,
+		use:                "plan [operation] [flags]",
+		listBrowserDefault: true,
+	})
+}
+
+func newCommand(cfg servicePlanCommandConfig) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          cfg.use,
+		Short:        "Manage Service Plans for your service",
+		Long:         `This command helps you manage the service plans for your service.`,
+		Run:          run,
+		SilenceUsage: true,
+	}
+
+	if cfg.legacyNotice {
+		cmd.PersistentPreRun = runLegacyNotice
+	}
+
+	cmd.AddCommand(newDeleteCmd(cfg.commandPath))
+	cmd.AddCommand(newReleaseCmd(cfg.commandPath))
+	cmd.AddCommand(newSetDefaultCmd(cfg.commandPath))
+	cmd.AddCommand(newDescribeCmd(cfg.commandPath))
+	cmd.AddCommand(newDescribeVersionCmd(cfg.commandPath))
+	cmd.AddCommand(newListCmd(cfg))
+	cmd.AddCommand(newListVersionsCmd(cfg.commandPath))
+	cmd.AddCommand(newEnableCmd(cfg.commandPath))
+	cmd.AddCommand(newDisableCmd(cfg.commandPath))
+	cmd.AddCommand(newUpdateCmd(cfg.commandPath))
+
+	return cmd
 }
 
 func run(cmd *cobra.Command, args []string) {
@@ -30,4 +70,19 @@ func run(cmd *cobra.Command, args []string) {
 	if err != nil {
 		return
 	}
+}
+
+func runLegacyNotice(cmd *cobra.Command, args []string) {
+	output, _ := cmd.Flags().GetString(OutputFlag)
+	if shouldPrintLegacyServicePlanNotice(output) {
+		utils.PrintWarning(servicePlanDeprecationNotice)
+	}
+}
+
+func shouldPrintLegacyServicePlanNotice(output string) bool {
+	return output != "json"
+}
+
+func servicePlanExample(commandPath, example string) string {
+	return strings.ReplaceAll(example, "omnistrate-ctl service-plan", "omnistrate-ctl "+commandPath)
 }

--- a/cmd/serviceplan/serviceplan_test.go
+++ b/cmd/serviceplan/serviceplan_test.go
@@ -1,13 +1,60 @@
 package serviceplan
 
 import (
+	"sort"
+	"testing"
+
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
 	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
-
-	"testing"
+	"github.com/spf13/cobra"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestNewNestedCommandMirrorsLegacySubcommands(t *testing.T) {
+	legacy := NewLegacyCommand()
+	nested := NewNestedCommand()
+
+	require.Equal(t, "service-plan [operation] [flags]", legacy.Use)
+	require.Equal(t, "plan [operation] [flags]", nested.Use)
+	require.Equal(t, commandNames(legacy), commandNames(nested))
+	require.NotNil(t, legacy.PersistentPreRun)
+	require.Nil(t, nested.PersistentPreRun)
+}
+
+func TestServicePlanListCommandModes(t *testing.T) {
+	legacyList := newListCmd(servicePlanCommandConfig{commandPath: legacyServicePlanCommandPath})
+	nestedList := newListCmd(servicePlanCommandConfig{commandPath: nestedServicePlanCommandPath, listBrowserDefault: true})
+
+	require.False(t, shouldRunPlanBrowser(legacyList, "table", false))
+	require.True(t, shouldRunPlanBrowser(legacyList, "table", true))
+	require.False(t, shouldRunPlanBrowser(nestedList, "json", false))
+	require.True(t, shouldRunPlanBrowser(nestedList, "table", false))
+
+	interactiveFlag := nestedList.Flags().Lookup("interactive")
+	require.NotNil(t, interactiveFlag)
+	require.Equal(t, "false", interactiveFlag.DefValue)
+
+	filterFlag := nestedList.Flags().Lookup("filter")
+	require.NotNil(t, filterFlag)
+	require.Equal(t, "f", filterFlag.Shorthand)
+}
+
+func TestLegacyServicePlanNoticeOnlyForNonJSON(t *testing.T) {
+	require.False(t, shouldPrintLegacyServicePlanNotice("json"))
+	require.True(t, shouldPrintLegacyServicePlanNotice("table"))
+	require.True(t, shouldPrintLegacyServicePlanNotice("text"))
+}
+
+func commandNames(cmd interface{ Commands() []*cobra.Command }) []string {
+	commands := cmd.Commands()
+	names := make([]string, 0, len(commands))
+	for _, command := range commands {
+		names = append(names, command.Name())
+	}
+	sort.Strings(names)
+	return names
+}
 
 func TestFilterLatestNVersions(t *testing.T) {
 	require := require.New(t)

--- a/cmd/serviceplan/setdefault.go
+++ b/cmd/serviceplan/setdefault.go
@@ -23,26 +23,27 @@ omnistrate-ctl service-plan set-default [service-name] [plan-name] --version=[ve
 omnistrate-ctl service-plan set-default --service-id=[service-id] --plan-id=[plan-id] --version=[version]`
 )
 
-var setDefaultCmd = &cobra.Command{
-	Use:   "set-default [service-name] [plan-name] --version=[version] [flags]",
-	Short: "Set a Version of a Service Plan as Default(Preferred)",
-	Long: `This command helps you set a Version of a Service Plan as the default (preferred) version for your service.
+func newSetDefaultCmd(commandPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "set-default [service-name] [plan-name] --version=[version] [flags]",
+		Short: "Set a Version of a Service Plan as Default(Preferred)",
+		Long: `This command helps you set a Version of a Service Plan as the default (preferred) version for your service.
 By setting it as default, new instance deployments from your customers will be created with this version by default.`,
-	Example:      setDefaultExample,
-	RunE:         runSetDefault,
-	SilenceUsage: true,
-}
-
-func init() {
-	setDefaultCmd.Flags().String("version", "", "Specify the version number to set the default to. Use 'latest' to set the latest version as default.")
-	setDefaultCmd.Flags().StringP("environment", "", "", "Environment name. Use this flag with service name and plan name to set the default version in a specific environment")
-	setDefaultCmd.Flags().StringP("service-id", "", "", "Service ID. Required if service name is not provided")
-	setDefaultCmd.Flags().StringP("plan-id", "", "", "Plan ID. Required if plan name is not provided")
-
-	err := setDefaultCmd.MarkFlagRequired("version")
-	if err != nil {
-		return
+		Example:      servicePlanExample(commandPath, setDefaultExample),
+		RunE:         runSetDefault,
+		SilenceUsage: true,
 	}
+
+	cmd.Flags().String("version", "", "Specify the version number to set the default to. Use 'latest' to set the latest version as default.")
+	cmd.Flags().StringP("environment", "", "", "Environment name. Use this flag with service name and plan name to set the default version in a specific environment")
+	cmd.Flags().StringP("service-id", "", "", "Service ID. Required if service name is not provided")
+	cmd.Flags().StringP("plan-id", "", "", "Plan ID. Required if plan name is not provided")
+
+	err := cmd.MarkFlagRequired("version")
+	if err != nil {
+		return cmd
+	}
+	return cmd
 }
 
 func runSetDefault(cmd *cobra.Command, args []string) error {

--- a/cmd/serviceplan/update.go
+++ b/cmd/serviceplan/update.go
@@ -20,32 +20,33 @@ omnistrate-ctl service-plan update [service-name] [plan-name] --version=[version
 omnistrate-ctl service-plan update --service-id=[service-id] --plan-id=[plan-id] --version=[version] --name=[new-name]`
 )
 
-var updateCmd = &cobra.Command{
-	Use:   "update [service-name] [plan-name] --version=[version] --name=[new-name] [flags]",
-	Short: "Update Service Plan properties",
-	Long: `This command helps you update various properties of a Service Plan.
+func newUpdateCmd(commandPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "update [service-name] [plan-name] --version=[version] --name=[new-name] [flags]",
+		Short: "Update Service Plan properties",
+		Long: `This command helps you update various properties of a Service Plan.
 Currently supports updating the name of a specific version of a Service Plan.
 The version name is used as the release description for the version.`,
-	Example:      updateExample,
-	RunE:         runUpdate,
-	SilenceUsage: true,
-}
-
-func init() {
-	updateCmd.Flags().String("version", "", "Specify the version number to update the name for.")
-	updateCmd.Flags().String("name", "", "Specify the new name for the version.")
-	updateCmd.Flags().StringP("environment", "", "", "Environment name. Use this flag with service name and plan name to update the version name in a specific environment")
-	updateCmd.Flags().StringP("service-id", "", "", "Service ID. Required if service name is not provided")
-	updateCmd.Flags().StringP("plan-id", "", "", "Plan ID. Required if plan name is not provided")
-
-	err := updateCmd.MarkFlagRequired("version")
-	if err != nil {
-		return
+		Example:      servicePlanExample(commandPath, updateExample),
+		RunE:         runUpdate,
+		SilenceUsage: true,
 	}
-	err = updateCmd.MarkFlagRequired("name")
+
+	cmd.Flags().String("version", "", "Specify the version number to update the name for.")
+	cmd.Flags().String("name", "", "Specify the new name for the version.")
+	cmd.Flags().StringP("environment", "", "", "Environment name. Use this flag with service name and plan name to update the version name in a specific environment")
+	cmd.Flags().StringP("service-id", "", "", "Service ID. Required if service name is not provided")
+	cmd.Flags().StringP("plan-id", "", "", "Plan ID. Required if plan name is not provided")
+
+	err := cmd.MarkFlagRequired("version")
 	if err != nil {
-		return
+		return cmd
 	}
+	err = cmd.MarkFlagRequired("name")
+	if err != nil {
+		return cmd
+	}
+	return cmd
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {

--- a/internal/dataaccess/customer.go
+++ b/internal/dataaccess/customer.go
@@ -1,0 +1,200 @@
+package dataaccess
+
+import (
+	"context"
+	"strings"
+
+	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
+)
+
+type CustomerUserCreateRequest struct {
+	Email                  string
+	Name                   string
+	password               string
+	LegalCompanyName       string
+	CompanyURL             string
+	EnableAutoVerification bool
+	Attributes             map[string]string
+}
+
+type CustomerUserUpdateRequest struct {
+	Attributes map[string]string
+}
+
+type CustomerUserListOptions struct {
+	NextPageToken string
+	PageSize      int64
+	ExcludeStats  bool
+}
+
+func NewCustomerUserCreateRequest(email, name, password, legalCompanyName, companyURL string, enableAutoVerification bool, attributes map[string]string) CustomerUserCreateRequest {
+	return CustomerUserCreateRequest{
+		Email:                  email,
+		Name:                   name,
+		password:               password,
+		LegalCompanyName:       legalCompanyName,
+		CompanyURL:             companyURL,
+		EnableAutoVerification: enableAutoVerification,
+		Attributes:             attributes,
+	}
+}
+
+func CreateCustomerUser(ctx context.Context, token string, req CustomerUserCreateRequest) (string, error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	body := openapiclientfleet.FleetCreateConsumptionUserRequest2{
+		Email:                  req.Email,
+		EnableAutoVerification: req.EnableAutoVerification,
+		LegalCompanyName:       req.LegalCompanyName,
+		Name:                   req.Name,
+		Password:               req.password,
+	}
+	if strings.TrimSpace(req.CompanyURL) != "" {
+		body.CompanyUrl = &req.CompanyURL
+	}
+	if len(req.Attributes) > 0 {
+		body.Attributes = &req.Attributes
+	}
+
+	resp, r, err := apiClient.InventoryApiAPI.InventoryApiCreateConsumptionUser(ctxWithToken).
+		FleetCreateConsumptionUserRequest2(body).
+		Execute()
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+	if err != nil {
+		return "", handleFleetError(err)
+	}
+	return cleanupId(resp), nil
+}
+
+func ListCustomerUsers(ctx context.Context, token string, opts CustomerUserListOptions) (*openapiclientfleet.FleetListAllUsersResult, error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.InventoryApiAPI.InventoryApiListAllUsers(ctxWithToken).
+		ExcludeStats(opts.ExcludeStats)
+	if opts.NextPageToken != "" {
+		req = req.NextPageToken(opts.NextPageToken)
+	}
+	if opts.PageSize > 0 {
+		req = req.PageSize(opts.PageSize)
+	}
+
+	resp, r, err := req.Execute()
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+	if err != nil {
+		return nil, handleFleetError(err)
+	}
+	return resp, nil
+}
+
+func DescribeCustomerUser(ctx context.Context, token, userID string) (*openapiclientfleet.FleetDescribeUserResult, error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	resp, r, err := apiClient.InventoryApiAPI.InventoryApiDescribeOrgUser(ctxWithToken, userID).Execute()
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+	if err != nil {
+		return nil, handleFleetError(err)
+	}
+	return resp, nil
+}
+
+func UpdateCustomerUser(ctx context.Context, token, userID string, req CustomerUserUpdateRequest) error {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	body := openapiclientfleet.FleetUpdateConsumptionUserRequest2{}
+	if len(req.Attributes) > 0 {
+		body.Attributes = &req.Attributes
+	}
+
+	r, err := apiClient.InventoryApiAPI.InventoryApiUpdateConsumptionUser(ctxWithToken, userID).
+		FleetUpdateConsumptionUserRequest2(body).
+		Execute()
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+	if err != nil {
+		return handleFleetError(err)
+	}
+	return nil
+}
+
+func DeleteCustomerUser(ctx context.Context, token, userID string) error {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	r, err := apiClient.InventoryApiAPI.InventoryApiDeleteUser(ctxWithToken, userID).Execute()
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+	if err != nil {
+		return handleFleetError(err)
+	}
+	return nil
+}
+
+func SendCustomerUserVerificationEmail(ctx context.Context, token, userID string) error {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	r, err := apiClient.InventoryApiAPI.InventoryApiResendVerificationEmail(ctxWithToken, userID).Execute()
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+	if err != nil {
+		return handleFleetError(err)
+	}
+	return nil
+}
+
+func SuspendCustomerUser(ctx context.Context, token, userID string) error {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	r, err := apiClient.InventoryApiAPI.InventoryApiSuspendUser(ctxWithToken, userID).Execute()
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+	if err != nil {
+		return handleFleetError(err)
+	}
+	return nil
+}
+
+func UnsuspendCustomerUser(ctx context.Context, token, userID string) error {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	r, err := apiClient.InventoryApiAPI.InventoryApiUnsuspendUser(ctxWithToken, userID).Execute()
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+	if err != nil {
+		return handleFleetError(err)
+	}
+	return nil
+}

--- a/internal/dataaccess/resourceinstance.go
+++ b/internal/dataaccess/resourceinstance.go
@@ -108,8 +108,17 @@ func DescribeResourceInstanceSnapshot(ctx context.Context, token string, service
 
 // ListResourceInstanceOptions contains all optional parameters for ListResourceInstance
 type ListResourceInstanceOptions struct {
-	Filter        *string
-	ProductTierId *string
+	Filter                  *string
+	ProductTierId           *string
+	ProductTierVersion      *string
+	SubscriptionId          *string
+	ExcludeDetail           *bool
+	ExcludeNetworkTopology  *bool
+	ExcludeHAStatus         *bool
+	ExcludeIntegrations     *bool
+	ExcludeMaintenanceTasks *bool
+	NextPageToken           string
+	PageSize                *int64
 }
 
 func ListResourceInstance(ctx context.Context, token string, serviceID, environmentID string, options *ListResourceInstanceOptions) (res *openapiclientfleet.ListFleetResourceInstancesResultInternal, err error) {
@@ -130,6 +139,33 @@ func ListResourceInstance(ctx context.Context, token string, serviceID, environm
 		if options.ProductTierId != nil {
 			req = req.ProductTierId(*options.ProductTierId)
 		}
+		if options.ProductTierVersion != nil {
+			req = req.ProductTierVersion(*options.ProductTierVersion)
+		}
+		if options.SubscriptionId != nil {
+			req = req.SubscriptionId(*options.SubscriptionId)
+		}
+		if options.ExcludeDetail != nil {
+			req = req.ExcludeDetail(*options.ExcludeDetail)
+		}
+		if options.ExcludeNetworkTopology != nil {
+			req = req.ExcludeNetworkTopology(*options.ExcludeNetworkTopology)
+		}
+		if options.ExcludeHAStatus != nil {
+			req = req.ExcludeHAStatus(*options.ExcludeHAStatus)
+		}
+		if options.ExcludeIntegrations != nil {
+			req = req.ExcludeIntegrations(*options.ExcludeIntegrations)
+		}
+		if options.ExcludeMaintenanceTasks != nil {
+			req = req.ExcludeMaintenanceTasks(*options.ExcludeMaintenanceTasks)
+		}
+		if options.NextPageToken != "" {
+			req = req.NextPageToken(options.NextPageToken)
+		}
+		if options.PageSize != nil {
+			req = req.PageSize(*options.PageSize)
+		}
 	}
 
 	var r *http.Response
@@ -144,6 +180,29 @@ func ListResourceInstance(ctx context.Context, token string, serviceID, environm
 		return nil, handleFleetError(err)
 	}
 	return
+}
+
+func ListAllResourceInstances(ctx context.Context, token string, serviceID, environmentID string, options *ListResourceInstanceOptions) (instances []openapiclientfleet.ResourceInstance, err error) {
+	var nextPageToken string
+
+	for {
+		pageOptions := ListResourceInstanceOptions{}
+		if options != nil {
+			pageOptions = *options
+		}
+		pageOptions.NextPageToken = nextPageToken
+
+		res, err := ListResourceInstance(ctx, token, serviceID, environmentID, &pageOptions)
+		if err != nil {
+			return nil, err
+		}
+		instances = append(instances, res.GetResourceInstances()...)
+
+		nextPageToken = res.GetNextPageToken()
+		if nextPageToken == "" {
+			return instances, nil
+		}
+	}
 }
 
 func ListResourceInstanceSnapshots(ctx context.Context, token string, serviceID, environmentID, instanceID string) (res *openapiclientfleet.FleetListInstanceSnapshotResult, err error) {

--- a/internal/dataaccess/subscription.go
+++ b/internal/dataaccess/subscription.go
@@ -118,7 +118,20 @@ func GetSubscriptionByCustomerEmailInEnvironment(
 	return resp, nil
 }
 
+type ListSubscriptionsOptions struct {
+	ProductTierId   *string
+	IncludeInactive *bool
+	ExcludePricing  *bool
+	ExcludeStats    *bool
+	NextPageToken   string
+	PageSize        *int64
+}
+
 func ListSubscriptions(ctx context.Context, token string, serviceID, environmentID string) (resp *openapiclientfleet.FleetListSubscriptionsResult, err error) {
+	return ListSubscriptionsWithOptions(ctx, token, serviceID, environmentID, nil)
+}
+
+func ListSubscriptionsWithOptions(ctx context.Context, token string, serviceID, environmentID string, opts *ListSubscriptionsOptions) (resp *openapiclientfleet.FleetListSubscriptionsResult, err error) {
 	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
 	apiClient := getFleetClient()
 
@@ -127,6 +140,27 @@ func ListSubscriptions(ctx context.Context, token string, serviceID, environment
 		serviceID,
 		environmentID,
 	)
+
+	if opts != nil {
+		if opts.ProductTierId != nil {
+			req = req.ProductTierId(*opts.ProductTierId)
+		}
+		if opts.IncludeInactive != nil {
+			req = req.IncludeInactive(*opts.IncludeInactive)
+		}
+		if opts.ExcludePricing != nil {
+			req = req.ExcludePricing(*opts.ExcludePricing)
+		}
+		if opts.ExcludeStats != nil {
+			req = req.ExcludeStats(*opts.ExcludeStats)
+		}
+		if opts.NextPageToken != "" {
+			req = req.NextPageToken(opts.NextPageToken)
+		}
+		if opts.PageSize != nil {
+			req = req.PageSize(*opts.PageSize)
+		}
+	}
 
 	var r *http.Response
 	defer func() {
@@ -140,6 +174,98 @@ func ListSubscriptions(ctx context.Context, token string, serviceID, environment
 		return nil, handleFleetError(err)
 	}
 	return
+}
+
+func ListAllSubscriptions(ctx context.Context, token string, serviceID, environmentID string, opts *ListSubscriptionsOptions) (subscriptions []openapiclientfleet.FleetDescribeSubscriptionResult, err error) {
+	var nextPageToken string
+
+	for {
+		pageOptions := ListSubscriptionsOptions{}
+		if opts != nil {
+			pageOptions = *opts
+		}
+		pageOptions.NextPageToken = nextPageToken
+
+		res, err := ListSubscriptionsWithOptions(ctx, token, serviceID, environmentID, &pageOptions)
+		if err != nil {
+			return nil, err
+		}
+		subscriptions = append(subscriptions, res.GetSubscriptions()...)
+
+		nextPageToken = res.GetNextPageToken()
+		if nextPageToken == "" {
+			return subscriptions, nil
+		}
+	}
+}
+
+type ListUsersOptions struct {
+	NextPageToken  string
+	PageSize       *int64
+	SubscriptionId *string
+	ExcludeStats   *bool
+}
+
+func ListUsers(ctx context.Context, token string, serviceID, environmentID string, opts *ListUsersOptions) (resp *openapiclientfleet.FleetListUsersResult, err error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.InventoryApiAPI.InventoryApiListUsers(
+		ctxWithToken,
+		serviceID,
+		environmentID,
+	)
+
+	if opts != nil {
+		if opts.NextPageToken != "" {
+			req = req.NextPageToken(opts.NextPageToken)
+		}
+		if opts.PageSize != nil {
+			req = req.PageSize(*opts.PageSize)
+		}
+		if opts.SubscriptionId != nil {
+			req = req.SubscriptionId(*opts.SubscriptionId)
+		}
+		if opts.ExcludeStats != nil {
+			req = req.ExcludeStats(*opts.ExcludeStats)
+		}
+	}
+
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	resp, r, err = req.Execute()
+	if err != nil {
+		return nil, handleFleetError(err)
+	}
+	return
+}
+
+func ListAllUsers(ctx context.Context, token string, serviceID, environmentID string, opts *ListUsersOptions) (users []openapiclientfleet.User, err error) {
+	var nextPageToken string
+
+	for {
+		pageOptions := ListUsersOptions{}
+		if opts != nil {
+			pageOptions = *opts
+		}
+		pageOptions.NextPageToken = nextPageToken
+
+		res, err := ListUsers(ctx, token, serviceID, environmentID, &pageOptions)
+		if err != nil {
+			return nil, err
+		}
+		users = append(users, res.GetUsers()...)
+
+		nextPageToken = res.GetNextPageToken()
+		if nextPageToken == "" {
+			return users, nil
+		}
+	}
 }
 
 func ListSubscriptionRequests(ctx context.Context, token string, serviceID, environmentID string) (resp *openapiclientfleet.ListSubscriptionRequestsResult, err error) {

--- a/internal/model/customer.go
+++ b/internal/model/customer.go
@@ -1,0 +1,14 @@
+package model
+
+type CustomerUser struct {
+	UserID            string `json:"user_id"`
+	UserName          string `json:"user_name"`
+	Email             string `json:"email"`
+	Status            string `json:"status"`
+	Enabled           string `json:"enabled"`
+	OrgID             string `json:"org_id"`
+	OrgName           string `json:"org_name"`
+	SubscriptionCount string `json:"subscription_count,omitempty"`
+	InstanceCount     string `json:"instance_count,omitempty"`
+	CreatedAt         string `json:"created_at,omitempty"`
+}

--- a/internal/utils/spinner.go
+++ b/internal/utils/spinner.go
@@ -16,6 +16,7 @@ const (
 	spinnerRunning  = 0
 	spinnerComplete = 1
 	spinnerError    = 2
+	spinnerPending  = 3
 )
 
 type spinnerEntry struct {
@@ -56,6 +57,24 @@ func (s *Spinner) UpdateMessage(msg string) {
 	defer s.mgr.mu.Unlock()
 	if s.idx < len(s.mgr.entries) {
 		s.mgr.entries[s.idx].message = msg
+	}
+}
+
+// Start marks the spinner entry as actively running.
+func (s *Spinner) Start() {
+	s.mgr.mu.Lock()
+	defer s.mgr.mu.Unlock()
+	if s.idx < len(s.mgr.entries) {
+		s.mgr.entries[s.idx].state = spinnerRunning
+	}
+}
+
+// Pending marks the spinner entry as queued but not currently running.
+func (s *Spinner) Pending() {
+	s.mgr.mu.Lock()
+	defer s.mgr.mu.Unlock()
+	if s.idx < len(s.mgr.entries) {
+		s.mgr.entries[s.idx].state = spinnerPending
 	}
 }
 
@@ -246,6 +265,7 @@ func (m spinnerModel) View() string {
 
 	completeIcon := lipgloss.NewStyle().Foreground(lipgloss.Color("82")).Render("✓")
 	errorIcon := lipgloss.NewStyle().Foreground(lipgloss.Color("203")).Render("✗")
+	pendingIcon := lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Render("○")
 
 	entries := m.mgr.entries[m.mgr.startOffset:]
 	if len(entries) == 0 {
@@ -263,6 +283,8 @@ func (m spinnerModel) View() string {
 			lines = append(lines, fmt.Sprintf("  %s %s", completeIcon, e.message))
 		case spinnerError:
 			lines = append(lines, fmt.Sprintf("  %s %s", errorIcon, e.message))
+		case spinnerPending:
+			lines = append(lines, fmt.Sprintf("  %s %s", pendingIcon, e.message))
 		default:
 			lines = append(lines, fmt.Sprintf("  %s %s", m.spin.View(), e.message))
 		}
@@ -533,6 +555,8 @@ func spinnerStepIcon(state int, spinnerView string, completeStyle, runningStyle,
 		return completeStyle.Render("✓")
 	case spinnerError:
 		return errorStyle.Render("✗")
+	case spinnerPending:
+		return runningStyle.Render("○")
 	default:
 		if spinnerView == "" {
 			return runningStyle.Render("•")

--- a/internal/utils/spinner_test.go
+++ b/internal/utils/spinner_test.go
@@ -116,6 +116,20 @@ func TestGroupedDeploymentViewKeepsInstanceDeploymentRunningBeforeSubmit(t *test
 	require.NotContains(t, view, "100%")
 }
 
+func TestSpinnerViewShowsPendingEntries(t *testing.T) {
+	mgr := &spinnerMgr{
+		entries: []*spinnerEntry{
+			{message: "queued feature", state: spinnerPending},
+			{message: "finished feature", state: spinnerComplete},
+		},
+	}
+
+	view := spinnerModel{mgr: mgr, width: 100}.View()
+
+	require.Contains(t, view, "○ queued feature")
+	require.Contains(t, view, "✓ finished feature")
+}
+
 func TestFinalGroupedDeploymentViewRendersCompleteFrame(t *testing.T) {
 	mgr := &spinnerMgr{
 		width: 96,

--- a/mkdocs/docs/omnistrate-ctl.md
+++ b/mkdocs/docs/omnistrate-ctl.md
@@ -50,6 +50,7 @@ omnistrate-ctl [flags]
 * [omnistrate-ctl build-from-repo](omnistrate-ctl_build-from-repo.md)	 - Build Service from Git Repository
 * [omnistrate-ctl cost](omnistrate-ctl_cost.md)	 - Manage cost analytics for your services
 * [omnistrate-ctl custom-network](omnistrate-ctl_custom-network.md)	 - List and describe custom networks of your customers
+* [omnistrate-ctl customer](omnistrate-ctl_customer.md)	 - Manage customer portal users
 * [omnistrate-ctl deploy](omnistrate-ctl_deploy.md)	 - Build or update a service and deploy or upgrade an instance
 * [omnistrate-ctl deployment-cell](omnistrate-ctl_deployment-cell.md)	 - Manage Deployment Cells
 * [omnistrate-ctl docs](omnistrate-ctl_docs.md)	 - Search and access documentation

--- a/mkdocs/docs/omnistrate-ctl_customer.md
+++ b/mkdocs/docs/omnistrate-ctl_customer.md
@@ -1,0 +1,37 @@
+## omnistrate-ctl customer
+
+Manage customer portal users
+
+### Synopsis
+
+This command helps ISVs manage customer portal users.
+
+```
+omnistrate-ctl customer [operation] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for customer
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl](omnistrate-ctl.md)	 - Manage your Omnistrate SaaS from the command line
+* [omnistrate-ctl customer create](omnistrate-ctl_customer_create.md)	 - Create a customer portal user
+* [omnistrate-ctl customer delete](omnistrate-ctl_customer_delete.md)	 - Delete a customer portal user
+* [omnistrate-ctl customer describe](omnistrate-ctl_customer_describe.md)	 - Describe a customer portal user
+* [omnistrate-ctl customer list](omnistrate-ctl_customer_list.md)	 - List customer portal users
+* [omnistrate-ctl customer suspend](omnistrate-ctl_customer_suspend.md)	 - Suspend a customer portal user
+* [omnistrate-ctl customer unsuspend](omnistrate-ctl_customer_unsuspend.md)	 - Unsuspend a customer portal user
+* [omnistrate-ctl customer update](omnistrate-ctl_customer_update.md)	 - Update a customer portal user
+* [omnistrate-ctl customer verify](omnistrate-ctl_customer_verify.md)	 - Send a customer portal user verification email
+

--- a/mkdocs/docs/omnistrate-ctl_customer_create.md
+++ b/mkdocs/docs/omnistrate-ctl_customer_create.md
@@ -1,0 +1,50 @@
+## omnistrate-ctl customer create
+
+Create a customer portal user
+
+### Synopsis
+
+This command creates a customer portal user.
+
+```
+omnistrate-ctl customer create [flags]
+```
+
+### Examples
+
+```
+# Create a customer portal user
+omnistrate-ctl customer create --email user@example.com --name "Jane Doe" --password "$PASSWORD" --legal-company-name "Example Inc"
+
+# Create a customer portal user and auto-verify the account
+omnistrate-ctl customer create --email user@example.com --name "Jane Doe" --password "$PASSWORD" --legal-company-name "Example Inc" --auto-verify
+
+# Create a customer portal user with the password read from stdin
+echo "$PASSWORD" | omnistrate-ctl customer create --email user@example.com --name "Jane Doe" --password-stdin --legal-company-name "Example Inc"
+```
+
+### Options
+
+```
+      --attribute stringArray       Customer user attribute in key=value format. Can be repeated or comma-separated
+      --auto-verify                 Enable automatic verification for the customer user
+      --company-url string          Customer company URL
+      --email string                Customer user email
+  -h, --help                        help for create
+      --legal-company-name string   Customer legal company name
+      --name string                 Customer user name
+      --password string             Customer user password
+      --password-stdin              Reads the customer user password from stdin
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl customer](omnistrate-ctl_customer.md)	 - Manage customer portal users
+

--- a/mkdocs/docs/omnistrate-ctl_customer_delete.md
+++ b/mkdocs/docs/omnistrate-ctl_customer_delete.md
@@ -1,0 +1,37 @@
+## omnistrate-ctl customer delete
+
+Delete a customer portal user
+
+### Synopsis
+
+This command deletes a customer portal user.
+
+```
+omnistrate-ctl customer delete [flags]
+```
+
+### Examples
+
+```
+# Delete a customer portal user
+omnistrate-ctl customer delete --user-id user-123
+```
+
+### Options
+
+```
+  -h, --help             help for delete
+      --user-id string   Customer user ID
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl customer](omnistrate-ctl_customer.md)	 - Manage customer portal users
+

--- a/mkdocs/docs/omnistrate-ctl_customer_describe.md
+++ b/mkdocs/docs/omnistrate-ctl_customer_describe.md
@@ -1,0 +1,37 @@
+## omnistrate-ctl customer describe
+
+Describe a customer portal user
+
+### Synopsis
+
+This command describes a customer portal user.
+
+```
+omnistrate-ctl customer describe [flags]
+```
+
+### Examples
+
+```
+# Describe a customer portal user
+omnistrate-ctl customer describe --user-id user-123
+```
+
+### Options
+
+```
+  -h, --help             help for describe
+      --user-id string   Customer user ID
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl customer](omnistrate-ctl_customer.md)	 - Manage customer portal users
+

--- a/mkdocs/docs/omnistrate-ctl_customer_list.md
+++ b/mkdocs/docs/omnistrate-ctl_customer_list.md
@@ -1,0 +1,42 @@
+## omnistrate-ctl customer list
+
+List customer portal users
+
+### Synopsis
+
+This command lists customer portal users.
+
+```
+omnistrate-ctl customer list [flags]
+```
+
+### Examples
+
+```
+# List customer portal users
+omnistrate-ctl customer list
+
+# List customer portal users as JSON
+omnistrate-ctl customer list --output json
+```
+
+### Options
+
+```
+      --exclude-stats            Exclude user statistics from the response
+  -h, --help                     help for list
+      --next-page-token string   Token for the next page of results
+      --page-size int            Number of users to return per page
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl customer](omnistrate-ctl_customer.md)	 - Manage customer portal users
+

--- a/mkdocs/docs/omnistrate-ctl_customer_suspend.md
+++ b/mkdocs/docs/omnistrate-ctl_customer_suspend.md
@@ -1,0 +1,37 @@
+## omnistrate-ctl customer suspend
+
+Suspend a customer portal user
+
+### Synopsis
+
+This command suspends a customer portal user.
+
+```
+omnistrate-ctl customer suspend [flags]
+```
+
+### Examples
+
+```
+# Suspend a customer portal user
+omnistrate-ctl customer suspend --user-id user-123
+```
+
+### Options
+
+```
+  -h, --help             help for suspend
+      --user-id string   Customer user ID
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl customer](omnistrate-ctl_customer.md)	 - Manage customer portal users
+

--- a/mkdocs/docs/omnistrate-ctl_customer_unsuspend.md
+++ b/mkdocs/docs/omnistrate-ctl_customer_unsuspend.md
@@ -1,0 +1,37 @@
+## omnistrate-ctl customer unsuspend
+
+Unsuspend a customer portal user
+
+### Synopsis
+
+This command unsuspends a customer portal user.
+
+```
+omnistrate-ctl customer unsuspend [flags]
+```
+
+### Examples
+
+```
+# Unsuspend a customer portal user
+omnistrate-ctl customer unsuspend --user-id user-123
+```
+
+### Options
+
+```
+  -h, --help             help for unsuspend
+      --user-id string   Customer user ID
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl customer](omnistrate-ctl_customer.md)	 - Manage customer portal users
+

--- a/mkdocs/docs/omnistrate-ctl_customer_update.md
+++ b/mkdocs/docs/omnistrate-ctl_customer_update.md
@@ -1,0 +1,38 @@
+## omnistrate-ctl customer update
+
+Update a customer portal user
+
+### Synopsis
+
+This command updates customer portal user attributes.
+
+```
+omnistrate-ctl customer update [flags]
+```
+
+### Examples
+
+```
+# Update attributes on a customer portal user
+omnistrate-ctl customer update --user-id user-123 --attribute plan=enterprise --attribute region=us-west-2
+```
+
+### Options
+
+```
+      --attribute stringArray   Customer user attribute in key=value format. Can be repeated or comma-separated
+  -h, --help                    help for update
+      --user-id string          Customer user ID
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl customer](omnistrate-ctl_customer.md)	 - Manage customer portal users
+

--- a/mkdocs/docs/omnistrate-ctl_customer_verify.md
+++ b/mkdocs/docs/omnistrate-ctl_customer_verify.md
@@ -1,0 +1,37 @@
+## omnistrate-ctl customer verify
+
+Send a customer portal user verification email
+
+### Synopsis
+
+This command sends a verification email to a customer portal user.
+
+```
+omnistrate-ctl customer verify [flags]
+```
+
+### Examples
+
+```
+# Send a verification email to a customer portal user
+omnistrate-ctl customer verify --user-id user-123
+```
+
+### Options
+
+```
+  -h, --help             help for verify
+      --user-id string   Customer user ID
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl customer](omnistrate-ctl_customer.md)	 - Manage customer portal users
+

--- a/mkdocs/docs/omnistrate-ctl_service.md
+++ b/mkdocs/docs/omnistrate-ctl_service.md
@@ -30,4 +30,5 @@ omnistrate-ctl service [operation] [flags]
 * [omnistrate-ctl service delete](omnistrate-ctl_service_delete.md)	 - Delete a service
 * [omnistrate-ctl service describe](omnistrate-ctl_service_describe.md)	 - Describe a service
 * [omnistrate-ctl service list](omnistrate-ctl_service_list.md)	 - List services for your account
+* [omnistrate-ctl service plan](omnistrate-ctl_service_plan.md)	 - Manage Service Plans for your service
 

--- a/mkdocs/docs/omnistrate-ctl_service_plan.md
+++ b/mkdocs/docs/omnistrate-ctl_service_plan.md
@@ -1,0 +1,39 @@
+## omnistrate-ctl service plan
+
+Manage Service Plans for your service
+
+### Synopsis
+
+This command helps you manage the service plans for your service.
+
+```
+omnistrate-ctl service plan [operation] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for plan
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl service](omnistrate-ctl_service.md)	 - Manage Services for your account
+* [omnistrate-ctl service plan delete](omnistrate-ctl_service_plan_delete.md)	 - Delete a Service Plan
+* [omnistrate-ctl service plan describe](omnistrate-ctl_service_plan_describe.md)	 - Describe a Service Plan
+* [omnistrate-ctl service plan describe-version](omnistrate-ctl_service_plan_describe-version.md)	 - Describe a specific version of a Service Plan
+* [omnistrate-ctl service plan disable-feature](omnistrate-ctl_service_plan_disable-feature.md)	 - Disable feature for a service plan
+* [omnistrate-ctl service plan enable-feature](omnistrate-ctl_service_plan_enable-feature.md)	 - Enable feature for a service plan
+* [omnistrate-ctl service plan list](omnistrate-ctl_service_plan_list.md)	 - List Service Plans for your service
+* [omnistrate-ctl service plan list-versions](omnistrate-ctl_service_plan_list-versions.md)	 - List Versions of a specific Service Plan
+* [omnistrate-ctl service plan release](omnistrate-ctl_service_plan_release.md)	 - Release a Service Plan
+* [omnistrate-ctl service plan set-default](omnistrate-ctl_service_plan_set-default.md)	 - Set a Version of a Service Plan as Default(Preferred)
+* [omnistrate-ctl service plan update](omnistrate-ctl_service_plan_update.md)	 - Update Service Plan properties
+

--- a/mkdocs/docs/omnistrate-ctl_service_plan_delete.md
+++ b/mkdocs/docs/omnistrate-ctl_service_plan_delete.md
@@ -1,0 +1,42 @@
+## omnistrate-ctl service plan delete
+
+Delete a Service Plan
+
+### Synopsis
+
+This command helps you delete a Service Plan from your service.
+
+```
+omnistrate-ctl service plan delete [service-name] [plan-name] [flags]
+```
+
+### Examples
+
+```
+# Delete service plan
+omnistrate-ctl service plan delete [service-name] [plan-name]
+
+# Delete service plan by ID instead of name
+omnistrate-ctl service plan delete --service-id=[service-id] --plan-id=[plan-id]
+```
+
+### Options
+
+```
+      --environment string   Environment name. Use this flag with service name and plan name to delete the service plan in a specific environment
+  -h, --help                 help for delete
+      --plan-id string       Plan ID. Required if plan name is not provided
+      --service-id string    Service ID. Required if service name is not provided
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl service plan](omnistrate-ctl_service_plan.md)	 - Manage Service Plans for your service
+

--- a/mkdocs/docs/omnistrate-ctl_service_plan_describe-version.md
+++ b/mkdocs/docs/omnistrate-ctl_service_plan_describe-version.md
@@ -1,0 +1,37 @@
+## omnistrate-ctl service plan describe-version
+
+Describe a specific version of a Service Plan
+
+### Synopsis
+
+This command helps you get details of a specific version of a Service Plan for your service. You can get environment, enabled features, and resource configuration details for the version.
+
+```
+omnistrate-ctl service plan describe-version [service-name] [plan-name] [flags]
+```
+
+### Examples
+
+```
+# Describe a service plan version
+omnistrate-ctl service plan describe-version [service-name] [plan-name] --version [version]
+
+# Describe a service plan version by ID instead of name
+omnistrate-ctl service plan describe-version --service-id [service-id] --plan-id [plan-id] --version [version]
+```
+
+### Options
+
+```
+      --environment string   Environment name. Use this flag with service name and plan name to describe the version in a specific environment
+  -h, --help                 help for describe-version
+  -o, --output string        Output format. Only json is supported (default "json")
+      --plan-id string       Plan ID. Required if plan name is not provided
+      --service-id string    Service ID. Required if service name is not provided
+  -v, --version string       Service plan version (latest|preferred|1.0 etc.)
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl service plan](omnistrate-ctl_service_plan.md)	 - Manage Service Plans for your service
+

--- a/mkdocs/docs/omnistrate-ctl_service_plan_describe.md
+++ b/mkdocs/docs/omnistrate-ctl_service_plan_describe.md
@@ -1,0 +1,42 @@
+## omnistrate-ctl service plan describe
+
+Describe a Service Plan
+
+### Synopsis
+
+This command helps you get details of a Service Plan for your service.
+
+```
+omnistrate-ctl service plan describe [service-name] [plan-name] [flags]
+```
+
+### Examples
+
+```
+# Describe service plan
+omnistrate-ctl service plan describe [service-name] [plan-name]
+
+# Describe service plan by ID instead of name
+omnistrate-ctl service plan describe --service-id [service-id] --plan-id [plan-id]
+```
+
+### Options
+
+```
+      --environment string   Environment name. Use this flag with service name and plan name to describe the service plan in a specific environment
+  -h, --help                 help for describe
+  -o, --output string        Output format. Only json is supported (default "json")
+      --plan-id string       Plan ID. Required if plan name is not provided
+      --service-id string    Service ID. Required if service name is not provided
+```
+
+### Options inherited from parent commands
+
+```
+  -v, --version   Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl service plan](omnistrate-ctl_service_plan.md)	 - Manage Service Plans for your service
+

--- a/mkdocs/docs/omnistrate-ctl_service_plan_disable-feature.md
+++ b/mkdocs/docs/omnistrate-ctl_service_plan_disable-feature.md
@@ -1,0 +1,43 @@
+## omnistrate-ctl service plan disable-feature
+
+Disable feature for a service plan
+
+### Synopsis
+
+This command helps you disable active service plan feature.
+
+```
+omnistrate-ctl service plan disable-feature [service-name] [plan-name] [flags]
+```
+
+### Examples
+
+```
+# Disable service plan feature 
+omnistrate-ctl service plan disable-feature [service-name] [plan-name] --feature [feature-name]
+
+#  Disable service plan feature by ID instead of name
+omnistrate-ctl service plan enable-feature --service-id [service-id] --plan-id [plan-id] --feature [feature-name]
+```
+
+### Options
+
+```
+      --environment string   Environment name. Use this flag with service name and plan name to describe the service plan in a specific environment
+      --feature string       Name / identifier of the feature to disable
+  -h, --help                 help for disable-feature
+      --plan-id string       Plan ID. Required if plan name is not provided
+      --service-id string    Service ID. Required if service name is not provided
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl service plan](omnistrate-ctl_service_plan.md)	 - Manage Service Plans for your service
+

--- a/mkdocs/docs/omnistrate-ctl_service_plan_enable-feature.md
+++ b/mkdocs/docs/omnistrate-ctl_service_plan_enable-feature.md
@@ -1,0 +1,45 @@
+## omnistrate-ctl service plan enable-feature
+
+Enable feature for a service plan
+
+### Synopsis
+
+This command helps you enable & configure service plan features such as CUSTOM_TERRAFORM_POLICY.
+
+```
+omnistrate-ctl service plan enable-feature [service-name] [plan-name] [flags]
+```
+
+### Examples
+
+```
+# Enable service plan feature 
+omnistrate-ctl service plan enable-feature [service-name] [plan-name] --feature [feature-name] --feature-configuration [feature-configuration]
+
+# Enable service plan feature by ID instead of name and configure using file
+omnistrate-ctl service plan enable-feature --service-id [service-id] --plan-id [plan-id] --feature [feature-name] --feature-configuration-file /path/to/feature-config-file.json
+```
+
+### Options
+
+```
+      --environment string                  Environment name. Use this flag with service name and plan name to describe the service plan in a specific environment
+      --feature string                      Name / identifier of the feature to enable
+      --feature-configuration string        Configuration of the feature
+      --feature-configuration-file string   Json file containing feature configuration
+  -h, --help                                help for enable-feature
+      --plan-id string                      Plan ID. Required if plan name is not provided
+      --service-id string                   Service ID. Required if service name is not provided
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl service plan](omnistrate-ctl_service_plan.md)	 - Manage Service Plans for your service
+

--- a/mkdocs/docs/omnistrate-ctl_service_plan_list-versions.md
+++ b/mkdocs/docs/omnistrate-ctl_service_plan_list-versions.md
@@ -1,0 +1,43 @@
+## omnistrate-ctl service plan list-versions
+
+List Versions of a specific Service Plan
+
+### Synopsis
+
+This command helps you list Versions of a specific Service Plan.
+You can filter for specific service plan versions by using the filter flag.
+
+```
+omnistrate-ctl service plan list-versions [service-name] [plan-name] [flags]
+```
+
+### Examples
+
+```
+# List service plan versions of the service postgres in the prod and dev environments
+omnistrate-ctl service plan list-versions postgres postgres -f="service_name:postgres,environment:prod" -f="service:postgres,environment:dev"
+```
+
+### Options
+
+```
+      --environment string   Environment name. Use this flag with service name and plan name to describe the version in a specific environment
+  -f, --filter stringArray   Filter to apply to the list of service plan versions. E.g.: key1:value1,key2:value2, which filters service plans where key1 equals value1 and key2 equals value2. Allow use of multiple filters to form the logical OR operation. Supported keys: plan_id,plan_name,service_id,service_name,environment,version,release_description,version_set_status,is_new_service_plan_version_created. Check the examples for more details.
+  -h, --help                 help for list-versions
+      --limit int            List only the latest N service plan versions (default -1)
+      --plan-id string       Plan ID. Required if plan name is not provided
+      --service-id string    Service ID. Required if service name is not provided
+      --truncate             Truncate long names in the output
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl service plan](omnistrate-ctl_service_plan.md)	 - Manage Service Plans for your service
+

--- a/mkdocs/docs/omnistrate-ctl_service_plan_list.md
+++ b/mkdocs/docs/omnistrate-ctl_service_plan_list.md
@@ -1,0 +1,40 @@
+## omnistrate-ctl service plan list
+
+List Service Plans for your service
+
+### Synopsis
+
+This command helps you list Service Plans for your service.
+You can filter for specific service plans by using the filter flag.
+
+```
+omnistrate-ctl service plan list [flags]
+```
+
+### Examples
+
+```
+# List service plans of the service postgres in the prod and dev environments
+omnistrate-ctl service plan list -f="service_name:postgres,environment:prod" -f="service:postgres,environment:dev"
+```
+
+### Options
+
+```
+  -f, --filter stringArray   Filter to apply to the list of service plans. E.g.: key1:value1,key2:value2, which filters service plans where key1 equals value1 and key2 equals value2. Allow use of multiple filters to form the logical OR operation. Supported keys: plan_id,plan_name,service_id,service_name,environment,version,release_description,version_set_status,is_new_service_plan_version_created. Check the examples for more details.
+  -h, --help                 help for list
+  -i, --interactive          Launch interactive plan browser
+      --truncate             Truncate long names in the output
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl service plan](omnistrate-ctl_service_plan.md)	 - Manage Service Plans for your service
+

--- a/mkdocs/docs/omnistrate-ctl_service_plan_release.md
+++ b/mkdocs/docs/omnistrate-ctl_service_plan_release.md
@@ -1,0 +1,45 @@
+## omnistrate-ctl service plan release
+
+Release a Service Plan
+
+### Synopsis
+
+This command helps you release a Service Plan for your service. You can specify a custom release description and set the service plan as preferred if needed.
+
+```
+omnistrate-ctl service plan release [service-name] [plan-name] [flags]
+```
+
+### Examples
+
+```
+# Release service plan by name
+omnistrate-ctl service plan release [service-name] [plan-name]
+
+# Release service plan by ID
+omnistrate-ctl service plan release --service-id=[service-id] --plan-id=[plan-id]
+```
+
+### Options
+
+```
+      --dryrun                       Perform a dry run without making any changes
+      --environment string           Environment name. Use this flag with service name and plan name to release the service plan in a specific environment
+  -h, --help                         help for release
+      --plan-id string               Plan ID. Required if plan name is not provided
+      --release-as-preferred         Release the service plan as preferred
+      --release-description string   Set custom release description for this release version
+      --service-id string            Service ID. Required if service name is not provided
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl service plan](omnistrate-ctl_service_plan.md)	 - Manage Service Plans for your service
+

--- a/mkdocs/docs/omnistrate-ctl_service_plan_set-default.md
+++ b/mkdocs/docs/omnistrate-ctl_service_plan_set-default.md
@@ -1,0 +1,43 @@
+## omnistrate-ctl service plan set-default
+
+Set a Version of a Service Plan as Default(Preferred)
+
+### Synopsis
+
+This command helps you set a Version of a Service Plan as the default (preferred) version for your service.
+By setting it as default, new instance deployments from your customers will be created with this version by default.
+
+```
+omnistrate-ctl service plan set-default [service-name] [plan-name] --version=[version] [flags]
+```
+
+### Examples
+
+```
+# Set service plan as default
+omnistrate-ctl service plan set-default [service-name] [plan-name] --version=[version]
+
+# Set  service plan as default by ID instead of name
+omnistrate-ctl service plan set-default --service-id=[service-id] --plan-id=[plan-id] --version=[version]
+```
+
+### Options
+
+```
+      --environment string   Environment name. Use this flag with service name and plan name to set the default version in a specific environment
+  -h, --help                 help for set-default
+      --plan-id string       Plan ID. Required if plan name is not provided
+      --service-id string    Service ID. Required if service name is not provided
+      --version string       Specify the version number to set the default to. Use 'latest' to set the latest version as default.
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl service plan](omnistrate-ctl_service_plan.md)	 - Manage Service Plans for your service
+

--- a/mkdocs/docs/omnistrate-ctl_service_plan_update.md
+++ b/mkdocs/docs/omnistrate-ctl_service_plan_update.md
@@ -1,0 +1,45 @@
+## omnistrate-ctl service plan update
+
+Update Service Plan properties
+
+### Synopsis
+
+This command helps you update various properties of a Service Plan.
+Currently supports updating the name of a specific version of a Service Plan.
+The version name is used as the release description for the version.
+
+```
+omnistrate-ctl service plan update [service-name] [plan-name] --version=[version] --name=[new-name] [flags]
+```
+
+### Examples
+
+```
+# Update service plan version name
+omnistrate-ctl service plan update [service-name] [plan-name] --version=[version] --name=[new-name]
+
+# Update service plan version name by ID instead of name
+omnistrate-ctl service plan update --service-id=[service-id] --plan-id=[plan-id] --version=[version] --name=[new-name]
+```
+
+### Options
+
+```
+      --environment string   Environment name. Use this flag with service name and plan name to update the version name in a specific environment
+  -h, --help                 help for update
+      --name string          Specify the new name for the version.
+      --plan-id string       Plan ID. Required if plan name is not provided
+      --service-id string    Service ID. Required if service name is not provided
+      --version string       Specify the version number to update the name for.
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl service plan](omnistrate-ctl_service_plan.md)	 - Manage Service Plans for your service
+


### PR DESCRIPTION
**Build summarizer**
<img width="908" height="494" alt="image" src="https://github.com/user-attachments/assets/45a56dd9-f8d3-4469-b8f9-b6586e561310" />


**Product Plan Browser**
<img width="1663" height="1101" alt="image" src="https://github.com/user-attachments/assets/f3f12ae3-79f6-4675-b032-cb1dd119c586" />

**Deployment Wizard**

<img width="1644" height="365" alt="image" src="https://github.com/user-attachments/assets/20e5cf02-4c93-4f8a-9f07-d821a1d1e1f1" />

- Also deprecates `omctl service-plan` commands in favor of `omctl service plan` for scoping-based command structure standardization
