### PR TITLE
feat: add Compose resource debug support and simplify parameter display

### DIFF
--- a/cmd/instance/debug.go
+++ b/cmd/instance/debug.go
@@ -35,8 +35,8 @@ type DebugData struct {
 	ProductTierID     string                        `json:"productTierId,omitempty"`
 	TierVersion       string                        `json:"tierVersion,omitempty"`
 	Token             string                        `json:"-"`
-	ResultParams      map[string]interface{}         `json:"-"`
-	InputParams       map[string]interface{}         `json:"-"`
+	ResultParams      map[string]interface{}        `json:"-"`
+	InputParams       map[string]interface{}        `json:"-"`
 	ResourceDebugInfo map[string]*ResourceDebugInfo `json:"resourceDebugInfo,omitempty"`
 }
 
@@ -258,7 +258,8 @@ func runDebugJSON(instanceID, token string) error {
 
 // collectResourceDebugInfo fetches all per-resource debug data for the JSON output path.
 // It collects helm data (logs, values), terraform data (progress, history, files, logs),
-// and operator data (input/output parameters) for each resource in the plan DAG.
+// operator data (input/output parameters), and compose data (input/output parameters)
+// for each resource in the plan DAG.
 // Errors for individual resources or data sources are handled gracefully — partial data
 // is returned rather than failing the entire operation.
 func collectResourceDebugInfo(ctx context.Context, token, serviceID, environmentID, instanceID string, planDAG *PlanDAG, instanceData *openapiclientfleet.ResourceInstance) map[string]*ResourceDebugInfo {
@@ -526,6 +527,13 @@ func collectOperatorDebugInfo(ctx context.Context, token, serviceID string, plan
 // collectComposeDebugInfo fetches compose debug data (input/output parameters)
 // for compose-type resources.
 func collectComposeDebugInfo(ctx context.Context, token, serviceID string, planDAG *PlanDAG, instanceData *openapiclientfleet.ResourceInstance, inputParams map[string]interface{}, resultParams map[string]interface{}, result map[string]*ResourceDebugInfo) {
+	collectComposeDebugInfoWithFetchers(ctx, token, serviceID, planDAG, instanceData, inputParams, resultParams, result, fetchInputParams, fetchOutputParams)
+}
+
+type inputParamsFetcher func(context.Context, string, string, string, string, string, map[string]interface{}) ([]OperatorInputParam, error)
+type outputParamsFetcher func(context.Context, string, string, string, string, string, map[string]interface{}) ([]OperatorOutputParam, error)
+
+func collectComposeDebugInfoWithFetchers(ctx context.Context, token, serviceID string, planDAG *PlanDAG, instanceData *openapiclientfleet.ResourceInstance, inputParams map[string]interface{}, resultParams map[string]interface{}, result map[string]*ResourceDebugInfo, fetchInput inputParamsFetcher, fetchOutput outputParamsFetcher) {
 	for _, node := range planDAG.Nodes {
 		lower := strings.ToLower(node.Type)
 		if !strings.Contains(lower, "compose") {
@@ -544,7 +552,7 @@ func collectComposeDebugInfo(ctx context.Context, token, serviceID string, planD
 		cData := &ComposeData{}
 
 		// Fetch all input parameters
-		fetchedInputParams, inputErr := fetchInputParams(
+		fetchedInputParams, inputErr := fetchInput(
 			ctx, token, serviceID, node.ID,
 			instanceData.ProductTierId, instanceData.TierVersion,
 			inputParams,
@@ -554,7 +562,7 @@ func collectComposeDebugInfo(ctx context.Context, token, serviceID string, planD
 		}
 
 		// Fetch exported output parameters
-		outputParams, outputErr := fetchOutputParams(
+		outputParams, outputErr := fetchOutput(
 			ctx, token, serviceID, node.ID,
 			instanceData.ProductTierId, instanceData.TierVersion,
 			resultParams,

--- a/cmd/instance/debug.go
+++ b/cmd/instance/debug.go
@@ -306,6 +306,9 @@ func collectResourceDebugInfo(ctx context.Context, token, serviceID, environment
 	// Collect operator debug data (input/output parameters) for non-helm, non-terraform resources
 	collectOperatorDebugInfo(ctx, token, serviceID, planDAG, instanceData, inputParams, resultParams, result)
 
+	// Collect compose debug data (input/output parameters) for compose resources
+	collectComposeDebugInfo(ctx, token, serviceID, planDAG, instanceData, inputParams, resultParams, result)
+
 	// Remove entries that have no debug data
 	for key, info := range result {
 		if !info.hasData() {
@@ -516,6 +519,52 @@ func collectOperatorDebugInfo(ctx context.Context, token, serviceID string, plan
 
 		if len(opData.InputParams) > 0 || len(opData.OutputParams) > 0 || len(opData.CRDOutputParams) > 0 {
 			info.Operator = opData
+		}
+	}
+}
+
+// collectComposeDebugInfo fetches compose debug data (input/output parameters)
+// for compose-type resources.
+func collectComposeDebugInfo(ctx context.Context, token, serviceID string, planDAG *PlanDAG, instanceData *openapiclientfleet.ResourceInstance, inputParams map[string]interface{}, resultParams map[string]interface{}, result map[string]*ResourceDebugInfo) {
+	for _, node := range planDAG.Nodes {
+		lower := strings.ToLower(node.Type)
+		if !strings.Contains(lower, "compose") {
+			continue
+		}
+
+		key := node.Key
+		if key == "" {
+			key = node.ID
+		}
+		info, exists := result[key]
+		if !exists {
+			continue
+		}
+
+		cData := &ComposeData{}
+
+		// Fetch all input parameters
+		fetchedInputParams, inputErr := fetchInputParams(
+			ctx, token, serviceID, node.ID,
+			instanceData.ProductTierId, instanceData.TierVersion,
+			inputParams,
+		)
+		if inputErr == nil {
+			cData.InputParams = fetchedInputParams
+		}
+
+		// Fetch exported output parameters
+		outputParams, outputErr := fetchOutputParams(
+			ctx, token, serviceID, node.ID,
+			instanceData.ProductTierId, instanceData.TierVersion,
+			resultParams,
+		)
+		if outputErr == nil {
+			cData.OutputParams = outputParams
+		}
+
+		if len(cData.InputParams) > 0 || len(cData.OutputParams) > 0 {
+			info.Compose = cData
 		}
 	}
 }

--- a/cmd/instance/debug_compose_detail_tui.go
+++ b/cmd/instance/debug_compose_detail_tui.go
@@ -27,16 +27,11 @@ func init() {
 	}
 }
 
-// ComposeData holds debug information specific to compose-type resources.
-type ComposeData struct {
-	InputParams  []OperatorInputParam  `json:"inputParams,omitempty"`
-	OutputParams []OperatorOutputParam `json:"outputParams,omitempty"`
-}
-
 // composeDataMsg is sent when compose debug data has been fetched.
 type composeDataMsg struct {
 	composeData *ComposeData
-	err         error
+	inputErr    error
+	outputErr   error
 }
 
 type composeDetailModel struct {
@@ -46,9 +41,11 @@ type composeDetailModel struct {
 	width     int
 	height    int
 
-	loading bool
-	loadErr error
-	spinner spinner.Model
+	loading   bool
+	loadErr   error
+	inputErr  error
+	outputErr error
+	spinner   spinner.Model
 
 	composeData *ComposeData
 
@@ -115,11 +112,11 @@ func (m composeDetailModel) fetchComposeData() tea.Cmd {
 			cData.OutputParams = outputParams
 		}
 
-		if inputErr != nil && outputErr != nil {
-			return composeDataMsg{err: fmt.Errorf("failed to fetch compose data: %w", inputErr)}
+		return composeDataMsg{
+			composeData: cData,
+			inputErr:    inputErr,
+			outputErr:   outputErr,
 		}
-
-		return composeDataMsg{composeData: cData}
 	}
 }
 
@@ -140,10 +137,8 @@ func (m composeDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case composeDataMsg:
 		m.loading = false
-		if msg.err != nil {
-			m.loadErr = msg.err
-			return m, nil
-		}
+		m.inputErr = msg.inputErr
+		m.outputErr = msg.outputErr
 		m.composeData = msg.composeData
 		if m.composeData != nil {
 			m.inputTree = buildOperatorParamTree(m.composeData.InputParams)
@@ -487,16 +482,20 @@ func (m composeDetailModel) getComposeTabContent() string {
 }
 
 func (m composeDetailModel) renderComposeInputVarsTab() string {
-	return m.renderComposeParamTreeTab("Input Parameters", m.inputTree, m.inputCursor, m.inputScroll)
+	return m.renderComposeParamTreeTab("Input Parameters", m.inputTree, m.inputCursor, m.inputScroll, m.inputErr)
 }
 
 func (m composeDetailModel) renderComposeOutputVarsTab() string {
-	return m.renderComposeParamTreeTab("Output Parameters", m.outputTree, m.outputCursor, m.outputScroll)
+	return m.renderComposeParamTreeTab("Output Parameters", m.outputTree, m.outputCursor, m.outputScroll, m.outputErr)
 }
 
-func (m composeDetailModel) renderComposeParamTreeTab(title string, tree []outputNode, cursor, scroll int) string {
+func (m composeDetailModel) renderComposeParamTreeTab(title string, tree []outputNode, cursor, scroll int, fetchErr error) string {
 	if m.loading {
 		return fmt.Sprintf("\n  %s Fetching %s...", m.spinner.View(), strings.ToLower(title))
+	}
+	if fetchErr != nil {
+		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
+		return fmt.Sprintf("\n  %s\n", errStyle.Render(fmt.Sprintf("Error fetching %s: %v", strings.ToLower(title), fetchErr)))
 	}
 	if m.loadErr != nil {
 		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
@@ -596,7 +595,7 @@ func (m composeDetailModel) renderComposeParamTreeTab(title string, tree []outpu
 			pct := (scrollOffset * 100) / (totalEntries - visibleRows)
 			pos = fmt.Sprintf("%d%%", pct)
 		}
-		fmt.Fprintf(&b, "\n  %s\n", dimStyle.Render(fmt.Sprintf("↑↓: navigate  ←→/enter: expand/collapse  [%d/%d %s]", cursorIndex+1, totalEntries, pos)))
+		fmt.Fprintf(&b, "\n  %s\n", dimStyle.Render(fmt.Sprintf("↑↓: navigate  [%d/%d %s]", cursorIndex+1, totalEntries, pos)))
 	}
 
 	return b.String()
@@ -617,7 +616,7 @@ func (m composeDetailModel) renderComposeFooter() string {
 	case composeTabInputVars, composeTabOutputVars:
 		if (m.activeTab == composeTabInputVars && len(m.inputTree) > 0) ||
 			(m.activeTab == composeTabOutputVars && len(m.outputTree) > 0) {
-			text = "↑↓: navigate  ←→/enter: expand/collapse  y: copy  tab/shift+tab: switch tabs  esc: back  q: quit"
+			text = "↑↓: navigate  y: copy  tab/shift+tab: switch tabs  esc: back  q: quit"
 		} else {
 			text = "tab/shift+tab: switch tabs  esc: back  q: quit"
 		}

--- a/cmd/instance/debug_compose_detail_tui.go
+++ b/cmd/instance/debug_compose_detail_tui.go
@@ -1,0 +1,687 @@
+package instance
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	composeTabInputVars  = 0
+	composeTabOutputVars = 1
+	composeTabWfErrors   = 2
+	composeNumTabs       = 3
+)
+
+var composeTabNames = []string{"Input Parameters", "Output Parameters", "Workflow Events"}
+
+func init() {
+	if len(composeTabNames) != composeNumTabs {
+		panic(fmt.Sprintf("composeTabNames length %d does not match composeNumTabs %d", len(composeTabNames), composeNumTabs))
+	}
+}
+
+// ComposeData holds debug information specific to compose-type resources.
+type ComposeData struct {
+	InputParams  []OperatorInputParam  `json:"inputParams,omitempty"`
+	OutputParams []OperatorOutputParam `json:"outputParams,omitempty"`
+}
+
+// composeDataMsg is sent when compose debug data has been fetched.
+type composeDataMsg struct {
+	composeData *ComposeData
+	err         error
+}
+
+type composeDetailModel struct {
+	node      PlanDAGNode
+	debugData DebugData
+	activeTab int
+	width     int
+	height    int
+
+	loading bool
+	loadErr error
+	spinner spinner.Model
+
+	composeData *ComposeData
+
+	// Input variables tree
+	inputTree   []outputNode
+	inputCursor int
+	inputScroll int
+
+	// Output variables tree
+	outputTree   []outputNode
+	outputCursor int
+	outputScroll int
+
+	// Workflow Events tab
+	wfErrors *workflowErrorsState
+
+	clipboardMsg string
+}
+
+func newComposeDetailModel(node PlanDAGNode, data DebugData) composeDetailModel {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+
+	return composeDetailModel{
+		node:      node,
+		debugData: data,
+		activeTab: composeTabInputVars,
+		loading:   true,
+		spinner:   s,
+		wfErrors:  &workflowErrorsState{},
+	}
+}
+
+func (m composeDetailModel) Init() tea.Cmd {
+	return tea.Batch(m.spinner.Tick, m.fetchComposeData())
+}
+
+func (m composeDetailModel) fetchComposeData() tea.Cmd {
+	return func() tea.Msg {
+		ctx := context.Background()
+
+		cData := &ComposeData{}
+
+		// Fetch all input parameters
+		inputParams, inputErr := fetchInputParams(
+			ctx, m.debugData.Token,
+			m.debugData.ServiceID, m.node.ID,
+			m.debugData.ProductTierID, m.debugData.TierVersion,
+			m.debugData.InputParams,
+		)
+		if inputErr == nil {
+			cData.InputParams = inputParams
+		}
+
+		// Fetch exported output parameters
+		outputParams, outputErr := fetchOutputParams(
+			ctx, m.debugData.Token,
+			m.debugData.ServiceID, m.node.ID,
+			m.debugData.ProductTierID, m.debugData.TierVersion,
+			m.debugData.ResultParams,
+		)
+		if outputErr == nil {
+			cData.OutputParams = outputParams
+		}
+
+		if inputErr != nil && outputErr != nil {
+			return composeDataMsg{err: fmt.Errorf("failed to fetch compose data: %w", inputErr)}
+		}
+
+		return composeDataMsg{composeData: cData}
+	}
+}
+
+func (m composeDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		m.height = msg.Height
+		return m, nil
+
+	case spinner.TickMsg:
+		if m.loading || m.wfErrors.refreshing || isWorkflowInProgress(m.getWfEvents()) {
+			var cmd tea.Cmd
+			m.spinner, cmd = m.spinner.Update(msg)
+			return m, cmd
+		}
+		return m, nil
+
+	case composeDataMsg:
+		m.loading = false
+		if msg.err != nil {
+			m.loadErr = msg.err
+			return m, nil
+		}
+		m.composeData = msg.composeData
+		if m.composeData != nil {
+			m.inputTree = buildOperatorParamTree(m.composeData.InputParams)
+			m.outputTree = buildOperatorOutputParamTree(m.composeData.OutputParams)
+		}
+		var cmds []tea.Cmd
+		if isWorkflowInProgress(m.getWfEvents()) {
+			cmds = append(cmds, scheduleWfEventsRefresh(), scheduleWfCountdownTick())
+		}
+		if len(cmds) > 0 {
+			return m, tea.Batch(cmds...)
+		}
+		return m, nil
+
+	case wfEventsRefreshTickMsg:
+		steps := m.getWfEvents()
+		if isWorkflowInProgress(steps) && !m.wfErrors.refreshing {
+			m.wfErrors.refreshing = true
+			return m, fetchWfEventsForResource(m.debugData, m.node.Key)
+		}
+	case wfEventsRefreshMsg:
+		m.wfErrors.refreshing = false
+		m.wfErrors.lastRefresh = time.Now()
+		if msg.err == nil && msg.steps != nil {
+			if m.debugData.PlanDAG != nil {
+				if m.debugData.PlanDAG.WorkflowStepsByKey == nil {
+					m.debugData.PlanDAG.WorkflowStepsByKey = make(map[string]*ResourceWorkflowSteps)
+				}
+				m.debugData.PlanDAG.WorkflowStepsByKey[m.node.Key] = msg.steps
+			}
+		}
+		if isWorkflowInProgress(m.getWfEvents()) {
+			return m, tea.Batch(scheduleWfEventsRefresh(), scheduleWfCountdownTick())
+		}
+	case wfCountdownTickMsg:
+		if isWorkflowInProgress(m.getWfEvents()) {
+			return m, scheduleWfCountdownTick()
+		}
+
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "ctrl+c", "q":
+			return m, tea.Quit
+		case "esc":
+			if m.wfErrors.modalText != "" {
+				m.wfErrors.modalText = ""
+				m.wfErrors.modalTitle = ""
+				m.wfErrors.modalScroll = 0
+				return m, nil
+			}
+			return m, func() tea.Msg { return backToDagMsg{} }
+		case "tab":
+			if m.wfErrors.modalText != "" {
+				return m, nil
+			}
+			m.activeTab = (m.activeTab + 1) % composeNumTabs
+			return m, nil
+		case "shift+tab":
+			if m.wfErrors.modalText != "" {
+				return m, nil
+			}
+			m.activeTab = (m.activeTab - 1 + composeNumTabs) % composeNumTabs
+			return m, nil
+		case "up", "k":
+			if m.wfErrors.modalText != "" {
+				if m.wfErrors.modalScroll > 0 {
+					m.wfErrors.modalScroll--
+				}
+				return m, nil
+			}
+			switch m.activeTab {
+			case composeTabInputVars:
+				if len(m.inputTree) > 0 {
+					visibleNodes := flattenOutputTree(m.inputTree)
+					if m.inputCursor > 0 {
+						m.inputCursor--
+					}
+					m.inputCursor, m.inputScroll = normalizeViewport(
+						m.inputCursor, m.inputScroll, len(visibleNodes), m.composeVisibleRows(),
+					)
+				}
+			case composeTabOutputVars:
+				if len(m.outputTree) > 0 {
+					visibleNodes := flattenOutputTree(m.outputTree)
+					if m.outputCursor > 0 {
+						m.outputCursor--
+					}
+					m.outputCursor, m.outputScroll = normalizeViewport(
+						m.outputCursor, m.outputScroll, len(visibleNodes), m.composeVisibleRows(),
+					)
+				}
+			case composeTabWfErrors:
+				items := flattenWfEventItems(m.getWfEvents())
+				if m.wfErrors.cursor > 0 {
+					m.wfErrors.cursor--
+				}
+				_ = items
+			}
+		case "down", "j":
+			if m.wfErrors.modalText != "" {
+				m.wfErrors.modalScroll++
+				maxScroll := wfEventModalMaxScroll(m.wfErrors, m.width, m.height)
+				if m.wfErrors.modalScroll > maxScroll {
+					m.wfErrors.modalScroll = maxScroll
+				}
+				return m, nil
+			}
+			switch m.activeTab {
+			case composeTabInputVars:
+				if len(m.inputTree) > 0 {
+					visibleNodes := flattenOutputTree(m.inputTree)
+					if m.inputCursor < len(visibleNodes)-1 {
+						m.inputCursor++
+					}
+					m.inputCursor, m.inputScroll = normalizeViewport(
+						m.inputCursor, m.inputScroll, len(visibleNodes), m.composeVisibleRows(),
+					)
+				}
+			case composeTabOutputVars:
+				if len(m.outputTree) > 0 {
+					visibleNodes := flattenOutputTree(m.outputTree)
+					if m.outputCursor < len(visibleNodes)-1 {
+						m.outputCursor++
+					}
+					m.outputCursor, m.outputScroll = normalizeViewport(
+						m.outputCursor, m.outputScroll, len(visibleNodes), m.composeVisibleRows(),
+					)
+				}
+			case composeTabWfErrors:
+				items := flattenWfEventItems(m.getWfEvents())
+				if m.wfErrors.cursor < len(items)-1 {
+					m.wfErrors.cursor++
+				}
+				_ = items
+			}
+		case "enter":
+			switch m.activeTab {
+			case composeTabInputVars:
+				if len(m.inputTree) > 0 {
+					visibleNodes := flattenOutputTree(m.inputTree)
+					if m.inputCursor < len(visibleNodes) && visibleNodes[m.inputCursor].expandable {
+						visibleNodes[m.inputCursor].expanded = !visibleNodes[m.inputCursor].expanded
+					}
+				}
+			case composeTabOutputVars:
+				if len(m.outputTree) > 0 {
+					visibleNodes := flattenOutputTree(m.outputTree)
+					if m.outputCursor < len(visibleNodes) && visibleNodes[m.outputCursor].expandable {
+						visibleNodes[m.outputCursor].expanded = !visibleNodes[m.outputCursor].expanded
+					}
+				}
+			case composeTabWfErrors:
+				items := flattenWfEventItems(m.getWfEvents())
+				if m.wfErrors.cursor < len(items) {
+					item := items[m.wfErrors.cursor]
+					if item.event != nil {
+						m.wfErrors.modalText = formatEventDetail(item.event)
+						m.wfErrors.modalTitle = extractEventAction(item.event.Message)
+						m.wfErrors.modalScroll = 0
+					}
+				}
+			}
+		case "right", "l":
+			switch m.activeTab {
+			case composeTabInputVars:
+				if len(m.inputTree) > 0 {
+					visibleNodes := flattenOutputTree(m.inputTree)
+					if m.inputCursor < len(visibleNodes) && visibleNodes[m.inputCursor].expandable && !visibleNodes[m.inputCursor].expanded {
+						visibleNodes[m.inputCursor].expanded = true
+					}
+				}
+			case composeTabOutputVars:
+				if len(m.outputTree) > 0 {
+					visibleNodes := flattenOutputTree(m.outputTree)
+					if m.outputCursor < len(visibleNodes) && visibleNodes[m.outputCursor].expandable && !visibleNodes[m.outputCursor].expanded {
+						visibleNodes[m.outputCursor].expanded = true
+					}
+				}
+			}
+		case "left", "h":
+			switch m.activeTab {
+			case composeTabInputVars:
+				if len(m.inputTree) > 0 {
+					visibleNodes := flattenOutputTree(m.inputTree)
+					if m.inputCursor < len(visibleNodes) && visibleNodes[m.inputCursor].expandable && visibleNodes[m.inputCursor].expanded {
+						visibleNodes[m.inputCursor].expanded = false
+					}
+				}
+			case composeTabOutputVars:
+				if len(m.outputTree) > 0 {
+					visibleNodes := flattenOutputTree(m.outputTree)
+					if m.outputCursor < len(visibleNodes) && visibleNodes[m.outputCursor].expandable && visibleNodes[m.outputCursor].expanded {
+						visibleNodes[m.outputCursor].expanded = false
+					}
+				}
+			}
+		case "pgup":
+			switch m.activeTab {
+			case composeTabWfErrors:
+				m.wfErrors.cursor -= m.composeVisibleRows()
+				if m.wfErrors.cursor < 0 {
+					m.wfErrors.cursor = 0
+				}
+			}
+		case "pgdown":
+			switch m.activeTab {
+			case composeTabWfErrors:
+				items := flattenWfEventItems(m.getWfEvents())
+				m.wfErrors.cursor += m.composeVisibleRows()
+				if m.wfErrors.cursor >= len(items) {
+					m.wfErrors.cursor = len(items) - 1
+				}
+				if m.wfErrors.cursor < 0 {
+					m.wfErrors.cursor = 0
+				}
+			}
+		case "y":
+			content := m.composeCopyableContent()
+			if content != "" {
+				return m, copyToClipboardCmd(content)
+			}
+		}
+
+	case clipboardResultMsg:
+		if msg.err != nil {
+			m.clipboardMsg = fmt.Sprintf("✗ %v", msg.err)
+		} else {
+			m.clipboardMsg = "✓ Copied to clipboard"
+		}
+		return m, tea.Tick(2*time.Second, func(time.Time) tea.Msg { return clearClipboardMsg{} })
+	case clearClipboardMsg:
+		m.clipboardMsg = ""
+	}
+	return m, nil
+}
+
+func (m composeDetailModel) View() string {
+	if m.width == 0 || m.height == 0 {
+		return "Loading..."
+	}
+
+	if m.wfErrors.modalText != "" {
+		return renderWfEventModal(m.wfErrors, m.width, m.height)
+	}
+
+	header := m.renderComposeHeader()
+	tabs := m.renderComposeTabsWithBody()
+	footer := m.renderComposeFooter()
+
+	return lipgloss.JoinVertical(lipgloss.Left, header, tabs, footer)
+}
+
+func (m composeDetailModel) renderComposeHeader() string {
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230"))
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+
+	title := titleStyle.Render(m.node.Name)
+	if m.node.Name == "" {
+		title = titleStyle.Render(m.node.Key)
+	}
+
+	typeTag := dimStyle.Render(fmt.Sprintf("[%s]", m.node.Type))
+
+	return lipgloss.Place(m.width, 1, lipgloss.Left, lipgloss.Top,
+		lipgloss.NewStyle().Padding(0, 1).Render(fmt.Sprintf("%s  %s", title, typeTag)))
+}
+
+func (m composeDetailModel) renderComposeTabsWithBody() string {
+	inactiveTabBorder := tabBorderWithBottom("┴", "─", "┴")
+	activeTabBorder := tabBorderWithBottom("┘", " ", "└")
+
+	inactiveTabStyle := lipgloss.NewStyle().
+		Border(inactiveTabBorder, true).
+		BorderForeground(lipgloss.Color("240")).
+		Padding(0, 1)
+	activeTabStyle := lipgloss.NewStyle().
+		Border(activeTabBorder, true).
+		BorderForeground(lipgloss.Color("240")).
+		Padding(0, 1).
+		Bold(true).
+		Foreground(lipgloss.Color("230"))
+
+	var renderedTabs []string
+	for i, name := range composeTabNames {
+		style := inactiveTabStyle
+		isActive := i == m.activeTab
+
+		if isActive {
+			style = activeTabStyle
+		} else {
+			style = inactiveTabStyle
+		}
+
+		if i == 0 {
+			border := style.GetBorderStyle()
+			if isActive {
+				border.BottomLeft = "│"
+			} else {
+				border.BottomLeft = "├"
+			}
+			style = style.Border(border, true)
+		}
+		renderedTabs = append(renderedTabs, style.Render(name))
+	}
+
+	row := lipgloss.JoinHorizontal(lipgloss.Top, renderedTabs...)
+
+	rowWidth := lipgloss.Width(row)
+	gapWidth := m.width - rowWidth - 2
+	if gapWidth > 0 {
+		gap := lipgloss.NewStyle().Border(lipgloss.Border{
+			Bottom:      "─",
+			BottomLeft:  "┴",
+			BottomRight: "┐",
+		}, false, false, true).BorderForeground(lipgloss.Color("240")).Width(gapWidth).Render("")
+		row = lipgloss.JoinHorizontal(lipgloss.Bottom, row, gap)
+	}
+
+	content := m.getComposeTabContent()
+
+	window := lipgloss.NewStyle().
+		Border(lipgloss.Border{Left: "│", Right: "│", Bottom: "─", BottomLeft: "└", BottomRight: "┘"}, false, true, true).
+		BorderForeground(lipgloss.Color("240")).
+		Width(m.width - 2).
+		Height(m.composeBodyHeight()).
+		Render(content)
+
+	return lipgloss.JoinVertical(lipgloss.Left, row, window)
+}
+
+func (m composeDetailModel) getComposeTabContent() string {
+	switch m.activeTab {
+	case composeTabInputVars:
+		return m.renderComposeInputVarsTab()
+	case composeTabOutputVars:
+		return m.renderComposeOutputVarsTab()
+	case composeTabWfErrors:
+		return m.renderComposeWfErrorsTab()
+	}
+	return ""
+}
+
+func (m composeDetailModel) renderComposeInputVarsTab() string {
+	return m.renderComposeParamTreeTab("Input Parameters", m.inputTree, m.inputCursor, m.inputScroll)
+}
+
+func (m composeDetailModel) renderComposeOutputVarsTab() string {
+	return m.renderComposeParamTreeTab("Output Parameters", m.outputTree, m.outputCursor, m.outputScroll)
+}
+
+func (m composeDetailModel) renderComposeParamTreeTab(title string, tree []outputNode, cursor, scroll int) string {
+	if m.loading {
+		return fmt.Sprintf("\n  %s Fetching %s...", m.spinner.View(), strings.ToLower(title))
+	}
+	if m.loadErr != nil {
+		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
+		return fmt.Sprintf("\n  %s\n", errStyle.Render(fmt.Sprintf("Error: %v", m.loadErr)))
+	}
+	if len(tree) == 0 {
+		subtleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+		return fmt.Sprintf("\n  %s\n", subtleStyle.Render(fmt.Sprintf("No %s available for this resource.", strings.ToLower(title))))
+	}
+
+	var b strings.Builder
+
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
+	fmt.Fprintf(&b, "  %s\n\n", headerStyle.Render(title))
+
+	visibleNodes := flattenOutputTree(tree)
+
+	visibleRows := m.composeVisibleRows()
+	totalEntries := len(visibleNodes)
+	cursorIndex, scrollOffset := normalizeViewport(cursor, scroll, totalEntries, visibleRows)
+
+	end := scrollOffset + visibleRows
+	if end > totalEntries {
+		end = totalEntries
+	}
+
+	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("117"))
+	strStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("114"))
+	numStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("178"))
+	boolStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("178"))
+	nullStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	braceStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	selectedBg := lipgloss.NewStyle().Background(lipgloss.Color("236"))
+	maxLineWidth := m.composeContentWidth() - 4
+	if maxLineWidth < 1 {
+		maxLineWidth = 1
+	}
+	rowStyle := lipgloss.NewStyle().MaxWidth(maxLineWidth)
+	selectedRowStyle := selectedBg.MaxWidth(maxLineWidth)
+
+	for idx := scrollOffset; idx < end; idx++ {
+		node := visibleNodes[idx]
+		indent := strings.Repeat("  ", node.depth)
+
+		cursorMarker := "  "
+		if idx == cursorIndex {
+			cursorMarker = "▶ "
+		}
+
+		var line string
+		if node.expandable {
+			arrow := "▸"
+			if node.expanded {
+				arrow = "▾"
+			}
+			childCount := len(node.children)
+			typeMark := braceStyle.Render("{}")
+			if node.nodeType == "array" {
+				typeMark = braceStyle.Render("[]")
+			}
+			countStr := lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render(fmt.Sprintf("  %d items", childCount))
+			line = fmt.Sprintf("%s%s %s %s%s", indent, arrow, keyStyle.Render(node.key), typeMark, countStr)
+		} else {
+			var styledVal string
+			switch node.nodeType {
+			case "string":
+				styledVal = strStyle.Render(fmt.Sprintf("%q", node.value))
+			case "number":
+				styledVal = numStyle.Render(node.value)
+			case "bool":
+				styledVal = boolStyle.Render(node.value)
+			case "null":
+				styledVal = nullStyle.Render("null")
+			default:
+				styledVal = lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Render(node.value)
+			}
+			line = fmt.Sprintf("%s  %s: %s", indent, keyStyle.Render(node.key), styledVal)
+		}
+
+		if idx == cursorIndex {
+			line = selectedRowStyle.Render(line)
+		} else {
+			line = rowStyle.Render(line)
+		}
+
+		fmt.Fprintf(&b, "  %s%s\n", cursorMarker, line)
+	}
+
+	if totalEntries > visibleRows {
+		dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+		pos := ""
+		if scrollOffset == 0 {
+			pos = "top"
+		} else if end >= totalEntries {
+			pos = "end"
+		} else {
+			pct := (scrollOffset * 100) / (totalEntries - visibleRows)
+			pos = fmt.Sprintf("%d%%", pct)
+		}
+		fmt.Fprintf(&b, "\n  %s\n", dimStyle.Render(fmt.Sprintf("↑↓: navigate  ←→/enter: expand/collapse  [%d/%d %s]", cursorIndex+1, totalEntries, pos)))
+	}
+
+	return b.String()
+}
+
+func (m composeDetailModel) renderComposeWfErrorsTab() string {
+	loading := m.debugData.PlanDAG != nil && m.debugData.PlanDAG.ProgressLoading
+	steps := m.getWfEvents()
+	enrichBootstrapSteps(steps, m.node.Key, m.debugData.PlanDAG)
+	isLive := isWorkflowInProgress(steps)
+	return renderWorkflowEventsTab(steps, m.wfErrors, m.composeBodyHeight(), m.composeContentWidth(), loading, m.spinner.View(), isLive)
+}
+
+func (m composeDetailModel) renderComposeFooter() string {
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Padding(0, 1)
+	var text string
+	switch m.activeTab {
+	case composeTabInputVars, composeTabOutputVars:
+		if (m.activeTab == composeTabInputVars && len(m.inputTree) > 0) ||
+			(m.activeTab == composeTabOutputVars && len(m.outputTree) > 0) {
+			text = "↑↓: navigate  ←→/enter: expand/collapse  y: copy  tab/shift+tab: switch tabs  esc: back  q: quit"
+		} else {
+			text = "tab/shift+tab: switch tabs  esc: back  q: quit"
+		}
+	case composeTabWfErrors:
+		text = "↑↓/pgup/pgdn: scroll  y: copy  tab/shift+tab: switch tabs  esc: back  q: quit"
+	default:
+		text = "tab/shift+tab: switch tabs  esc: back  q: quit"
+	}
+	if m.clipboardMsg != "" {
+		clipStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("82"))
+		text = clipStyle.Render(m.clipboardMsg) + "  " + text
+	}
+	return lipgloss.Place(m.width, 1, lipgloss.Left, lipgloss.Top, style.Render(text))
+}
+
+func (m composeDetailModel) composeCopyableContent() string {
+	switch m.activeTab {
+	case composeTabInputVars:
+		if m.composeData != nil && len(m.composeData.InputParams) > 0 {
+			raw, err := json.Marshal(m.composeData.InputParams)
+			if err == nil {
+				return string(raw)
+			}
+		}
+	case composeTabOutputVars:
+		if m.composeData != nil && len(m.composeData.OutputParams) > 0 {
+			raw, err := json.Marshal(m.composeData.OutputParams)
+			if err == nil {
+				return string(raw)
+			}
+		}
+	case composeTabWfErrors:
+		return workflowEventsCopyText(m.getWfEvents())
+	}
+	return ""
+}
+
+func (m composeDetailModel) composeBodyHeight() int {
+	h := m.height - 8
+	if h < 1 {
+		h = 1
+	}
+	return h
+}
+
+func (m composeDetailModel) composeVisibleRows() int {
+	rows := m.composeBodyHeight() - 4
+	if rows < 1 {
+		rows = 1
+	}
+	return rows
+}
+
+func (m composeDetailModel) composeContentWidth() int {
+	w := m.width - 4
+	if w < 20 {
+		w = 20
+	}
+	return w
+}
+
+func (m composeDetailModel) getWfEvents() *ResourceWorkflowSteps {
+	if m.debugData.PlanDAG != nil && m.debugData.PlanDAG.WorkflowStepsByKey != nil {
+		return m.debugData.PlanDAG.WorkflowStepsByKey[m.node.Key]
+	}
+	return nil
+}

--- a/cmd/instance/debug_compose_detail_tui.go
+++ b/cmd/instance/debug_compose_detail_tui.go
@@ -18,7 +18,7 @@ const (
 	composeNumTabs       = 3
 )
 
-var composeTabNames = []string{"Input Parameters", "Output Parameters", "Workflow Events"}
+var composeTabNames = []string{"Deployment API parameters", "Deployment Output Parameters", "Workflow Events"}
 
 func init() {
 	if len(composeTabNames) != composeNumTabs {
@@ -320,11 +320,11 @@ func (m composeDetailModel) getComposeTabContent() string {
 }
 
 func (m composeDetailModel) renderComposeInputVarsTab() string {
-	return m.renderComposeParamTreeTab("Input Parameters", m.inputTree, m.inputCursor, m.inputScroll, m.inputErr)
+	return m.renderComposeParamTreeTab("Deployment API parameters", m.inputTree, m.inputCursor, m.inputScroll, m.inputErr)
 }
 
 func (m composeDetailModel) renderComposeOutputVarsTab() string {
-	return m.renderComposeParamTreeTab("Output Parameters", m.outputTree, m.outputCursor, m.outputScroll, m.outputErr)
+	return m.renderComposeParamTreeTab("Deployment Output Parameters", m.outputTree, m.outputCursor, m.outputScroll, m.outputErr)
 }
 
 func (m composeDetailModel) renderComposeParamTreeTab(title string, tree []outputNode, cursor, scroll int, fetchErr error) string {

--- a/cmd/instance/debug_compose_detail_tui.go
+++ b/cmd/instance/debug_compose_detail_tui.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -66,16 +65,12 @@ type composeDetailModel struct {
 }
 
 func newComposeDetailModel(node PlanDAGNode, data DebugData) composeDetailModel {
-	s := spinner.New()
-	s.Spinner = spinner.Dot
-	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
-
 	return composeDetailModel{
 		node:      node,
 		debugData: data,
 		activeTab: composeTabInputVars,
 		loading:   true,
-		spinner:   s,
+		spinner:   newResourceDetailSpinner(),
 		wfErrors:  &workflowErrorsState{},
 	}
 }
@@ -144,39 +139,14 @@ func (m composeDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.inputTree = buildOperatorParamTree(m.composeData.InputParams)
 			m.outputTree = buildOperatorOutputParamTree(m.composeData.OutputParams)
 		}
-		var cmds []tea.Cmd
-		if isWorkflowInProgress(m.getWfEvents()) {
-			cmds = append(cmds, scheduleWfEventsRefresh(), scheduleWfCountdownTick())
-		}
-		if len(cmds) > 0 {
-			return m, tea.Batch(cmds...)
-		}
-		return m, nil
+		return m, scheduleResourceWorkflowRefreshIfNeeded(m.debugData, m.node)
 
 	case wfEventsRefreshTickMsg:
-		steps := m.getWfEvents()
-		if isWorkflowInProgress(steps) && !m.wfErrors.refreshing {
-			m.wfErrors.refreshing = true
-			return m, fetchWfEventsForResource(m.debugData, m.node.Key)
-		}
+		return m, handleResourceWorkflowRefreshTick(m.debugData, m.node, m.wfErrors)
 	case wfEventsRefreshMsg:
-		m.wfErrors.refreshing = false
-		m.wfErrors.lastRefresh = time.Now()
-		if msg.err == nil && msg.steps != nil {
-			if m.debugData.PlanDAG != nil {
-				if m.debugData.PlanDAG.WorkflowStepsByKey == nil {
-					m.debugData.PlanDAG.WorkflowStepsByKey = make(map[string]*ResourceWorkflowSteps)
-				}
-				m.debugData.PlanDAG.WorkflowStepsByKey[m.node.Key] = msg.steps
-			}
-		}
-		if isWorkflowInProgress(m.getWfEvents()) {
-			return m, tea.Batch(scheduleWfEventsRefresh(), scheduleWfCountdownTick())
-		}
+		return m, handleResourceWorkflowRefresh(m.debugData, m.node, m.wfErrors, msg)
 	case wfCountdownTickMsg:
-		if isWorkflowInProgress(m.getWfEvents()) {
-			return m, scheduleWfCountdownTick()
-		}
+		return m, handleResourceWorkflowCountdown(m.debugData, m.node)
 
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -211,25 +181,9 @@ func (m composeDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			switch m.activeTab {
 			case composeTabInputVars:
-				if len(m.inputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.inputTree)
-					if m.inputCursor > 0 {
-						m.inputCursor--
-					}
-					m.inputCursor, m.inputScroll = normalizeViewport(
-						m.inputCursor, m.inputScroll, len(visibleNodes), m.composeVisibleRows(),
-					)
-				}
+				m.inputCursor, m.inputScroll = moveResourceDetailTreeUp(m.inputTree, m.inputCursor, m.inputScroll, m.composeVisibleRows())
 			case composeTabOutputVars:
-				if len(m.outputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.outputTree)
-					if m.outputCursor > 0 {
-						m.outputCursor--
-					}
-					m.outputCursor, m.outputScroll = normalizeViewport(
-						m.outputCursor, m.outputScroll, len(visibleNodes), m.composeVisibleRows(),
-					)
-				}
+				m.outputCursor, m.outputScroll = moveResourceDetailTreeUp(m.outputTree, m.outputCursor, m.outputScroll, m.composeVisibleRows())
 			case composeTabWfErrors:
 				items := flattenWfEventItems(m.getWfEvents())
 				if m.wfErrors.cursor > 0 {
@@ -248,25 +202,9 @@ func (m composeDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			switch m.activeTab {
 			case composeTabInputVars:
-				if len(m.inputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.inputTree)
-					if m.inputCursor < len(visibleNodes)-1 {
-						m.inputCursor++
-					}
-					m.inputCursor, m.inputScroll = normalizeViewport(
-						m.inputCursor, m.inputScroll, len(visibleNodes), m.composeVisibleRows(),
-					)
-				}
+				m.inputCursor, m.inputScroll = moveResourceDetailTreeDown(m.inputTree, m.inputCursor, m.inputScroll, m.composeVisibleRows())
 			case composeTabOutputVars:
-				if len(m.outputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.outputTree)
-					if m.outputCursor < len(visibleNodes)-1 {
-						m.outputCursor++
-					}
-					m.outputCursor, m.outputScroll = normalizeViewport(
-						m.outputCursor, m.outputScroll, len(visibleNodes), m.composeVisibleRows(),
-					)
-				}
+				m.outputCursor, m.outputScroll = moveResourceDetailTreeDown(m.outputTree, m.outputCursor, m.outputScroll, m.composeVisibleRows())
 			case composeTabWfErrors:
 				items := flattenWfEventItems(m.getWfEvents())
 				if m.wfErrors.cursor < len(items)-1 {
@@ -277,19 +215,9 @@ func (m composeDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "enter":
 			switch m.activeTab {
 			case composeTabInputVars:
-				if len(m.inputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.inputTree)
-					if m.inputCursor < len(visibleNodes) && visibleNodes[m.inputCursor].expandable {
-						visibleNodes[m.inputCursor].expanded = !visibleNodes[m.inputCursor].expanded
-					}
-				}
+				toggleResourceDetailTreeNode(m.inputTree, m.inputCursor)
 			case composeTabOutputVars:
-				if len(m.outputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.outputTree)
-					if m.outputCursor < len(visibleNodes) && visibleNodes[m.outputCursor].expandable {
-						visibleNodes[m.outputCursor].expanded = !visibleNodes[m.outputCursor].expanded
-					}
-				}
+				toggleResourceDetailTreeNode(m.outputTree, m.outputCursor)
 			case composeTabWfErrors:
 				items := flattenWfEventItems(m.getWfEvents())
 				if m.wfErrors.cursor < len(items) {
@@ -304,36 +232,16 @@ func (m composeDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "right", "l":
 			switch m.activeTab {
 			case composeTabInputVars:
-				if len(m.inputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.inputTree)
-					if m.inputCursor < len(visibleNodes) && visibleNodes[m.inputCursor].expandable && !visibleNodes[m.inputCursor].expanded {
-						visibleNodes[m.inputCursor].expanded = true
-					}
-				}
+				expandResourceDetailTreeNode(m.inputTree, m.inputCursor)
 			case composeTabOutputVars:
-				if len(m.outputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.outputTree)
-					if m.outputCursor < len(visibleNodes) && visibleNodes[m.outputCursor].expandable && !visibleNodes[m.outputCursor].expanded {
-						visibleNodes[m.outputCursor].expanded = true
-					}
-				}
+				expandResourceDetailTreeNode(m.outputTree, m.outputCursor)
 			}
 		case "left", "h":
 			switch m.activeTab {
 			case composeTabInputVars:
-				if len(m.inputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.inputTree)
-					if m.inputCursor < len(visibleNodes) && visibleNodes[m.inputCursor].expandable && visibleNodes[m.inputCursor].expanded {
-						visibleNodes[m.inputCursor].expanded = false
-					}
-				}
+				collapseResourceDetailTreeNode(m.inputTree, m.inputCursor)
 			case composeTabOutputVars:
-				if len(m.outputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.outputTree)
-					if m.outputCursor < len(visibleNodes) && visibleNodes[m.outputCursor].expandable && visibleNodes[m.outputCursor].expanded {
-						visibleNodes[m.outputCursor].expanded = false
-					}
-				}
+				collapseResourceDetailTreeNode(m.outputTree, m.outputCursor)
 			}
 		case "pgup":
 			switch m.activeTab {
@@ -392,81 +300,11 @@ func (m composeDetailModel) View() string {
 }
 
 func (m composeDetailModel) renderComposeHeader() string {
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230"))
-	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-
-	title := titleStyle.Render(m.node.Name)
-	if m.node.Name == "" {
-		title = titleStyle.Render(m.node.Key)
-	}
-
-	typeTag := dimStyle.Render(fmt.Sprintf("[%s]", m.node.Type))
-
-	return lipgloss.Place(m.width, 1, lipgloss.Left, lipgloss.Top,
-		lipgloss.NewStyle().Padding(0, 1).Render(fmt.Sprintf("%s  %s", title, typeTag)))
+	return renderResourceDetailHeader(m.width, m.node)
 }
 
 func (m composeDetailModel) renderComposeTabsWithBody() string {
-	inactiveTabBorder := tabBorderWithBottom("┴", "─", "┴")
-	activeTabBorder := tabBorderWithBottom("┘", " ", "└")
-
-	inactiveTabStyle := lipgloss.NewStyle().
-		Border(inactiveTabBorder, true).
-		BorderForeground(lipgloss.Color("240")).
-		Padding(0, 1)
-	activeTabStyle := lipgloss.NewStyle().
-		Border(activeTabBorder, true).
-		BorderForeground(lipgloss.Color("240")).
-		Padding(0, 1).
-		Bold(true).
-		Foreground(lipgloss.Color("230"))
-
-	var renderedTabs []string
-	for i, name := range composeTabNames {
-		style := inactiveTabStyle
-		isActive := i == m.activeTab
-
-		if isActive {
-			style = activeTabStyle
-		} else {
-			style = inactiveTabStyle
-		}
-
-		if i == 0 {
-			border := style.GetBorderStyle()
-			if isActive {
-				border.BottomLeft = "│"
-			} else {
-				border.BottomLeft = "├"
-			}
-			style = style.Border(border, true)
-		}
-		renderedTabs = append(renderedTabs, style.Render(name))
-	}
-
-	row := lipgloss.JoinHorizontal(lipgloss.Top, renderedTabs...)
-
-	rowWidth := lipgloss.Width(row)
-	gapWidth := m.width - rowWidth - 2
-	if gapWidth > 0 {
-		gap := lipgloss.NewStyle().Border(lipgloss.Border{
-			Bottom:      "─",
-			BottomLeft:  "┴",
-			BottomRight: "┐",
-		}, false, false, true).BorderForeground(lipgloss.Color("240")).Width(gapWidth).Render("")
-		row = lipgloss.JoinHorizontal(lipgloss.Bottom, row, gap)
-	}
-
-	content := m.getComposeTabContent()
-
-	window := lipgloss.NewStyle().
-		Border(lipgloss.Border{Left: "│", Right: "│", Bottom: "─", BottomLeft: "└", BottomRight: "┘"}, false, true, true).
-		BorderForeground(lipgloss.Color("240")).
-		Width(m.width - 2).
-		Height(m.composeBodyHeight()).
-		Render(content)
-
-	return lipgloss.JoinVertical(lipgloss.Left, row, window)
+	return renderResourceDetailTabsWithBody(m.width, m.composeBodyHeight(), composeTabNames, m.activeTab, m.getComposeTabContent())
 }
 
 func (m composeDetailModel) getComposeTabContent() string {
@@ -490,127 +328,14 @@ func (m composeDetailModel) renderComposeOutputVarsTab() string {
 }
 
 func (m composeDetailModel) renderComposeParamTreeTab(title string, tree []outputNode, cursor, scroll int, fetchErr error) string {
-	if m.loading {
-		return fmt.Sprintf("\n  %s Fetching %s...", m.spinner.View(), strings.ToLower(title))
-	}
-	if fetchErr != nil {
-		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
-		return fmt.Sprintf("\n  %s\n", errStyle.Render(fmt.Sprintf("Error fetching %s: %v", strings.ToLower(title), fetchErr)))
-	}
-	if m.loadErr != nil {
-		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
-		return fmt.Sprintf("\n  %s\n", errStyle.Render(fmt.Sprintf("Error: %v", m.loadErr)))
-	}
-	if len(tree) == 0 {
-		subtleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-		return fmt.Sprintf("\n  %s\n", subtleStyle.Render(fmt.Sprintf("No %s available for this resource.", strings.ToLower(title))))
-	}
-
-	var b strings.Builder
-
-	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
-	fmt.Fprintf(&b, "  %s\n\n", headerStyle.Render(title))
-
-	visibleNodes := flattenOutputTree(tree)
-
-	visibleRows := m.composeVisibleRows()
-	totalEntries := len(visibleNodes)
-	cursorIndex, scrollOffset := normalizeViewport(cursor, scroll, totalEntries, visibleRows)
-
-	end := scrollOffset + visibleRows
-	if end > totalEntries {
-		end = totalEntries
-	}
-
-	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("117"))
-	strStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("114"))
-	numStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("178"))
-	boolStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("178"))
-	nullStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
-	braceStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-	selectedBg := lipgloss.NewStyle().Background(lipgloss.Color("236"))
-	maxLineWidth := m.composeContentWidth() - 4
-	if maxLineWidth < 1 {
-		maxLineWidth = 1
-	}
-	rowStyle := lipgloss.NewStyle().MaxWidth(maxLineWidth)
-	selectedRowStyle := selectedBg.MaxWidth(maxLineWidth)
-
-	for idx := scrollOffset; idx < end; idx++ {
-		node := visibleNodes[idx]
-		indent := strings.Repeat("  ", node.depth)
-
-		cursorMarker := "  "
-		if idx == cursorIndex {
-			cursorMarker = "▶ "
-		}
-
-		var line string
-		if node.expandable {
-			arrow := "▸"
-			if node.expanded {
-				arrow = "▾"
-			}
-			childCount := len(node.children)
-			typeMark := braceStyle.Render("{}")
-			if node.nodeType == "array" {
-				typeMark = braceStyle.Render("[]")
-			}
-			countStr := lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render(fmt.Sprintf("  %d items", childCount))
-			line = fmt.Sprintf("%s%s %s %s%s", indent, arrow, keyStyle.Render(node.key), typeMark, countStr)
-		} else {
-			var styledVal string
-			switch node.nodeType {
-			case "string":
-				styledVal = strStyle.Render(fmt.Sprintf("%q", node.value))
-			case "number":
-				styledVal = numStyle.Render(node.value)
-			case "bool":
-				styledVal = boolStyle.Render(node.value)
-			case "null":
-				styledVal = nullStyle.Render("null")
-			default:
-				styledVal = lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Render(node.value)
-			}
-			line = fmt.Sprintf("%s  %s: %s", indent, keyStyle.Render(node.key), styledVal)
-		}
-
-		if idx == cursorIndex {
-			line = selectedRowStyle.Render(line)
-		} else {
-			line = rowStyle.Render(line)
-		}
-
-		fmt.Fprintf(&b, "  %s%s\n", cursorMarker, line)
-	}
-
-	if totalEntries > visibleRows {
-		dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
-		pos := ""
-		if scrollOffset == 0 {
-			pos = "top"
-		} else if end >= totalEntries {
-			pos = "end"
-		} else {
-			pct := (scrollOffset * 100) / (totalEntries - visibleRows)
-			pos = fmt.Sprintf("%d%%", pct)
-		}
-		fmt.Fprintf(&b, "\n  %s\n", dimStyle.Render(fmt.Sprintf("↑↓: navigate  [%d/%d %s]", cursorIndex+1, totalEntries, pos)))
-	}
-
-	return b.String()
+	return renderResourceDetailParamTreeTab(title, tree, cursor, scroll, m.composeVisibleRows(), m.composeContentWidth(), m.loading, m.spinner.View(), m.loadErr, fetchErr, false)
 }
 
 func (m composeDetailModel) renderComposeWfErrorsTab() string {
-	loading := m.debugData.PlanDAG != nil && m.debugData.PlanDAG.ProgressLoading
-	steps := m.getWfEvents()
-	enrichBootstrapSteps(steps, m.node.Key, m.debugData.PlanDAG)
-	isLive := isWorkflowInProgress(steps)
-	return renderWorkflowEventsTab(steps, m.wfErrors, m.composeBodyHeight(), m.composeContentWidth(), loading, m.spinner.View(), isLive)
+	return renderResourceWorkflowEventsTab(m.debugData, m.node, m.wfErrors, m.composeBodyHeight(), m.composeContentWidth(), m.spinner.View())
 }
 
 func (m composeDetailModel) renderComposeFooter() string {
-	style := lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Padding(0, 1)
 	var text string
 	switch m.activeTab {
 	case composeTabInputVars, composeTabOutputVars:
@@ -625,11 +350,7 @@ func (m composeDetailModel) renderComposeFooter() string {
 	default:
 		text = "tab/shift+tab: switch tabs  esc: back  q: quit"
 	}
-	if m.clipboardMsg != "" {
-		clipStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("82"))
-		text = clipStyle.Render(m.clipboardMsg) + "  " + text
-	}
-	return lipgloss.Place(m.width, 1, lipgloss.Left, lipgloss.Top, style.Render(text))
+	return renderResourceDetailFooter(m.width, m.clipboardMsg, text)
 }
 
 func (m composeDetailModel) composeCopyableContent() string {
@@ -655,32 +376,17 @@ func (m composeDetailModel) composeCopyableContent() string {
 }
 
 func (m composeDetailModel) composeBodyHeight() int {
-	h := m.height - 8
-	if h < 1 {
-		h = 1
-	}
-	return h
+	return resourceDetailBodyHeight(m.height)
 }
 
 func (m composeDetailModel) composeVisibleRows() int {
-	rows := m.composeBodyHeight() - 4
-	if rows < 1 {
-		rows = 1
-	}
-	return rows
+	return resourceDetailVisibleRows(m.height)
 }
 
 func (m composeDetailModel) composeContentWidth() int {
-	w := m.width - 4
-	if w < 20 {
-		w = 20
-	}
-	return w
+	return resourceDetailContentWidth(m.width)
 }
 
 func (m composeDetailModel) getWfEvents() *ResourceWorkflowSteps {
-	if m.debugData.PlanDAG != nil && m.debugData.PlanDAG.WorkflowStepsByKey != nil {
-		return m.debugData.PlanDAG.WorkflowStepsByKey[m.node.Key]
-	}
-	return nil
+	return getResourceWorkflowEvents(m.debugData, m.node)
 }

--- a/cmd/instance/debug_compose_detail_tui_test.go
+++ b/cmd/instance/debug_compose_detail_tui_test.go
@@ -1,0 +1,246 @@
+package instance
+
+import (
+	"encoding/json"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComposeTabNames(t *testing.T) {
+	require.Equal(t, composeNumTabs, len(composeTabNames), "composeTabNames length must match composeNumTabs")
+	require.Equal(t, "Input Parameters", composeTabNames[composeTabInputVars])
+	require.Equal(t, "Output Parameters", composeTabNames[composeTabOutputVars])
+	require.Equal(t, "Workflow Events", composeTabNames[composeTabWfErrors])
+}
+
+func TestNewComposeDetailModel(t *testing.T) {
+	node := PlanDAGNode{ID: "r1", Key: "my-compose", Name: "My Compose", Type: "DockerCompose"}
+	data := DebugData{InstanceID: "inst-1", ServiceID: "svc-1"}
+
+	m := newComposeDetailModel(node, data)
+
+	require.Equal(t, composeTabInputVars, m.activeTab)
+	require.True(t, m.loading)
+	require.NotNil(t, m.wfErrors)
+	require.Equal(t, "my-compose", m.node.Key)
+}
+
+func TestComposeTabCyclesAllThreeTabs(t *testing.T) {
+	model := composeDetailModel{
+		activeTab: composeTabInputVars,
+		wfErrors:  &workflowErrorsState{},
+	}
+
+	for i := 0; i < composeNumTabs; i++ {
+		require.Equal(t, i, model.activeTab)
+		updatedAny, _ := model.Update(tea.KeyMsg{Type: tea.KeyTab})
+		model = updatedAny.(composeDetailModel)
+	}
+	// Should wrap to 0
+	require.Equal(t, composeTabInputVars, model.activeTab)
+}
+
+func TestComposeShiftTabReverses(t *testing.T) {
+	model := composeDetailModel{
+		activeTab: composeTabInputVars,
+		wfErrors:  &workflowErrorsState{},
+	}
+
+	// Shift+tab from first goes to last
+	updatedAny, _ := model.Update(tea.KeyMsg{Type: tea.KeyShiftTab})
+	model = updatedAny.(composeDetailModel)
+	require.Equal(t, composeTabWfErrors, model.activeTab)
+}
+
+func TestComposeInputTabNavigationUpDown(t *testing.T) {
+	params := []OperatorInputParam{
+		{Key: "a", DisplayName: "A", Type: "String", ResolvedValue: "val-a"},
+		{Key: "b", DisplayName: "B", Type: "String", ResolvedValue: "val-b"},
+	}
+
+	model := composeDetailModel{
+		activeTab: composeTabInputVars,
+		width:     80,
+		height:    20,
+		inputTree: buildOperatorParamTree(params),
+		wfErrors:  &workflowErrorsState{},
+	}
+
+	// Move down
+	updatedAny, _ := model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	updated := updatedAny.(composeDetailModel)
+	require.Equal(t, 1, updated.inputCursor)
+
+	// Move up
+	updatedAny, _ = updated.Update(tea.KeyMsg{Type: tea.KeyUp})
+	updated = updatedAny.(composeDetailModel)
+	require.Equal(t, 0, updated.inputCursor)
+}
+
+func TestComposeOutputTabNavigationUpDown(t *testing.T) {
+	params := []OperatorOutputParam{
+		{Key: "x", DisplayName: "X", Description: "Param X"},
+		{Key: "y", DisplayName: "Y", Description: "Param Y"},
+	}
+
+	model := composeDetailModel{
+		activeTab:    composeTabOutputVars,
+		width:        80,
+		height:       20,
+		outputTree:   buildOperatorOutputParamTree(params),
+		outputCursor: 0,
+		wfErrors:     &workflowErrorsState{},
+	}
+
+	// Move down
+	updatedAny, _ := model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	updated := updatedAny.(composeDetailModel)
+	require.Equal(t, 1, updated.outputCursor)
+
+	// Move up
+	updatedAny, _ = updated.Update(tea.KeyMsg{Type: tea.KeyUp})
+	updated = updatedAny.(composeDetailModel)
+	require.Equal(t, 0, updated.outputCursor)
+}
+
+func TestComposeCopyableContent(t *testing.T) {
+	node := PlanDAGNode{ID: "r1", Key: "my-compose", Name: "Compose", Type: "DockerCompose"}
+	data := DebugData{InstanceID: "inst-1"}
+
+	m := newComposeDetailModel(node, data)
+	m.loading = false
+	m.composeData = &ComposeData{
+		InputParams: []OperatorInputParam{
+			{Key: "replicas", Type: "int", Required: true},
+		},
+		OutputParams: []OperatorOutputParam{
+			{Key: "status", Description: "Status", Type: "string"},
+		},
+	}
+
+	t.Run("input vars tab", func(t *testing.T) {
+		m.activeTab = composeTabInputVars
+		content := m.composeCopyableContent()
+		require.Contains(t, content, "replicas")
+	})
+
+	t.Run("output vars tab", func(t *testing.T) {
+		m.activeTab = composeTabOutputVars
+		content := m.composeCopyableContent()
+		require.Contains(t, content, "status")
+	})
+
+	t.Run("wf errors tab with no events", func(t *testing.T) {
+		m.activeTab = composeTabWfErrors
+		content := m.composeCopyableContent()
+		require.Empty(t, content)
+	})
+}
+
+func TestComposeDataJSONIncludesInputOutputParams(t *testing.T) {
+	require := require.New(t)
+
+	composeData := &ComposeData{
+		InputParams: []OperatorInputParam{
+			{Key: "port", DisplayName: "Port", Type: "String", Required: true},
+		},
+		OutputParams: []OperatorOutputParam{
+			{Key: "endpoint", DisplayName: "Endpoint", Value: "https://example.com"},
+		},
+	}
+
+	jsonBytes, err := json.Marshal(composeData)
+	require.NoError(err)
+
+	var decoded map[string]interface{}
+	require.NoError(json.Unmarshal(jsonBytes, &decoded))
+
+	require.Contains(decoded, "inputParams")
+	require.Contains(decoded, "outputParams")
+}
+
+func TestComposeDataJSONOmitsEmptyInputOutputParams(t *testing.T) {
+	require := require.New(t)
+
+	composeData := &ComposeData{}
+
+	jsonBytes, err := json.Marshal(composeData)
+	require.NoError(err)
+
+	var decoded map[string]interface{}
+	require.NoError(json.Unmarshal(jsonBytes, &decoded))
+
+	require.NotContains(decoded, "inputParams")
+	require.NotContains(decoded, "outputParams")
+}
+
+func TestComposeRenderParamTreeTabShowsTitle(t *testing.T) {
+	params := []OperatorInputParam{
+		{Key: "name", DisplayName: "Name", Type: "String", ResolvedValue: "my-app"},
+	}
+
+	model := composeDetailModel{
+		activeTab:   composeTabInputVars,
+		width:       80,
+		height:      20,
+		inputTree:   buildOperatorParamTree(params),
+		composeData: &ComposeData{InputParams: params},
+		wfErrors:    &workflowErrorsState{},
+	}
+
+	rendered := model.renderComposeParamTreeTab("Input Parameters", model.inputTree, model.inputCursor, model.inputScroll)
+	require.Contains(t, rendered, "Input Parameters")
+}
+
+func TestComposeRenderParamTreeTabEmptyShowsNoDataMessage(t *testing.T) {
+	model := composeDetailModel{
+		activeTab: composeTabInputVars,
+		width:     80,
+		height:    20,
+		inputTree: nil,
+		wfErrors:  &workflowErrorsState{},
+	}
+
+	rendered := model.renderComposeParamTreeTab("Input Parameters", model.inputTree, 0, 0)
+	require.Contains(t, rendered, "No input parameters available")
+}
+
+func TestComposeFooterShowsTreeNavForInputOutputTabs(t *testing.T) {
+	model := composeDetailModel{
+		width:    80,
+		height:   20,
+		wfErrors: &workflowErrorsState{},
+		inputTree: buildOperatorParamTree([]OperatorInputParam{
+			{Key: "x", DisplayName: "X", Description: "test"},
+		}),
+		outputTree: buildOperatorOutputParamTree([]OperatorOutputParam{
+			{Key: "y", DisplayName: "Y", Description: "test"},
+		}),
+	}
+
+	model.activeTab = composeTabInputVars
+	footer := model.renderComposeFooter()
+	require.Contains(t, footer, "expand/collapse")
+
+	model.activeTab = composeTabOutputVars
+	footer = model.renderComposeFooter()
+	require.Contains(t, footer, "expand/collapse")
+
+	model.activeTab = composeTabWfErrors
+	footer = model.renderComposeFooter()
+	require.Contains(t, footer, "pgup/pgdn")
+}
+
+func TestResourceDebugInfoHasDataWithCompose(t *testing.T) {
+	info := &ResourceDebugInfo{
+		Compose: &ComposeData{
+			InputParams: []OperatorInputParam{{Key: "x"}},
+		},
+	}
+	require.True(t, info.hasData())
+
+	emptyInfo := &ResourceDebugInfo{}
+	require.False(t, emptyInfo.hasData())
+}

--- a/cmd/instance/debug_compose_detail_tui_test.go
+++ b/cmd/instance/debug_compose_detail_tui_test.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -190,7 +191,7 @@ func TestComposeRenderParamTreeTabShowsTitle(t *testing.T) {
 		wfErrors:    &workflowErrorsState{},
 	}
 
-	rendered := model.renderComposeParamTreeTab("Input Parameters", model.inputTree, model.inputCursor, model.inputScroll)
+	rendered := model.renderComposeParamTreeTab("Input Parameters", model.inputTree, model.inputCursor, model.inputScroll, nil)
 	require.Contains(t, rendered, "Input Parameters")
 }
 
@@ -203,11 +204,25 @@ func TestComposeRenderParamTreeTabEmptyShowsNoDataMessage(t *testing.T) {
 		wfErrors:  &workflowErrorsState{},
 	}
 
-	rendered := model.renderComposeParamTreeTab("Input Parameters", model.inputTree, 0, 0)
+	rendered := model.renderComposeParamTreeTab("Input Parameters", model.inputTree, 0, 0, nil)
 	require.Contains(t, rendered, "No input parameters available")
 }
 
-func TestComposeFooterShowsTreeNavForInputOutputTabs(t *testing.T) {
+func TestComposeRenderParamTreeTabShowsFetchError(t *testing.T) {
+	model := composeDetailModel{
+		activeTab: composeTabInputVars,
+		width:     80,
+		height:    20,
+		wfErrors:  &workflowErrorsState{},
+	}
+
+	rendered := model.renderComposeParamTreeTab("Input Parameters", model.inputTree, 0, 0, errors.New("request failed"))
+	require.Contains(t, rendered, "Error fetching input parameters")
+	require.Contains(t, rendered, "request failed")
+	require.NotContains(t, rendered, "No input parameters available")
+}
+
+func TestComposeFooterShowsNavigationForInputOutputTabs(t *testing.T) {
 	model := composeDetailModel{
 		width:    80,
 		height:   20,
@@ -222,11 +237,15 @@ func TestComposeFooterShowsTreeNavForInputOutputTabs(t *testing.T) {
 
 	model.activeTab = composeTabInputVars
 	footer := model.renderComposeFooter()
-	require.Contains(t, footer, "expand/collapse")
+	require.Contains(t, footer, "↑↓: navigate")
+	require.Contains(t, footer, "y: copy")
+	require.NotContains(t, footer, "expand/collapse")
 
 	model.activeTab = composeTabOutputVars
 	footer = model.renderComposeFooter()
-	require.Contains(t, footer, "expand/collapse")
+	require.Contains(t, footer, "↑↓: navigate")
+	require.Contains(t, footer, "y: copy")
+	require.NotContains(t, footer, "expand/collapse")
 
 	model.activeTab = composeTabWfErrors
 	footer = model.renderComposeFooter()

--- a/cmd/instance/debug_compose_detail_tui_test.go
+++ b/cmd/instance/debug_compose_detail_tui_test.go
@@ -11,8 +11,8 @@ import (
 
 func TestComposeTabNames(t *testing.T) {
 	require.Equal(t, composeNumTabs, len(composeTabNames), "composeTabNames length must match composeNumTabs")
-	require.Equal(t, "Input Parameters", composeTabNames[composeTabInputVars])
-	require.Equal(t, "Output Parameters", composeTabNames[composeTabOutputVars])
+	require.Equal(t, "Deployment API parameters", composeTabNames[composeTabInputVars])
+	require.Equal(t, "Deployment Output Parameters", composeTabNames[composeTabOutputVars])
 	require.Equal(t, "Workflow Events", composeTabNames[composeTabWfErrors])
 }
 
@@ -191,8 +191,8 @@ func TestComposeRenderParamTreeTabShowsTitle(t *testing.T) {
 		wfErrors:    &workflowErrorsState{},
 	}
 
-	rendered := model.renderComposeParamTreeTab("Input Parameters", model.inputTree, model.inputCursor, model.inputScroll, nil)
-	require.Contains(t, rendered, "Input Parameters")
+	rendered := model.renderComposeParamTreeTab("Deployment API parameters", model.inputTree, model.inputCursor, model.inputScroll, nil)
+	require.Contains(t, rendered, "Deployment API parameters")
 }
 
 func TestComposeRenderParamTreeTabEmptyShowsNoDataMessage(t *testing.T) {
@@ -204,8 +204,8 @@ func TestComposeRenderParamTreeTabEmptyShowsNoDataMessage(t *testing.T) {
 		wfErrors:  &workflowErrorsState{},
 	}
 
-	rendered := model.renderComposeParamTreeTab("Input Parameters", model.inputTree, 0, 0, nil)
-	require.Contains(t, rendered, "No input parameters available")
+	rendered := model.renderComposeParamTreeTab("Deployment API parameters", model.inputTree, 0, 0, nil)
+	require.Contains(t, rendered, "No deployment api parameters available")
 }
 
 func TestComposeRenderParamTreeTabShowsFetchError(t *testing.T) {
@@ -216,8 +216,8 @@ func TestComposeRenderParamTreeTabShowsFetchError(t *testing.T) {
 		wfErrors:  &workflowErrorsState{},
 	}
 
-	rendered := model.renderComposeParamTreeTab("Input Parameters", model.inputTree, 0, 0, errors.New("request failed"))
-	require.Contains(t, rendered, "Error fetching input parameters")
+	rendered := model.renderComposeParamTreeTab("Deployment API parameters", model.inputTree, 0, 0, errors.New("request failed"))
+	require.Contains(t, rendered, "Error fetching deployment api parameters")
 	require.Contains(t, rendered, "request failed")
 	require.NotContains(t, rendered, "No input parameters available")
 }

--- a/cmd/instance/debug_dag_tui.go
+++ b/cmd/instance/debug_dag_tui.go
@@ -738,6 +738,15 @@ func (m dagModel) openNodeDetail() (tea.Model, tea.Cmd) {
 		return m, detail.Init()
 	}
 
+	if strings.Contains(lower, "compose") {
+		detail := newComposeDetailModel(node, m.debugData)
+		detail.width = m.width
+		detail.height = m.height
+		m.detailModel = detail
+		m.inDetail = true
+		return m, detail.Init()
+	}
+
 	if !strings.Contains(lower, "operator") {
 		return m, nil
 	}

--- a/cmd/instance/debug_dag_tui.go
+++ b/cmd/instance/debug_dag_tui.go
@@ -738,7 +738,7 @@ func (m dagModel) openNodeDetail() (tea.Model, tea.Cmd) {
 		return m, detail.Init()
 	}
 
-	if strings.Contains(lower, "compose") {
+	if isComposeResourceType(node.Type) {
 		detail := newComposeDetailModel(node, m.debugData)
 		detail.width = m.width
 		detail.height = m.height
@@ -747,17 +747,17 @@ func (m dagModel) openNodeDetail() (tea.Model, tea.Cmd) {
 		return m, detail.Init()
 	}
 
-	if !strings.Contains(lower, "operator") {
-		return m, nil
+	if strings.Contains(lower, "operator") {
+		// For operator resource types, open the operator detail TUI
+		detail := newOperatorDetailModel(node, m.debugData)
+		detail.width = m.width
+		detail.height = m.height
+		m.detailModel = detail
+		m.inDetail = true
+		return m, detail.Init()
 	}
 
-	// For operator resource types, open the operator detail TUI
-	detail := newOperatorDetailModel(node, m.debugData)
-	detail.width = m.width
-	detail.height = m.height
-	m.detailModel = detail
-	m.inDetail = true
-	return m, detail.Init()
+	return m, nil
 }
 
 func (m dagModel) View() string {

--- a/cmd/instance/debug_helm_detail_tui.go
+++ b/cmd/instance/debug_helm_detail_tui.go
@@ -23,7 +23,7 @@ const (
 	helmNumTabs       = 5
 )
 
-var helmTabNames = []string{"Helm Logs", "Chart Values", "Input Parameters", "Output Parameters", "Workflow Events"}
+var helmTabNames = []string{"Helm Logs", "Chart Values", "Deployment API parameters", "Deployment Output Parameters", "Workflow Events"}
 
 func init() {
 	if len(helmTabNames) != helmNumTabs {
@@ -67,12 +67,12 @@ type helmDetailModel struct {
 	valuesCursor int
 	valuesScroll int
 
-	// Input Parameters tab (tree explorer)
+	// Deployment API parameters tab (tree explorer)
 	inputTree   []outputNode
 	inputCursor int
 	inputScroll int
 
-	// Output Parameters tab (tree explorer)
+	// Deployment Output Parameters tab (tree explorer)
 	outputTree   []outputNode
 	outputCursor int
 	outputScroll int
@@ -866,9 +866,9 @@ func (m helmDetailModel) getHelmTabContent() string {
 	case helmTabValues:
 		return m.renderHelmValuesTab()
 	case helmTabInputVars:
-		return m.renderHelmParamTreeTab("Input Parameters", m.inputTree, m.inputCursor, m.inputScroll)
+		return m.renderHelmParamTreeTab("Deployment API parameters", m.inputTree, m.inputCursor, m.inputScroll)
 	case helmTabOutputVars:
-		return m.renderHelmParamTreeTab("Output Parameters", m.outputTree, m.outputCursor, m.outputScroll)
+		return m.renderHelmParamTreeTab("Deployment Output Parameters", m.outputTree, m.outputCursor, m.outputScroll)
 	case helmTabWfErrors:
 		return m.renderHelmWfErrorsTab()
 	}
@@ -1212,7 +1212,7 @@ func (m helmDetailModel) renderHelmWfErrorsTab() string {
 	return renderWorkflowEventsTab(steps, m.wfErrors, m.helmBodyHeight(), m.helmContentWidth(), loading, m.spinner.View(), isLive)
 }
 
-// renderHelmParamTreeTab renders a generic parameter tree tab (used for Input/Output Parameters).
+// renderHelmParamTreeTab renders a generic parameter tree tab.
 func (m helmDetailModel) renderHelmParamTreeTab(title string, tree []outputNode, cursor, scroll int) string {
 	if m.loading {
 		return fmt.Sprintf("\n  %s Fetching %s...", m.spinner.View(), strings.ToLower(title))

--- a/cmd/instance/debug_helm_detail_tui_test.go
+++ b/cmd/instance/debug_helm_detail_tui_test.go
@@ -151,8 +151,8 @@ func TestHelmTabConstants(t *testing.T) {
 	require.Equal(4, helmTabWfErrors)
 	require.Equal(5, helmNumTabs)
 	require.Len(helmTabNames, helmNumTabs)
-	require.Equal("Input Parameters", helmTabNames[helmTabInputVars])
-	require.Equal("Output Parameters", helmTabNames[helmTabOutputVars])
+	require.Equal("Deployment API parameters", helmTabNames[helmTabInputVars])
+	require.Equal("Deployment Output Parameters", helmTabNames[helmTabOutputVars])
 }
 
 func TestHelmInputParamTreeBuildsFromOperatorInputParam(t *testing.T) {
@@ -278,8 +278,8 @@ func TestHelmRenderParamTreeTabShowsTitle(t *testing.T) {
 		wfErrors:  &workflowErrorsState{},
 	}
 
-	rendered := model.renderHelmParamTreeTab("Input Parameters", model.inputTree, model.inputCursor, model.inputScroll)
-	require.Contains(t, rendered, "Input Parameters")
+	rendered := model.renderHelmParamTreeTab("Deployment API parameters", model.inputTree, model.inputCursor, model.inputScroll)
+	require.Contains(t, rendered, "Deployment API parameters")
 }
 
 func TestHelmRenderParamTreeTabEmptyShowsNoDataMessage(t *testing.T) {
@@ -291,8 +291,8 @@ func TestHelmRenderParamTreeTabEmptyShowsNoDataMessage(t *testing.T) {
 		wfErrors:  &workflowErrorsState{},
 	}
 
-	rendered := model.renderHelmParamTreeTab("Input Parameters", model.inputTree, 0, 0)
-	require.Contains(t, rendered, "No input parameters available")
+	rendered := model.renderHelmParamTreeTab("Deployment API parameters", model.inputTree, 0, 0)
+	require.Contains(t, rendered, "No deployment api parameters available")
 }
 
 func TestHelmCopyableContentInputOutputTabs(t *testing.T) {

--- a/cmd/instance/debug_json_test.go
+++ b/cmd/instance/debug_json_test.go
@@ -1,10 +1,12 @@
 package instance
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -920,6 +922,63 @@ func TestResourceDebugInfoHasDataWithOperator(t *testing.T) {
 		Operator:     &OperatorData{},
 	}
 	require.True(info3.hasData())
+}
+
+func TestCollectComposeDebugInfoPopulatesComposeField(t *testing.T) {
+	require := require.New(t)
+
+	planDAG := &PlanDAG{
+		Nodes: map[string]PlanDAGNode{
+			"r-compose": {ID: "r-compose", Key: "compose", Name: "Compose", Type: "DockerCompose"},
+			"r-api":     {ID: "r-api", Key: "api", Name: "API", Type: "Generic"},
+		},
+	}
+	instanceData := &openapiclientfleet.ResourceInstance{
+		ProductTierId: "tier-1",
+		TierVersion:   "v1",
+	}
+	result := map[string]*ResourceDebugInfo{
+		"compose": {ResourceID: "r-compose", ResourceKey: "compose", ResourceType: "DockerCompose"},
+		"api":     {ResourceID: "r-api", ResourceKey: "api", ResourceType: "Generic"},
+	}
+	inputParams := map[string]interface{}{"image": "redis:7"}
+	resultParams := map[string]interface{}{"endpoint": "compose.example.com"}
+
+	collectComposeDebugInfoWithFetchers(
+		context.Background(),
+		"token",
+		"service-1",
+		planDAG,
+		instanceData,
+		inputParams,
+		resultParams,
+		result,
+		func(ctx context.Context, token, serviceID, resourceID, productTierID, tierVersion string, params map[string]interface{}) ([]OperatorInputParam, error) {
+			require.Equal("token", token)
+			require.Equal("service-1", serviceID)
+			require.Equal("r-compose", resourceID)
+			require.Equal("tier-1", productTierID)
+			require.Equal("v1", tierVersion)
+			require.Equal(inputParams, params)
+			return []OperatorInputParam{{Key: "image", ResolvedValue: "redis:7"}}, nil
+		},
+		func(ctx context.Context, token, serviceID, resourceID, productTierID, tierVersion string, params map[string]interface{}) ([]OperatorOutputParam, error) {
+			require.Equal("token", token)
+			require.Equal("service-1", serviceID)
+			require.Equal("r-compose", resourceID)
+			require.Equal("tier-1", productTierID)
+			require.Equal("v1", tierVersion)
+			require.Equal(resultParams, params)
+			return []OperatorOutputParam{{Key: "endpoint", ResolvedValue: "compose.example.com"}}, nil
+		},
+	)
+
+	require.NotNil(result["compose"].Compose)
+	require.Len(result["compose"].Compose.InputParams, 1)
+	require.Equal("image", result["compose"].Compose.InputParams[0].Key)
+	require.Len(result["compose"].Compose.OutputParams, 1)
+	require.Equal("endpoint", result["compose"].Compose.OutputParams[0].Key)
+	require.Nil(result["api"].Compose)
 }
 
 func TestResourceDebugInfoHasDataWithPlanPreview(t *testing.T) {

--- a/cmd/instance/debug_operator_detail_tui.go
+++ b/cmd/instance/debug_operator_detail_tui.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	"github.com/charmbracelet/bubbles/spinner"
@@ -71,16 +70,12 @@ type operatorDetailModel struct {
 }
 
 func newOperatorDetailModel(node PlanDAGNode, data DebugData) operatorDetailModel {
-	s := spinner.New()
-	s.Spinner = spinner.Dot
-	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
-
 	return operatorDetailModel{
 		node:      node,
 		debugData: data,
 		activeTab: opTabInputVars,
 		loading:   true,
-		spinner:   s,
+		spinner:   newResourceDetailSpinner(),
 		wfErrors:  &workflowErrorsState{},
 	}
 }
@@ -177,39 +172,14 @@ func (m operatorDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.outputTree = buildOperatorOutputParamTree(m.operatorData.OutputParams)
 			m.crdOutputTree = buildOperatorCRDOutputParamTree(m.operatorData.CRDOutputParams)
 		}
-		var cmds []tea.Cmd
-		if isWorkflowInProgress(m.getWfEvents()) {
-			cmds = append(cmds, scheduleWfEventsRefresh(), scheduleWfCountdownTick())
-		}
-		if len(cmds) > 0 {
-			return m, tea.Batch(cmds...)
-		}
-		return m, nil
+		return m, scheduleResourceWorkflowRefreshIfNeeded(m.debugData, m.node)
 
 	case wfEventsRefreshTickMsg:
-		steps := m.getWfEvents()
-		if isWorkflowInProgress(steps) && !m.wfErrors.refreshing {
-			m.wfErrors.refreshing = true
-			return m, fetchWfEventsForResource(m.debugData, m.node.Key)
-		}
+		return m, handleResourceWorkflowRefreshTick(m.debugData, m.node, m.wfErrors)
 	case wfEventsRefreshMsg:
-		m.wfErrors.refreshing = false
-		m.wfErrors.lastRefresh = time.Now()
-		if msg.err == nil && msg.steps != nil {
-			if m.debugData.PlanDAG != nil {
-				if m.debugData.PlanDAG.WorkflowStepsByKey == nil {
-					m.debugData.PlanDAG.WorkflowStepsByKey = make(map[string]*ResourceWorkflowSteps)
-				}
-				m.debugData.PlanDAG.WorkflowStepsByKey[m.node.Key] = msg.steps
-			}
-		}
-		if isWorkflowInProgress(m.getWfEvents()) {
-			return m, tea.Batch(scheduleWfEventsRefresh(), scheduleWfCountdownTick())
-		}
+		return m, handleResourceWorkflowRefresh(m.debugData, m.node, m.wfErrors, msg)
 	case wfCountdownTickMsg:
-		if isWorkflowInProgress(m.getWfEvents()) {
-			return m, scheduleWfCountdownTick()
-		}
+		return m, handleResourceWorkflowCountdown(m.debugData, m.node)
 
 	case tea.KeyMsg:
 		switch msg.String() {
@@ -244,35 +214,11 @@ func (m operatorDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			switch m.activeTab {
 			case opTabInputVars:
-				if len(m.inputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.inputTree)
-					if m.inputCursor > 0 {
-						m.inputCursor--
-					}
-					m.inputCursor, m.inputScroll = normalizeViewport(
-						m.inputCursor, m.inputScroll, len(visibleNodes), m.opVisibleRows(),
-					)
-				}
+				m.inputCursor, m.inputScroll = moveResourceDetailTreeUp(m.inputTree, m.inputCursor, m.inputScroll, m.opVisibleRows())
 			case opTabOutputVars:
-				if len(m.outputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.outputTree)
-					if m.outputCursor > 0 {
-						m.outputCursor--
-					}
-					m.outputCursor, m.outputScroll = normalizeViewport(
-						m.outputCursor, m.outputScroll, len(visibleNodes), m.opVisibleRows(),
-					)
-				}
+				m.outputCursor, m.outputScroll = moveResourceDetailTreeUp(m.outputTree, m.outputCursor, m.outputScroll, m.opVisibleRows())
 			case opTabCRDOutputVars:
-				if len(m.crdOutputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.crdOutputTree)
-					if m.crdOutputCursor > 0 {
-						m.crdOutputCursor--
-					}
-					m.crdOutputCursor, m.crdOutputScroll = normalizeViewport(
-						m.crdOutputCursor, m.crdOutputScroll, len(visibleNodes), m.opVisibleRows(),
-					)
-				}
+				m.crdOutputCursor, m.crdOutputScroll = moveResourceDetailTreeUp(m.crdOutputTree, m.crdOutputCursor, m.crdOutputScroll, m.opVisibleRows())
 			case opTabWfErrors:
 				items := flattenWfEventItems(m.getWfEvents())
 				if m.wfErrors.cursor > 0 {
@@ -291,35 +237,11 @@ func (m operatorDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			switch m.activeTab {
 			case opTabInputVars:
-				if len(m.inputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.inputTree)
-					if m.inputCursor < len(visibleNodes)-1 {
-						m.inputCursor++
-					}
-					m.inputCursor, m.inputScroll = normalizeViewport(
-						m.inputCursor, m.inputScroll, len(visibleNodes), m.opVisibleRows(),
-					)
-				}
+				m.inputCursor, m.inputScroll = moveResourceDetailTreeDown(m.inputTree, m.inputCursor, m.inputScroll, m.opVisibleRows())
 			case opTabOutputVars:
-				if len(m.outputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.outputTree)
-					if m.outputCursor < len(visibleNodes)-1 {
-						m.outputCursor++
-					}
-					m.outputCursor, m.outputScroll = normalizeViewport(
-						m.outputCursor, m.outputScroll, len(visibleNodes), m.opVisibleRows(),
-					)
-				}
+				m.outputCursor, m.outputScroll = moveResourceDetailTreeDown(m.outputTree, m.outputCursor, m.outputScroll, m.opVisibleRows())
 			case opTabCRDOutputVars:
-				if len(m.crdOutputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.crdOutputTree)
-					if m.crdOutputCursor < len(visibleNodes)-1 {
-						m.crdOutputCursor++
-					}
-					m.crdOutputCursor, m.crdOutputScroll = normalizeViewport(
-						m.crdOutputCursor, m.crdOutputScroll, len(visibleNodes), m.opVisibleRows(),
-					)
-				}
+				m.crdOutputCursor, m.crdOutputScroll = moveResourceDetailTreeDown(m.crdOutputTree, m.crdOutputCursor, m.crdOutputScroll, m.opVisibleRows())
 			case opTabWfErrors:
 				items := flattenWfEventItems(m.getWfEvents())
 				if m.wfErrors.cursor < len(items)-1 {
@@ -330,26 +252,11 @@ func (m operatorDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "enter":
 			switch m.activeTab {
 			case opTabInputVars:
-				if len(m.inputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.inputTree)
-					if m.inputCursor < len(visibleNodes) && visibleNodes[m.inputCursor].expandable {
-						visibleNodes[m.inputCursor].expanded = !visibleNodes[m.inputCursor].expanded
-					}
-				}
+				toggleResourceDetailTreeNode(m.inputTree, m.inputCursor)
 			case opTabOutputVars:
-				if len(m.outputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.outputTree)
-					if m.outputCursor < len(visibleNodes) && visibleNodes[m.outputCursor].expandable {
-						visibleNodes[m.outputCursor].expanded = !visibleNodes[m.outputCursor].expanded
-					}
-				}
+				toggleResourceDetailTreeNode(m.outputTree, m.outputCursor)
 			case opTabCRDOutputVars:
-				if len(m.crdOutputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.crdOutputTree)
-					if m.crdOutputCursor < len(visibleNodes) && visibleNodes[m.crdOutputCursor].expandable {
-						visibleNodes[m.crdOutputCursor].expanded = !visibleNodes[m.crdOutputCursor].expanded
-					}
-				}
+				toggleResourceDetailTreeNode(m.crdOutputTree, m.crdOutputCursor)
 			case opTabWfErrors:
 				items := flattenWfEventItems(m.getWfEvents())
 				if m.wfErrors.cursor < len(items) {
@@ -364,50 +271,20 @@ func (m operatorDetailModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "right", "l":
 			switch m.activeTab {
 			case opTabInputVars:
-				if len(m.inputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.inputTree)
-					if m.inputCursor < len(visibleNodes) && visibleNodes[m.inputCursor].expandable && !visibleNodes[m.inputCursor].expanded {
-						visibleNodes[m.inputCursor].expanded = true
-					}
-				}
+				expandResourceDetailTreeNode(m.inputTree, m.inputCursor)
 			case opTabOutputVars:
-				if len(m.outputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.outputTree)
-					if m.outputCursor < len(visibleNodes) && visibleNodes[m.outputCursor].expandable && !visibleNodes[m.outputCursor].expanded {
-						visibleNodes[m.outputCursor].expanded = true
-					}
-				}
+				expandResourceDetailTreeNode(m.outputTree, m.outputCursor)
 			case opTabCRDOutputVars:
-				if len(m.crdOutputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.crdOutputTree)
-					if m.crdOutputCursor < len(visibleNodes) && visibleNodes[m.crdOutputCursor].expandable && !visibleNodes[m.crdOutputCursor].expanded {
-						visibleNodes[m.crdOutputCursor].expanded = true
-					}
-				}
+				expandResourceDetailTreeNode(m.crdOutputTree, m.crdOutputCursor)
 			}
 		case "left", "h":
 			switch m.activeTab {
 			case opTabInputVars:
-				if len(m.inputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.inputTree)
-					if m.inputCursor < len(visibleNodes) && visibleNodes[m.inputCursor].expandable && visibleNodes[m.inputCursor].expanded {
-						visibleNodes[m.inputCursor].expanded = false
-					}
-				}
+				collapseResourceDetailTreeNode(m.inputTree, m.inputCursor)
 			case opTabOutputVars:
-				if len(m.outputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.outputTree)
-					if m.outputCursor < len(visibleNodes) && visibleNodes[m.outputCursor].expandable && visibleNodes[m.outputCursor].expanded {
-						visibleNodes[m.outputCursor].expanded = false
-					}
-				}
+				collapseResourceDetailTreeNode(m.outputTree, m.outputCursor)
 			case opTabCRDOutputVars:
-				if len(m.crdOutputTree) > 0 {
-					visibleNodes := flattenOutputTree(m.crdOutputTree)
-					if m.crdOutputCursor < len(visibleNodes) && visibleNodes[m.crdOutputCursor].expandable && visibleNodes[m.crdOutputCursor].expanded {
-						visibleNodes[m.crdOutputCursor].expanded = false
-					}
-				}
+				collapseResourceDetailTreeNode(m.crdOutputTree, m.crdOutputCursor)
 			}
 		case "pgup":
 			switch m.activeTab {
@@ -466,81 +343,11 @@ func (m operatorDetailModel) View() string {
 }
 
 func (m operatorDetailModel) renderOpHeader() string {
-	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230"))
-	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-
-	title := titleStyle.Render(m.node.Name)
-	if m.node.Name == "" {
-		title = titleStyle.Render(m.node.Key)
-	}
-
-	typeTag := dimStyle.Render(fmt.Sprintf("[%s]", m.node.Type))
-
-	return lipgloss.Place(m.width, 1, lipgloss.Left, lipgloss.Top,
-		lipgloss.NewStyle().Padding(0, 1).Render(fmt.Sprintf("%s  %s", title, typeTag)))
+	return renderResourceDetailHeader(m.width, m.node)
 }
 
 func (m operatorDetailModel) renderOpTabsWithBody() string {
-	inactiveTabBorder := tabBorderWithBottom("┴", "─", "┴")
-	activeTabBorder := tabBorderWithBottom("┘", " ", "└")
-
-	inactiveTabStyle := lipgloss.NewStyle().
-		Border(inactiveTabBorder, true).
-		BorderForeground(lipgloss.Color("240")).
-		Padding(0, 1)
-	activeTabStyle := lipgloss.NewStyle().
-		Border(activeTabBorder, true).
-		BorderForeground(lipgloss.Color("240")).
-		Padding(0, 1).
-		Bold(true).
-		Foreground(lipgloss.Color("230"))
-
-	var renderedTabs []string
-	for i, name := range opTabNames {
-		style := inactiveTabStyle
-		isActive := i == m.activeTab
-
-		if isActive {
-			style = activeTabStyle
-		} else {
-			style = inactiveTabStyle
-		}
-
-		if i == 0 {
-			border := style.GetBorderStyle()
-			if isActive {
-				border.BottomLeft = "│"
-			} else {
-				border.BottomLeft = "├"
-			}
-			style = style.Border(border, true)
-		}
-		renderedTabs = append(renderedTabs, style.Render(name))
-	}
-
-	row := lipgloss.JoinHorizontal(lipgloss.Top, renderedTabs...)
-
-	rowWidth := lipgloss.Width(row)
-	gapWidth := m.width - rowWidth - 2
-	if gapWidth > 0 {
-		gap := lipgloss.NewStyle().Border(lipgloss.Border{
-			Bottom:      "─",
-			BottomLeft:  "┴",
-			BottomRight: "┐",
-		}, false, false, true).BorderForeground(lipgloss.Color("240")).Width(gapWidth).Render("")
-		row = lipgloss.JoinHorizontal(lipgloss.Bottom, row, gap)
-	}
-
-	content := m.getOpTabContent()
-
-	window := lipgloss.NewStyle().
-		Border(lipgloss.Border{Left: "│", Right: "│", Bottom: "─", BottomLeft: "└", BottomRight: "┘"}, false, true, true).
-		BorderForeground(lipgloss.Color("240")).
-		Width(m.width - 2).
-		Height(m.opBodyHeight()).
-		Render(content)
-
-	return lipgloss.JoinVertical(lipgloss.Left, row, window)
+	return renderResourceDetailTabsWithBody(m.width, m.opBodyHeight(), opTabNames, m.activeTab, m.getOpTabContent())
 }
 
 func (m operatorDetailModel) getOpTabContent() string {
@@ -570,123 +377,14 @@ func (m operatorDetailModel) renderCRDOutputVarsTab() string {
 }
 
 func (m operatorDetailModel) renderParamTreeTab(title string, tree []outputNode, cursor, scroll int) string {
-	if m.loading {
-		return fmt.Sprintf("\n  %s Fetching %s...", m.spinner.View(), strings.ToLower(title))
-	}
-	if m.loadErr != nil {
-		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
-		return fmt.Sprintf("\n  %s\n", errStyle.Render(fmt.Sprintf("Error: %v", m.loadErr)))
-	}
-	if len(tree) == 0 {
-		subtleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-		return fmt.Sprintf("\n  %s\n", subtleStyle.Render(fmt.Sprintf("No %s available for this resource.", strings.ToLower(title))))
-	}
-
-	var b strings.Builder
-
-	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
-	fmt.Fprintf(&b, "  %s\n\n", headerStyle.Render(title))
-
-	visibleNodes := flattenOutputTree(tree)
-
-	visibleRows := m.opVisibleRows()
-	totalEntries := len(visibleNodes)
-	cursorIndex, scrollOffset := normalizeViewport(cursor, scroll, totalEntries, visibleRows)
-
-	end := scrollOffset + visibleRows
-	if end > totalEntries {
-		end = totalEntries
-	}
-
-	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("117"))
-	strStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("114"))
-	numStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("178"))
-	boolStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("178"))
-	nullStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
-	braceStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
-	selectedBg := lipgloss.NewStyle().Background(lipgloss.Color("236"))
-	maxLineWidth := m.opContentWidth() - 4
-	if maxLineWidth < 1 {
-		maxLineWidth = 1
-	}
-	rowStyle := lipgloss.NewStyle().MaxWidth(maxLineWidth)
-	selectedRowStyle := selectedBg.MaxWidth(maxLineWidth)
-
-	for idx := scrollOffset; idx < end; idx++ {
-		node := visibleNodes[idx]
-		indent := strings.Repeat("  ", node.depth)
-
-		cursorMarker := "  "
-		if idx == cursorIndex {
-			cursorMarker = "▶ "
-		}
-
-		var line string
-		if node.expandable {
-			arrow := "▸"
-			if node.expanded {
-				arrow = "▾"
-			}
-			childCount := len(node.children)
-			typeMark := braceStyle.Render("{}")
-			if node.nodeType == "array" {
-				typeMark = braceStyle.Render("[]")
-			}
-			countStr := lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render(fmt.Sprintf("  %d items", childCount))
-			line = fmt.Sprintf("%s%s %s %s%s", indent, arrow, keyStyle.Render(node.key), typeMark, countStr)
-		} else {
-			var styledVal string
-			switch node.nodeType {
-			case "string":
-				styledVal = strStyle.Render(fmt.Sprintf("%q", node.value))
-			case "number":
-				styledVal = numStyle.Render(node.value)
-			case "bool":
-				styledVal = boolStyle.Render(node.value)
-			case "null":
-				styledVal = nullStyle.Render("null")
-			default:
-				styledVal = lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Render(node.value)
-			}
-			line = fmt.Sprintf("%s  %s: %s", indent, keyStyle.Render(node.key), styledVal)
-		}
-
-		if idx == cursorIndex {
-			line = selectedRowStyle.Render(line)
-		} else {
-			line = rowStyle.Render(line)
-		}
-
-		fmt.Fprintf(&b, "  %s%s\n", cursorMarker, line)
-	}
-
-	if totalEntries > visibleRows {
-		dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
-		pos := ""
-		if scrollOffset == 0 {
-			pos = "top"
-		} else if end >= totalEntries {
-			pos = "end"
-		} else {
-			pct := (scrollOffset * 100) / (totalEntries - visibleRows)
-			pos = fmt.Sprintf("%d%%", pct)
-		}
-		fmt.Fprintf(&b, "\n  %s\n", dimStyle.Render(fmt.Sprintf("↑↓: navigate  ←→/enter: expand/collapse  [%d/%d %s]", cursorIndex+1, totalEntries, pos)))
-	}
-
-	return b.String()
+	return renderResourceDetailParamTreeTab(title, tree, cursor, scroll, m.opVisibleRows(), m.opContentWidth(), m.loading, m.spinner.View(), m.loadErr, nil, true)
 }
 
 func (m operatorDetailModel) renderOpWfErrorsTab() string {
-	loading := m.debugData.PlanDAG != nil && m.debugData.PlanDAG.ProgressLoading
-	steps := m.getWfEvents()
-	enrichBootstrapSteps(steps, m.node.Key, m.debugData.PlanDAG)
-	isLive := isWorkflowInProgress(steps)
-	return renderWorkflowEventsTab(steps, m.wfErrors, m.opBodyHeight(), m.opContentWidth(), loading, m.spinner.View(), isLive)
+	return renderResourceWorkflowEventsTab(m.debugData, m.node, m.wfErrors, m.opBodyHeight(), m.opContentWidth(), m.spinner.View())
 }
 
 func (m operatorDetailModel) renderOpFooter() string {
-	style := lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Padding(0, 1)
 	var text string
 	switch m.activeTab {
 	case opTabInputVars, opTabOutputVars, opTabCRDOutputVars:
@@ -702,11 +400,7 @@ func (m operatorDetailModel) renderOpFooter() string {
 	default:
 		text = "tab/shift+tab: switch tabs  esc: back  q: quit"
 	}
-	if m.clipboardMsg != "" {
-		clipStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("82"))
-		text = clipStyle.Render(m.clipboardMsg) + "  " + text
-	}
-	return lipgloss.Place(m.width, 1, lipgloss.Left, lipgloss.Top, style.Render(text))
+	return renderResourceDetailFooter(m.width, m.clipboardMsg, text)
 }
 
 func (m operatorDetailModel) opCopyableContent() string {
@@ -739,34 +433,19 @@ func (m operatorDetailModel) opCopyableContent() string {
 }
 
 func (m operatorDetailModel) opBodyHeight() int {
-	h := m.height - 8
-	if h < 1 {
-		h = 1
-	}
-	return h
+	return resourceDetailBodyHeight(m.height)
 }
 
 func (m operatorDetailModel) opVisibleRows() int {
-	rows := m.opBodyHeight() - 4
-	if rows < 1 {
-		rows = 1
-	}
-	return rows
+	return resourceDetailVisibleRows(m.height)
 }
 
 func (m operatorDetailModel) opContentWidth() int {
-	w := m.width - 4
-	if w < 20 {
-		w = 20
-	}
-	return w
+	return resourceDetailContentWidth(m.width)
 }
 
 func (m operatorDetailModel) getWfEvents() *ResourceWorkflowSteps {
-	if m.debugData.PlanDAG != nil && m.debugData.PlanDAG.WorkflowStepsByKey != nil {
-		return m.debugData.PlanDAG.WorkflowStepsByKey[m.node.Key]
-	}
-	return nil
+	return getResourceWorkflowEvents(m.debugData, m.node)
 }
 
 // buildOperatorParamTree converts input parameters to a navigable tree of outputNodes.

--- a/cmd/instance/debug_operator_detail_tui.go
+++ b/cmd/instance/debug_operator_detail_tui.go
@@ -21,7 +21,7 @@ const (
 	opNumTabs          = 4
 )
 
-var opTabNames = []string{"Input Parameters", "Output Parameters", "Operator CRD Outputs", "Workflow Events"}
+var opTabNames = []string{"Deployment API parameters", "Deployment Output Parameters", "Operator CRD Outputs", "Workflow Events"}
 
 func init() {
 	if len(opTabNames) != opNumTabs {
@@ -365,11 +365,11 @@ func (m operatorDetailModel) getOpTabContent() string {
 }
 
 func (m operatorDetailModel) renderInputVarsTab() string {
-	return m.renderParamTreeTab("Input Parameters", m.inputTree, m.inputCursor, m.inputScroll)
+	return m.renderParamTreeTab("Deployment API parameters", m.inputTree, m.inputCursor, m.inputScroll)
 }
 
 func (m operatorDetailModel) renderOutputVarsTab() string {
-	return m.renderParamTreeTab("Output Parameters", m.outputTree, m.outputCursor, m.outputScroll)
+	return m.renderParamTreeTab("Deployment Output Parameters", m.outputTree, m.outputCursor, m.outputScroll)
 }
 
 func (m operatorDetailModel) renderCRDOutputVarsTab() string {

--- a/cmd/instance/debug_operator_detail_tui_test.go
+++ b/cmd/instance/debug_operator_detail_tui_test.go
@@ -8,8 +8,8 @@ import (
 
 func TestOperatorTabNames(t *testing.T) {
 	require.Equal(t, opNumTabs, len(opTabNames), "opTabNames length must match opNumTabs")
-	require.Equal(t, "Input Parameters", opTabNames[opTabInputVars])
-	require.Equal(t, "Output Parameters", opTabNames[opTabOutputVars])
+	require.Equal(t, "Deployment API parameters", opTabNames[opTabInputVars])
+	require.Equal(t, "Deployment Output Parameters", opTabNames[opTabOutputVars])
 	require.Equal(t, "Operator CRD Outputs", opTabNames[opTabCRDOutputVars])
 	require.Equal(t, "Workflow Events", opTabNames[opTabWfErrors])
 }

--- a/cmd/instance/debug_plan_dag.go
+++ b/cmd/instance/debug_plan_dag.go
@@ -62,6 +62,7 @@ func buildPlanDAG(ctx context.Context, token, serviceID string, instanceData *op
 		Edges:  []PlanDAGEdge{},
 		Errors: []string{},
 	}
+	deploymentTypes := deploymentTypesByResourceIdentity(instanceData.ResourceVersionSummaries)
 
 	for _, resource := range versionSet.Resources {
 		node := PlanDAGNode{
@@ -74,6 +75,7 @@ func buildPlanDAG(ctx context.Context, token, serviceID string, instanceData *op
 		if resource.ManagedResourceType != nil {
 			node.Type = *resource.ManagedResourceType
 		}
+		node.Type = mergePlanNodeDeploymentType(node, node.Type, deploymentTypes)
 		plan.Nodes[resource.Id] = node
 	}
 
@@ -86,7 +88,8 @@ func buildPlanDAG(ctx context.Context, token, serviceID string, instanceData *op
 
 		node.Name = resourceDetails.Name
 		node.Key = resourceDetails.Key
-		node.Type = resourceDetails.ResourceType
+		node.Type = mergePlanNodeResourceType(node.Type, resourceDetails.ResourceType)
+		node.Type = mergePlanNodeDeploymentType(node, node.Type, deploymentTypes)
 		plan.Nodes[resourceID] = node
 
 		for _, dependency := range resourceDetails.Dependencies {
@@ -161,6 +164,96 @@ func shouldHidePlanNode(node PlanDAGNode) bool {
 		}
 	}
 	return false
+}
+
+type resourceDeploymentTypes struct {
+	byID   map[string]string
+	byName map[string]string
+}
+
+func deploymentTypesByResourceIdentity(summaries []openapiclientfleet.ResourceVersionSummary) resourceDeploymentTypes {
+	types := resourceDeploymentTypes{
+		byID:   make(map[string]string),
+		byName: make(map[string]string),
+	}
+
+	for _, summary := range summaries {
+		deploymentType := deploymentTypeFromSummary(summary)
+		if deploymentType == "" {
+			continue
+		}
+		if summary.ResourceId != nil && *summary.ResourceId != "" {
+			types.byID[*summary.ResourceId] = deploymentType
+		}
+		if summary.ResourceName != nil && *summary.ResourceName != "" {
+			types.byName[*summary.ResourceName] = deploymentType
+		}
+	}
+
+	return types
+}
+
+func deploymentTypeFromSummary(summary openapiclientfleet.ResourceVersionSummary) string {
+	switch {
+	case summary.HelmDeploymentConfiguration != nil:
+		return "Helm"
+	case summary.TerraformDeploymentConfiguration != nil:
+		return "Terraform"
+	case summary.KustomizeDeploymentConfiguration != nil:
+		return "Kustomize"
+	case summary.GenericResourceDeploymentConfiguration != nil:
+		return "Compose"
+	default:
+		return ""
+	}
+}
+
+func mergePlanNodeResourceType(summaryType, detailType string) string {
+	detailType = strings.TrimSpace(detailType)
+	if detailType == "" {
+		if strings.TrimSpace(summaryType) == "" {
+			return "Compose"
+		}
+		return summaryType
+	}
+	if strings.EqualFold(detailType, "resource") && strings.TrimSpace(summaryType) == "" {
+		return "Compose"
+	}
+	if strings.EqualFold(detailType, "resource") && strings.TrimSpace(summaryType) != "" {
+		return summaryType
+	}
+	return detailType
+}
+
+func isComposeResourceType(resourceType string) bool {
+	resourceType = strings.TrimSpace(resourceType)
+	if resourceType == "" {
+		return true
+	}
+	lower := strings.ToLower(resourceType)
+	return strings.Contains(lower, "compose") || lower == "resource"
+}
+
+func mergePlanNodeDeploymentType(node PlanDAGNode, currentType string, deploymentTypes resourceDeploymentTypes) string {
+	deploymentType := ""
+	if node.ID != "" {
+		deploymentType = deploymentTypes.byID[node.ID]
+	}
+	if deploymentType == "" && node.Key != "" {
+		deploymentType = deploymentTypes.byName[node.Key]
+	}
+	if deploymentType == "" && node.Name != "" {
+		deploymentType = deploymentTypes.byName[node.Name]
+	}
+	if deploymentType == "" {
+		return currentType
+	}
+
+	currentType = strings.TrimSpace(currentType)
+	if currentType == "" || strings.EqualFold(currentType, "resource") || strings.EqualFold(currentType, "generic") {
+		return deploymentType
+	}
+	return currentType
 }
 
 func computePlanLevels(nodes map[string]PlanDAGNode, edges []PlanDAGEdge) ([][]string, bool) {

--- a/cmd/instance/debug_plan_dag.go
+++ b/cmd/instance/debug_plan_dag.go
@@ -62,7 +62,6 @@ func buildPlanDAG(ctx context.Context, token, serviceID string, instanceData *op
 		Edges:  []PlanDAGEdge{},
 		Errors: []string{},
 	}
-	deploymentTypes := deploymentTypesByResourceIdentity(instanceData.ResourceVersionSummaries)
 
 	for _, resource := range versionSet.Resources {
 		node := PlanDAGNode{
@@ -75,7 +74,6 @@ func buildPlanDAG(ctx context.Context, token, serviceID string, instanceData *op
 		if resource.ManagedResourceType != nil {
 			node.Type = *resource.ManagedResourceType
 		}
-		node.Type = mergePlanNodeDeploymentType(node, node.Type, deploymentTypes)
 		plan.Nodes[resource.Id] = node
 	}
 
@@ -89,7 +87,6 @@ func buildPlanDAG(ctx context.Context, token, serviceID string, instanceData *op
 		node.Name = resourceDetails.Name
 		node.Key = resourceDetails.Key
 		node.Type = resourceDetails.ResourceType
-		node.Type = mergePlanNodeDeploymentType(node, node.Type, deploymentTypes)
 		plan.Nodes[resourceID] = node
 
 		for _, dependency := range resourceDetails.Dependencies {
@@ -166,48 +163,6 @@ func shouldHidePlanNode(node PlanDAGNode) bool {
 	return false
 }
 
-type resourceDeploymentTypes struct {
-	byID   map[string]string
-	byName map[string]string
-}
-
-func deploymentTypesByResourceIdentity(summaries []openapiclientfleet.ResourceVersionSummary) resourceDeploymentTypes {
-	types := resourceDeploymentTypes{
-		byID:   make(map[string]string),
-		byName: make(map[string]string),
-	}
-
-	for _, summary := range summaries {
-		deploymentType := deploymentTypeFromSummary(summary)
-		if deploymentType == "" {
-			continue
-		}
-		if summary.ResourceId != nil && *summary.ResourceId != "" {
-			types.byID[*summary.ResourceId] = deploymentType
-		}
-		if summary.ResourceName != nil && *summary.ResourceName != "" {
-			types.byName[*summary.ResourceName] = deploymentType
-		}
-	}
-
-	return types
-}
-
-func deploymentTypeFromSummary(summary openapiclientfleet.ResourceVersionSummary) string {
-	switch {
-	case summary.HelmDeploymentConfiguration != nil:
-		return "Helm"
-	case summary.TerraformDeploymentConfiguration != nil:
-		return "Terraform"
-	case summary.KustomizeDeploymentConfiguration != nil:
-		return "Kustomize"
-	case summary.GenericResourceDeploymentConfiguration != nil:
-		return "Compose"
-	default:
-		return ""
-	}
-}
-
 func isComposeResourceType(resourceType string) bool {
 	resourceType = strings.TrimSpace(resourceType)
 	if resourceType == "" {
@@ -215,28 +170,6 @@ func isComposeResourceType(resourceType string) bool {
 	}
 	lower := strings.ToLower(resourceType)
 	return strings.Contains(lower, "compose") || lower == "resource"
-}
-
-func mergePlanNodeDeploymentType(node PlanDAGNode, currentType string, deploymentTypes resourceDeploymentTypes) string {
-	deploymentType := ""
-	if node.ID != "" {
-		deploymentType = deploymentTypes.byID[node.ID]
-	}
-	if deploymentType == "" && node.Key != "" {
-		deploymentType = deploymentTypes.byName[node.Key]
-	}
-	if deploymentType == "" && node.Name != "" {
-		deploymentType = deploymentTypes.byName[node.Name]
-	}
-	if deploymentType == "" {
-		return currentType
-	}
-
-	currentType = strings.TrimSpace(currentType)
-	if currentType == "" || strings.EqualFold(currentType, "resource") || strings.EqualFold(currentType, "generic") {
-		return deploymentType
-	}
-	return currentType
 }
 
 func computePlanLevels(nodes map[string]PlanDAGNode, edges []PlanDAGEdge) ([][]string, bool) {

--- a/cmd/instance/debug_plan_dag.go
+++ b/cmd/instance/debug_plan_dag.go
@@ -88,7 +88,7 @@ func buildPlanDAG(ctx context.Context, token, serviceID string, instanceData *op
 
 		node.Name = resourceDetails.Name
 		node.Key = resourceDetails.Key
-		node.Type = mergePlanNodeResourceType(node.Type, resourceDetails.ResourceType)
+		node.Type = resourceDetails.ResourceType
 		node.Type = mergePlanNodeDeploymentType(node, node.Type, deploymentTypes)
 		plan.Nodes[resourceID] = node
 
@@ -206,23 +206,6 @@ func deploymentTypeFromSummary(summary openapiclientfleet.ResourceVersionSummary
 	default:
 		return ""
 	}
-}
-
-func mergePlanNodeResourceType(summaryType, detailType string) string {
-	detailType = strings.TrimSpace(detailType)
-	if detailType == "" {
-		if strings.TrimSpace(summaryType) == "" {
-			return "Compose"
-		}
-		return summaryType
-	}
-	if strings.EqualFold(detailType, "resource") && strings.TrimSpace(summaryType) == "" {
-		return "Compose"
-	}
-	if strings.EqualFold(detailType, "resource") && strings.TrimSpace(summaryType) != "" {
-		return summaryType
-	}
-	return detailType
 }
 
 func isComposeResourceType(resourceType string) bool {

--- a/cmd/instance/debug_plan_dag_render.go
+++ b/cmd/instance/debug_plan_dag_render.go
@@ -569,8 +569,8 @@ func buildNodeCard(node PlanDAGNode, progress ResourceProgress, hasProgress bool
 }
 
 func formatTypeTag(resourceType string) string {
-	if resourceType == "" {
-		return "Resource"
+	if isComposeResourceType(resourceType) {
+		return "Compose"
 	}
 	lower := strings.ToLower(resourceType)
 	switch {
@@ -578,8 +578,6 @@ func formatTypeTag(resourceType string) string {
 		return "Helm"
 	case strings.Contains(lower, "terraform"):
 		return "Terraform"
-	case strings.Contains(lower, "compose"):
-		return "Compose"
 	case strings.Contains(lower, "kustomize"):
 		return "Kustomize"
 	default:

--- a/cmd/instance/debug_plan_dag_render.go
+++ b/cmd/instance/debug_plan_dag_render.go
@@ -578,6 +578,8 @@ func formatTypeTag(resourceType string) string {
 		return "Helm"
 	case strings.Contains(lower, "terraform"):
 		return "Terraform"
+	case strings.Contains(lower, "compose"):
+		return "Compose"
 	case strings.Contains(lower, "kustomize"):
 		return "Kustomize"
 	default:
@@ -606,6 +608,8 @@ func iconForType(tag string, theme cardTheme) (rune, lipgloss.Style) {
 		return 'H', style
 	case "Terraform":
 		return 'T', style
+	case "Compose":
+		return 'C', style
 	case "Kustomize":
 		return 'K', style
 	default:

--- a/cmd/instance/debug_plan_dag_test.go
+++ b/cmd/instance/debug_plan_dag_test.go
@@ -89,6 +89,18 @@ func TestBreakpointStatusForNode(t *testing.T) {
 	}
 }
 
+func TestComposeResourceTypeTagAndIcon(t *testing.T) {
+	tag := formatTypeTag("DockerCompose")
+	if tag != "Compose" {
+		t.Fatalf("expected Compose tag, got %q", tag)
+	}
+
+	icon, _ := iconForType(tag, cardTheme{icon: "255"})
+	if icon != 'C' {
+		t.Fatalf("expected Compose icon C, got %q", icon)
+	}
+}
+
 func TestPlanHasHitBreakpoint(t *testing.T) {
 	planWithoutHit := &PlanDAG{
 		BreakpointByID: map[string]string{

--- a/cmd/instance/debug_plan_dag_test.go
+++ b/cmd/instance/debug_plan_dag_test.go
@@ -101,6 +101,174 @@ func TestComposeResourceTypeTagAndIcon(t *testing.T) {
 	}
 }
 
+func TestEmptyResourceTypeTagAndIcon(t *testing.T) {
+	tag := formatTypeTag("")
+	if tag != "Compose" {
+		t.Fatalf("expected empty type to render as Compose, got %q", tag)
+	}
+}
+
+func TestResourceTypeOpensComposeDetail(t *testing.T) {
+	model := dagModel{
+		debugData: DebugData{},
+		plan: &PlanDAG{
+			Nodes: map[string]PlanDAGNode{
+				"r-postgres": {ID: "r-postgres", Key: "postgres", Name: "postgres", Type: "Resource"},
+			},
+			Levels: [][]string{{"r-postgres"}},
+		},
+		selectableNodes: []string{"r-postgres"},
+		cursorIndex:     0,
+		width:           100,
+		height:          30,
+	}
+
+	updated, cmd := model.openNodeDetail()
+	updatedModel := updated.(dagModel)
+
+	if !updatedModel.inDetail {
+		t.Fatalf("expected resource node to enter detail view")
+	}
+	if updatedModel.detailModel == nil {
+		t.Fatalf("expected resource node to open a detail model")
+	}
+	if _, ok := updatedModel.detailModel.(composeDetailModel); !ok {
+		t.Fatalf("expected resource node to open compose detail model, got %T", updatedModel.detailModel)
+	}
+	if cmd == nil {
+		t.Fatalf("expected detail init command")
+	}
+}
+
+func TestEmptyResourceTypeOpensComposeDetail(t *testing.T) {
+	model := dagModel{
+		debugData: DebugData{},
+		plan: &PlanDAG{
+			Nodes: map[string]PlanDAGNode{
+				"r-postgres": {ID: "r-postgres", Key: "postgres", Name: "postgres"},
+			},
+			Levels: [][]string{{"r-postgres"}},
+		},
+		selectableNodes: []string{"r-postgres"},
+		cursorIndex:     0,
+		width:           100,
+		height:          30,
+	}
+
+	updated, cmd := model.openNodeDetail()
+	updatedModel := updated.(dagModel)
+
+	if !updatedModel.inDetail {
+		t.Fatalf("expected empty-type node to enter detail view")
+	}
+	if updatedModel.detailModel == nil {
+		t.Fatalf("expected empty-type node to open a detail model")
+	}
+	if _, ok := updatedModel.detailModel.(composeDetailModel); !ok {
+		t.Fatalf("expected empty-type node to open compose detail model, got %T", updatedModel.detailModel)
+	}
+	if cmd == nil {
+		t.Fatalf("expected detail init command")
+	}
+}
+
+func TestMergePlanNodeResourceTypeKeepsManagedTypeWhenDetailIsGeneric(t *testing.T) {
+	tests := []struct {
+		name        string
+		summaryType string
+		detailType  string
+		want        string
+	}{
+		{
+			name:        "keeps compose type over generic detail type",
+			summaryType: "DockerCompose",
+			detailType:  "Resource",
+			want:        "DockerCompose",
+		},
+		{
+			name:        "uses specific detail type",
+			summaryType: "Resource",
+			detailType:  "Terraform",
+			want:        "Terraform",
+		},
+		{
+			name:        "uses compose for generic detail type without summary type",
+			summaryType: "",
+			detailType:  "Resource",
+			want:        "Compose",
+		},
+		{
+			name:        "keeps summary type when detail type is empty",
+			summaryType: "Helm",
+			detailType:  "",
+			want:        "Helm",
+		},
+		{
+			name:        "uses compose when both types are empty",
+			summaryType: "",
+			detailType:  "",
+			want:        "Compose",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := mergePlanNodeResourceType(tt.summaryType, tt.detailType); got != tt.want {
+				t.Fatalf("expected %q, got %q", tt.want, got)
+			}
+		})
+	}
+}
+
+func TestDeploymentTypesByResourceIdentityMarksGenericDeploymentAsCompose(t *testing.T) {
+	resourceID := "r-postgres"
+	resourceName := "postgres"
+	summaries := []openapiclientfleet.ResourceVersionSummary{
+		{
+			ResourceId:                             &resourceID,
+			ResourceName:                           &resourceName,
+			GenericResourceDeploymentConfiguration: &openapiclientfleet.GenericResourceDeploymentConfiguration{},
+		},
+	}
+
+	types := deploymentTypesByResourceIdentity(summaries)
+
+	if got := types.byID[resourceID]; got != "Compose" {
+		t.Fatalf("expected compose deployment type by ID, got %q", got)
+	}
+	if got := types.byName[resourceName]; got != "Compose" {
+		t.Fatalf("expected compose deployment type by name, got %q", got)
+	}
+}
+
+func TestMergePlanNodeDeploymentTypeUsesComposeForGenericResource(t *testing.T) {
+	deploymentTypes := resourceDeploymentTypes{
+		byID: map[string]string{
+			"r-postgres": "Compose",
+		},
+		byName: map[string]string{},
+	}
+	node := PlanDAGNode{ID: "r-postgres", Key: "postgres", Name: "postgres"}
+
+	if got := mergePlanNodeDeploymentType(node, "Resource", deploymentTypes); got != "Compose" {
+		t.Fatalf("expected compose deployment type, got %q", got)
+	}
+}
+
+func TestMergePlanNodeDeploymentTypePreservesSpecificType(t *testing.T) {
+	deploymentTypes := resourceDeploymentTypes{
+		byID: map[string]string{
+			"r-operator": "Compose",
+		},
+		byName: map[string]string{},
+	}
+	node := PlanDAGNode{ID: "r-operator", Key: "operator", Name: "operator"}
+
+	if got := mergePlanNodeDeploymentType(node, "OperatorCRD", deploymentTypes); got != "OperatorCRD" {
+		t.Fatalf("expected specific type to be preserved, got %q", got)
+	}
+}
+
 func TestPlanHasHitBreakpoint(t *testing.T) {
 	planWithoutHit := &PlanDAG{
 		BreakpointByID: map[string]string{

--- a/cmd/instance/debug_plan_dag_test.go
+++ b/cmd/instance/debug_plan_dag_test.go
@@ -172,55 +172,6 @@ func TestEmptyResourceTypeOpensComposeDetail(t *testing.T) {
 	}
 }
 
-func TestDeploymentTypesByResourceIdentityMarksGenericDeploymentAsCompose(t *testing.T) {
-	resourceID := "r-postgres"
-	resourceName := "postgres"
-	summaries := []openapiclientfleet.ResourceVersionSummary{
-		{
-			ResourceId:                             &resourceID,
-			ResourceName:                           &resourceName,
-			GenericResourceDeploymentConfiguration: &openapiclientfleet.GenericResourceDeploymentConfiguration{},
-		},
-	}
-
-	types := deploymentTypesByResourceIdentity(summaries)
-
-	if got := types.byID[resourceID]; got != "Compose" {
-		t.Fatalf("expected compose deployment type by ID, got %q", got)
-	}
-	if got := types.byName[resourceName]; got != "Compose" {
-		t.Fatalf("expected compose deployment type by name, got %q", got)
-	}
-}
-
-func TestMergePlanNodeDeploymentTypeUsesComposeForGenericResource(t *testing.T) {
-	deploymentTypes := resourceDeploymentTypes{
-		byID: map[string]string{
-			"r-postgres": "Compose",
-		},
-		byName: map[string]string{},
-	}
-	node := PlanDAGNode{ID: "r-postgres", Key: "postgres", Name: "postgres"}
-
-	if got := mergePlanNodeDeploymentType(node, "Resource", deploymentTypes); got != "Compose" {
-		t.Fatalf("expected compose deployment type, got %q", got)
-	}
-}
-
-func TestMergePlanNodeDeploymentTypePreservesSpecificType(t *testing.T) {
-	deploymentTypes := resourceDeploymentTypes{
-		byID: map[string]string{
-			"r-operator": "Compose",
-		},
-		byName: map[string]string{},
-	}
-	node := PlanDAGNode{ID: "r-operator", Key: "operator", Name: "operator"}
-
-	if got := mergePlanNodeDeploymentType(node, "OperatorCRD", deploymentTypes); got != "OperatorCRD" {
-		t.Fatalf("expected specific type to be preserved, got %q", got)
-	}
-}
-
 func TestPlanHasHitBreakpoint(t *testing.T) {
 	planWithoutHit := &PlanDAG{
 		BreakpointByID: map[string]string{

--- a/cmd/instance/debug_plan_dag_test.go
+++ b/cmd/instance/debug_plan_dag_test.go
@@ -172,54 +172,6 @@ func TestEmptyResourceTypeOpensComposeDetail(t *testing.T) {
 	}
 }
 
-func TestMergePlanNodeResourceTypeKeepsManagedTypeWhenDetailIsGeneric(t *testing.T) {
-	tests := []struct {
-		name        string
-		summaryType string
-		detailType  string
-		want        string
-	}{
-		{
-			name:        "keeps compose type over generic detail type",
-			summaryType: "DockerCompose",
-			detailType:  "Resource",
-			want:        "DockerCompose",
-		},
-		{
-			name:        "uses specific detail type",
-			summaryType: "Resource",
-			detailType:  "Terraform",
-			want:        "Terraform",
-		},
-		{
-			name:        "uses compose for generic detail type without summary type",
-			summaryType: "",
-			detailType:  "Resource",
-			want:        "Compose",
-		},
-		{
-			name:        "keeps summary type when detail type is empty",
-			summaryType: "Helm",
-			detailType:  "",
-			want:        "Helm",
-		},
-		{
-			name:        "uses compose when both types are empty",
-			summaryType: "",
-			detailType:  "",
-			want:        "Compose",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := mergePlanNodeResourceType(tt.summaryType, tt.detailType); got != tt.want {
-				t.Fatalf("expected %q, got %q", tt.want, got)
-			}
-		})
-	}
-}
-
 func TestDeploymentTypesByResourceIdentityMarksGenericDeploymentAsCompose(t *testing.T) {
 	resourceID := "r-postgres"
 	resourceName := "postgres"

--- a/cmd/instance/debug_resource_detail_tui.go
+++ b/cmd/instance/debug_resource_detail_tui.go
@@ -1,0 +1,333 @@
+package instance
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/bubbles/spinner"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+func newResourceDetailSpinner() spinner.Model {
+	s := spinner.New()
+	s.Spinner = spinner.Dot
+	s.Style = lipgloss.NewStyle().Foreground(lipgloss.Color("205"))
+	return s
+}
+
+func resourceDetailBodyHeight(height int) int {
+	h := height - 8
+	if h < 1 {
+		h = 1
+	}
+	return h
+}
+
+func resourceDetailVisibleRows(height int) int {
+	rows := resourceDetailBodyHeight(height) - 4
+	if rows < 1 {
+		rows = 1
+	}
+	return rows
+}
+
+func resourceDetailContentWidth(width int) int {
+	w := width - 4
+	if w < 20 {
+		w = 20
+	}
+	return w
+}
+
+func renderResourceDetailHeader(width int, node PlanDAGNode) string {
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("230"))
+	dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+
+	title := titleStyle.Render(node.Name)
+	if node.Name == "" {
+		title = titleStyle.Render(node.Key)
+	}
+
+	typeTag := dimStyle.Render(fmt.Sprintf("[%s]", node.Type))
+
+	return lipgloss.Place(width, 1, lipgloss.Left, lipgloss.Top,
+		lipgloss.NewStyle().Padding(0, 1).Render(fmt.Sprintf("%s  %s", title, typeTag)))
+}
+
+func renderResourceDetailTabsWithBody(width, bodyHeight int, tabNames []string, activeTab int, content string) string {
+	inactiveTabBorder := tabBorderWithBottom("┴", "─", "┴")
+	activeTabBorder := tabBorderWithBottom("┘", " ", "└")
+
+	inactiveTabStyle := lipgloss.NewStyle().
+		Border(inactiveTabBorder, true).
+		BorderForeground(lipgloss.Color("240")).
+		Padding(0, 1)
+	activeTabStyle := lipgloss.NewStyle().
+		Border(activeTabBorder, true).
+		BorderForeground(lipgloss.Color("240")).
+		Padding(0, 1).
+		Bold(true).
+		Foreground(lipgloss.Color("230"))
+
+	var renderedTabs []string
+	for i, name := range tabNames {
+		style := inactiveTabStyle
+		isActive := i == activeTab
+		if isActive {
+			style = activeTabStyle
+		}
+
+		if i == 0 {
+			border := style.GetBorderStyle()
+			if isActive {
+				border.BottomLeft = "│"
+			} else {
+				border.BottomLeft = "├"
+			}
+			style = style.Border(border, true)
+		}
+		renderedTabs = append(renderedTabs, style.Render(name))
+	}
+
+	row := lipgloss.JoinHorizontal(lipgloss.Top, renderedTabs...)
+	rowWidth := lipgloss.Width(row)
+	gapWidth := width - rowWidth - 2
+	if gapWidth > 0 {
+		gap := lipgloss.NewStyle().Border(lipgloss.Border{
+			Bottom:      "─",
+			BottomLeft:  "┴",
+			BottomRight: "┐",
+		}, false, false, true).BorderForeground(lipgloss.Color("240")).Width(gapWidth).Render("")
+		row = lipgloss.JoinHorizontal(lipgloss.Bottom, row, gap)
+	}
+
+	window := lipgloss.NewStyle().
+		Border(lipgloss.Border{Left: "│", Right: "│", Bottom: "─", BottomLeft: "└", BottomRight: "┘"}, false, true, true).
+		BorderForeground(lipgloss.Color("240")).
+		Width(width - 2).
+		Height(bodyHeight).
+		Render(content)
+
+	return lipgloss.JoinVertical(lipgloss.Left, row, window)
+}
+
+func renderResourceDetailParamTreeTab(title string, tree []outputNode, cursor, scroll, visibleRows, contentWidth int, loading bool, spinnerView string, loadErr, fetchErr error, includeExpandHelp bool) string {
+	if loading {
+		return fmt.Sprintf("\n  %s Fetching %s...", spinnerView, strings.ToLower(title))
+	}
+	if fetchErr != nil {
+		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
+		return fmt.Sprintf("\n  %s\n", errStyle.Render(fmt.Sprintf("Error fetching %s: %v", strings.ToLower(title), fetchErr)))
+	}
+	if loadErr != nil {
+		errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("203"))
+		return fmt.Sprintf("\n  %s\n", errStyle.Render(fmt.Sprintf("Error: %v", loadErr)))
+	}
+	if len(tree) == 0 {
+		subtleStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+		return fmt.Sprintf("\n  %s\n", subtleStyle.Render(fmt.Sprintf("No %s available for this resource.", strings.ToLower(title))))
+	}
+
+	var b strings.Builder
+
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("255"))
+	fmt.Fprintf(&b, "  %s\n\n", headerStyle.Render(title))
+
+	visibleNodes := flattenOutputTree(tree)
+	totalEntries := len(visibleNodes)
+	cursorIndex, scrollOffset := normalizeViewport(cursor, scroll, totalEntries, visibleRows)
+
+	end := scrollOffset + visibleRows
+	if end > totalEntries {
+		end = totalEntries
+	}
+
+	keyStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("117"))
+	strStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("114"))
+	numStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("178"))
+	boolStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("178"))
+	nullStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	braceStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	selectedBg := lipgloss.NewStyle().Background(lipgloss.Color("236"))
+	maxLineWidth := contentWidth - 4
+	if maxLineWidth < 1 {
+		maxLineWidth = 1
+	}
+	rowStyle := lipgloss.NewStyle().MaxWidth(maxLineWidth)
+	selectedRowStyle := selectedBg.MaxWidth(maxLineWidth)
+
+	for idx := scrollOffset; idx < end; idx++ {
+		node := visibleNodes[idx]
+		indent := strings.Repeat("  ", node.depth)
+
+		cursorMarker := "  "
+		if idx == cursorIndex {
+			cursorMarker = "▶ "
+		}
+
+		var line string
+		if node.expandable {
+			arrow := "▸"
+			if node.expanded {
+				arrow = "▾"
+			}
+			childCount := len(node.children)
+			typeMark := braceStyle.Render("{}")
+			if node.nodeType == "array" {
+				typeMark = braceStyle.Render("[]")
+			}
+			countStr := lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Render(fmt.Sprintf("  %d items", childCount))
+			line = fmt.Sprintf("%s%s %s %s%s", indent, arrow, keyStyle.Render(node.key), typeMark, countStr)
+		} else {
+			var styledVal string
+			switch node.nodeType {
+			case "string":
+				styledVal = strStyle.Render(fmt.Sprintf("%q", node.value))
+			case "number":
+				styledVal = numStyle.Render(node.value)
+			case "bool":
+				styledVal = boolStyle.Render(node.value)
+			case "null":
+				styledVal = nullStyle.Render("null")
+			default:
+				styledVal = lipgloss.NewStyle().Foreground(lipgloss.Color("252")).Render(node.value)
+			}
+			line = fmt.Sprintf("%s  %s: %s", indent, keyStyle.Render(node.key), styledVal)
+		}
+
+		if idx == cursorIndex {
+			line = selectedRowStyle.Render(line)
+		} else {
+			line = rowStyle.Render(line)
+		}
+
+		fmt.Fprintf(&b, "  %s%s\n", cursorMarker, line)
+	}
+
+	if totalEntries > visibleRows {
+		dimStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+		pos := ""
+		if scrollOffset == 0 {
+			pos = "top"
+		} else if end >= totalEntries {
+			pos = "end"
+		} else {
+			pct := (scrollOffset * 100) / (totalEntries - visibleRows)
+			pos = fmt.Sprintf("%d%%", pct)
+		}
+		hint := "↑↓: navigate"
+		if includeExpandHelp {
+			hint += "  ←→/enter: expand/collapse"
+		}
+		fmt.Fprintf(&b, "\n  %s\n", dimStyle.Render(fmt.Sprintf("%s  [%d/%d %s]", hint, cursorIndex+1, totalEntries, pos)))
+	}
+
+	return b.String()
+}
+
+func renderResourceWorkflowEventsTab(debugData DebugData, node PlanDAGNode, wfErrors *workflowErrorsState, bodyHeight, contentWidth int, spinnerView string) string {
+	loading := debugData.PlanDAG != nil && debugData.PlanDAG.ProgressLoading
+	steps := getResourceWorkflowEvents(debugData, node)
+	enrichBootstrapSteps(steps, node.Key, debugData.PlanDAG)
+	isLive := isWorkflowInProgress(steps)
+	return renderWorkflowEventsTab(steps, wfErrors, bodyHeight, contentWidth, loading, spinnerView, isLive)
+}
+
+func renderResourceDetailFooter(width int, clipboardMsg, text string) string {
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color("241")).Padding(0, 1)
+	if clipboardMsg != "" {
+		clipStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("82"))
+		text = clipStyle.Render(clipboardMsg) + "  " + text
+	}
+	return lipgloss.Place(width, 1, lipgloss.Left, lipgloss.Top, style.Render(text))
+}
+
+func getResourceWorkflowEvents(debugData DebugData, node PlanDAGNode) *ResourceWorkflowSteps {
+	if debugData.PlanDAG != nil && debugData.PlanDAG.WorkflowStepsByKey != nil {
+		return debugData.PlanDAG.WorkflowStepsByKey[node.Key]
+	}
+	return nil
+}
+
+func handleResourceWorkflowRefreshTick(debugData DebugData, node PlanDAGNode, wfErrors *workflowErrorsState) tea.Cmd {
+	steps := getResourceWorkflowEvents(debugData, node)
+	if isWorkflowInProgress(steps) && !wfErrors.refreshing {
+		wfErrors.refreshing = true
+		return fetchWfEventsForResource(debugData, node.Key)
+	}
+	return nil
+}
+
+func handleResourceWorkflowRefresh(debugData DebugData, node PlanDAGNode, wfErrors *workflowErrorsState, msg wfEventsRefreshMsg) tea.Cmd {
+	wfErrors.refreshing = false
+	wfErrors.lastRefresh = time.Now()
+	if msg.err == nil && msg.steps != nil && debugData.PlanDAG != nil {
+		if debugData.PlanDAG.WorkflowStepsByKey == nil {
+			debugData.PlanDAG.WorkflowStepsByKey = make(map[string]*ResourceWorkflowSteps)
+		}
+		debugData.PlanDAG.WorkflowStepsByKey[node.Key] = msg.steps
+	}
+	if isWorkflowInProgress(getResourceWorkflowEvents(debugData, node)) {
+		return tea.Batch(scheduleWfEventsRefresh(), scheduleWfCountdownTick())
+	}
+	return nil
+}
+
+func handleResourceWorkflowCountdown(debugData DebugData, node PlanDAGNode) tea.Cmd {
+	if isWorkflowInProgress(getResourceWorkflowEvents(debugData, node)) {
+		return scheduleWfCountdownTick()
+	}
+	return nil
+}
+
+func scheduleResourceWorkflowRefreshIfNeeded(debugData DebugData, node PlanDAGNode) tea.Cmd {
+	if isWorkflowInProgress(getResourceWorkflowEvents(debugData, node)) {
+		return tea.Batch(scheduleWfEventsRefresh(), scheduleWfCountdownTick())
+	}
+	return nil
+}
+
+func moveResourceDetailTreeUp(tree []outputNode, cursor, scroll, visibleRows int) (int, int) {
+	if len(tree) == 0 {
+		return cursor, scroll
+	}
+	visibleNodes := flattenOutputTree(tree)
+	if cursor > 0 {
+		cursor--
+	}
+	return normalizeViewport(cursor, scroll, len(visibleNodes), visibleRows)
+}
+
+func moveResourceDetailTreeDown(tree []outputNode, cursor, scroll, visibleRows int) (int, int) {
+	if len(tree) == 0 {
+		return cursor, scroll
+	}
+	visibleNodes := flattenOutputTree(tree)
+	if cursor < len(visibleNodes)-1 {
+		cursor++
+	}
+	return normalizeViewport(cursor, scroll, len(visibleNodes), visibleRows)
+}
+
+func toggleResourceDetailTreeNode(tree []outputNode, cursor int) {
+	visibleNodes := flattenOutputTree(tree)
+	if cursor >= 0 && cursor < len(visibleNodes) && visibleNodes[cursor].expandable {
+		visibleNodes[cursor].expanded = !visibleNodes[cursor].expanded
+	}
+}
+
+func expandResourceDetailTreeNode(tree []outputNode, cursor int) {
+	visibleNodes := flattenOutputTree(tree)
+	if cursor >= 0 && cursor < len(visibleNodes) && visibleNodes[cursor].expandable && !visibleNodes[cursor].expanded {
+		visibleNodes[cursor].expanded = true
+	}
+}
+
+func collapseResourceDetailTreeNode(tree []outputNode, cursor int) {
+	visibleNodes := flattenOutputTree(tree)
+	if cursor >= 0 && cursor < len(visibleNodes) && visibleNodes[cursor].expandable && visibleNodes[cursor].expanded {
+		visibleNodes[cursor].expanded = false
+	}
+}

--- a/cmd/instance/debug_shared.go
+++ b/cmd/instance/debug_shared.go
@@ -83,11 +83,14 @@ type ResourceDebugInfo struct {
 
 	// Operator-specific data (populated for operator resources)
 	Operator *OperatorData `json:"operator,omitempty"`
+
+	// Compose-specific data (populated for compose resources)
+	Compose *ComposeData `json:"compose,omitempty"`
 }
 
 // hasData returns true if any debug data has been populated for this resource.
 func (r *ResourceDebugInfo) hasData() bool {
-	return r.Helm != nil || r.Operator != nil || r.TerraformProgress != nil ||
+	return r.Helm != nil || r.Operator != nil || r.Compose != nil || r.TerraformProgress != nil ||
 		len(r.TerraformHistory) > 0 || len(r.TerraformFiles) > 0 || len(r.TerraformLogs) > 0 ||
 		len(r.TerraformPlanPreview) > 0 || len(r.TerraformPlanPreviewError) > 0
 }

--- a/cmd/instance/debug_shared.go
+++ b/cmd/instance/debug_shared.go
@@ -59,9 +59,15 @@ type OperatorCRDOutputParam struct {
 
 // OperatorData holds debug information specific to operator-type resources.
 type OperatorData struct {
-	InputParams    []OperatorInputParam     `json:"inputParams,omitempty"`
-	OutputParams   []OperatorOutputParam    `json:"outputParams,omitempty"`
+	InputParams     []OperatorInputParam     `json:"inputParams,omitempty"`
+	OutputParams    []OperatorOutputParam    `json:"outputParams,omitempty"`
 	CRDOutputParams []OperatorCRDOutputParam `json:"crdOutputParams,omitempty"`
+}
+
+// ComposeData holds debug information specific to compose-type resources.
+type ComposeData struct {
+	InputParams  []OperatorInputParam  `json:"inputParams,omitempty"`
+	OutputParams []OperatorOutputParam `json:"outputParams,omitempty"`
 }
 
 // ResourceDebugInfo holds all debug information for a specific resource in the plan DAG.


### PR DESCRIPTION
 ## Changes
 
 ### Compose Debug TUI
 - Added a detail view for Compose-type resources in the `instance debug` command
 - Tabs: **Input Parameters**, **Output Parameters**, **Workflow Events**
 - Works in both interactive TUI and JSON output modes
 
 ### Simplified Parameter Display
 - Input/Output parameter tree nodes now show just `key: value` instead of expandable nodes with metadata (description, modifiable, required, type)
 - Applies to Operator, Helm, and Compose parameter tabs
 - Makes the debug view cleaner and easier to scan
 
 ### JSON Output
 - Added `compose` field to `ResourceDebugInfo` for compose-type resources
 - Collects input/output parameters for compose resources in JSON mode