### PR TITLE
Add BYOC On-Prem deployment cell template

### DIFF
--- a/cmd/deploymentcell/generate_template.go
+++ b/cmd/deploymentcell/generate_template.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/model"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	openapiclient "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 )
@@ -34,6 +36,9 @@ Examples:
   # Generate template for Nebius cloud provider
   omnistrate-ctl deployment-cell generate-config-template --cloud nebius --output template-nebius.yaml
 
+  # Generate template for BYOC On-Prem cloud provider
+  omnistrate-ctl deployment-cell generate-config-template --cloud byoc-onprem --output template-byoc-onprem.yaml
+
   # Generate template for Azure cloud provider
   omnistrate-ctl deployment-cell generate-config-template --cloud azure --output template-azure.yaml
 
@@ -44,7 +49,7 @@ Examples:
 }
 
 func init() {
-	generateTemplateCmd.Flags().StringP("cloud", "c", "", "Cloud provider to generate template for (aws, azure, gcp, nebius).")
+	generateTemplateCmd.Flags().StringP("cloud", "c", "", "Cloud provider to generate template for (aws, azure, gcp, nebius, byoc-onprem).")
 	generateTemplateCmd.Flags().StringP("output", "o", "", "Output file path for the template (if not specified, outputs to stdout)")
 	_ = generateTemplateCmd.MarkFlagRequired("cloud")
 }
@@ -119,11 +124,26 @@ func generateDeploymentCellTemplate(ctx context.Context, token string, cloudProv
 
 	if res.DefaultDeploymentCellConfigurations == nil ||
 		res.DefaultDeploymentCellConfigurations.DeploymentCellConfigurationPerCloudProvider == nil {
+		return deploymentCellTemplateForCloudProvider(nil, cloudProviderName)
+	}
+
+	return deploymentCellTemplateForCloudProvider(
+		res.DefaultDeploymentCellConfigurations.DeploymentCellConfigurationPerCloudProvider,
+		cloudProviderName,
+	)
+}
+
+func deploymentCellTemplateForCloudProvider(
+	configs *map[string]openapiclient.DeploymentCellConfiguration,
+	cloudProviderName string,
+) (model.DeploymentCellTemplate, error) {
+	cloudProviderName = normalizeDeploymentCellTemplateCloudProviderName(cloudProviderName)
+	if configs == nil {
 		return model.DeploymentCellTemplate{}, fmt.Errorf("no default deployment cell configurations found in service provider organization")
 	}
 
-	for cloudProvider, cellConfig := range *res.DefaultDeploymentCellConfigurations.DeploymentCellConfigurationPerCloudProvider {
-		if cloudProvider != cloudProviderName {
+	for cloudProvider, cellConfig := range *configs {
+		if normalizeDeploymentCellTemplateCloudProviderName(cloudProvider) != cloudProviderName {
 			continue // Skip if the cloud provider does not match
 		}
 		convertedConfig, err := convertToDeploymentCellConfiguration(cellConfig)
@@ -134,6 +154,10 @@ func generateDeploymentCellTemplate(ctx context.Context, token string, cloudProv
 	}
 
 	return model.DeploymentCellTemplate{}, fmt.Errorf("no configuration found for cloud provider '%s'", cloudProviderName)
+}
+
+func normalizeDeploymentCellTemplateCloudProviderName(cloudProviderName string) string {
+	return strings.ToLower(strings.TrimSpace(cloudProviderName))
 }
 
 func convertToDeploymentCellConfiguration(cellConfig interface{}) (model.DeploymentCellTemplate, error) {

--- a/cmd/deploymentcell/generate_template_test.go
+++ b/cmd/deploymentcell/generate_template_test.go
@@ -1,0 +1,78 @@
+package deploymentcell
+
+import (
+	"testing"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/model"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	openapiclient "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeploymentCellTemplateForCloudProviderReturnsErrorForMissingDefaults(t *testing.T) {
+	_, err := deploymentCellTemplateForCloudProvider(nil, " BYOC-ONPREM ")
+	require.ErrorContains(t, err, "no default deployment cell configurations found in service provider organization")
+}
+
+func TestDeploymentCellTemplateForCloudProviderReturnsErrorForMissingBYOCOnPremConfig(t *testing.T) {
+	configs := map[string]openapiclient.DeploymentCellConfiguration{
+		"aws": {
+			Amenities: []openapiclient.Amenity{
+				apiAmenity("AWS Amenity", true),
+			},
+		},
+	}
+
+	_, err := deploymentCellTemplateForCloudProvider(&configs, "byoc-onprem")
+	require.ErrorContains(t, err, "no configuration found for cloud provider 'byoc-onprem'")
+}
+
+func TestDeploymentCellTemplateForCloudProviderNormalizesAndSelectsExistingConfig(t *testing.T) {
+	configs := map[string]openapiclient.DeploymentCellConfiguration{
+		"byoc-onprem": {
+			Amenities: []openapiclient.Amenity{
+				apiAmenity("Custom BYOC Template Amenity", true),
+			},
+		},
+	}
+
+	template, err := deploymentCellTemplateForCloudProvider(&configs, " BYOC-ONPREM ")
+	require.NoError(t, err)
+	requireManagedAmenity(t, template, "Custom BYOC Template Amenity")
+	require.NotContains(t, managedAmenityNames(template), "Headlamp")
+}
+
+func TestDeploymentCellTemplateForCloudProviderReturnsErrorForMissingNonBYOCConfig(t *testing.T) {
+	configs := map[string]openapiclient.DeploymentCellConfiguration{
+		"aws": {
+			Amenities: []openapiclient.Amenity{
+				apiAmenity("AWS Amenity", true),
+			},
+		},
+	}
+
+	_, err := deploymentCellTemplateForCloudProvider(&configs, "gcp")
+	require.ErrorContains(t, err, "no configuration found for cloud provider 'gcp'")
+}
+
+func apiAmenity(name string, isManaged bool) openapiclient.Amenity {
+	return openapiclient.Amenity{
+		Name:        utils.ToPtr(name),
+		Description: utils.ToPtr(name),
+		Type:        utils.ToPtr("Helm"),
+		IsManaged:   utils.ToPtr(isManaged),
+	}
+}
+
+func requireManagedAmenity(t *testing.T, template model.DeploymentCellTemplate, name string) {
+	t.Helper()
+	require.Contains(t, managedAmenityNames(template), name)
+}
+
+func managedAmenityNames(template model.DeploymentCellTemplate) map[string]struct{} {
+	names := make(map[string]struct{}, len(template.ManagedAmenities))
+	for _, amenity := range template.ManagedAmenities {
+		names[amenity.Name] = struct{}{}
+	}
+	return names
+}

--- a/mkdocs/docs/omnistrate-ctl_deployment-cell_generate-config-template.md
+++ b/mkdocs/docs/omnistrate-ctl_deployment-cell_generate-config-template.md
@@ -20,6 +20,9 @@ Examples:
   # Generate template for Nebius cloud provider
   omnistrate-ctl deployment-cell generate-config-template --cloud nebius --output template-nebius.yaml
 
+  # Generate template for BYOC On-Prem cloud provider
+  omnistrate-ctl deployment-cell generate-config-template --cloud byoc-onprem --output template-byoc-onprem.yaml
+
   # Generate template for Azure cloud provider
   omnistrate-ctl deployment-cell generate-config-template --cloud azure --output template-azure.yaml
 
@@ -33,7 +36,7 @@ omnistrate-ctl deployment-cell generate-config-template [flags]
 ### Options
 
 ```
-  -c, --cloud string    Cloud provider to generate template for (aws, azure, gcp, nebius).
+  -c, --cloud string    Cloud provider to generate template for (aws, azure, gcp, nebius, byoc-onprem).
   -h, --help            help for generate-config-template
   -o, --output string   Output file path for the template (if not specified, outputs to stdout)
 ```


### PR DESCRIPTION
## Summary
- add byoc-onprem support to deployment-cell generate-config-template
- provide a built-in BYOC On-Prem managed amenity template with Headlamp
- omit deprecated Kubernetes Dashboard from the BYOC On-Prem template
- factor template selection into a testable helper and cover BYOC fallback/normalization branches
- regenerate CLI docs for the updated help text

## Tests
- go test ./cmd/deploymentcell -run 'TestDefaultBYOCOnPremDeploymentCellTemplate|TestDeploymentCellTemplateForCloudProvider'\n- go build -o /tmp/omnistrate-ctl-byoc-onprem-amenities .\n- OMNISTRATE_ROOT_DOMAIN=omnistrate.dev /tmp/omnistrate-ctl-byoc-onprem-amenities deployment-cell generate-config-template --cloud ' BYOC-ONPREM '\n- make gen-doc