### PR TITLE
fix: support BYOC On-Premise customer onboarding flags

### DIFF
--- a/cmd/account/create.go
+++ b/cmd/account/create.go
@@ -41,6 +41,7 @@ func init() {
 	createCmd.Args = cobra.ExactArgs(1) // Require exactly one argument
 
 	addCloudAccountProviderFlags(createCmd)
+	markCloudAccountProviderRequired(createCmd)
 }
 
 func runCreate(cmd *cobra.Command, args []string) error {
@@ -124,14 +125,17 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 // CloudAccountParams holds the parameters for creating a cloud account
 type CloudAccountParams struct {
-	Name                string
-	AwsAccountID        string
-	GcpProjectID        string
-	GcpProjectNumber    string
-	AzureSubscriptionID string
-	AzureTenantID       string
-	NebiusTenantID      string
-	NebiusBindings      []openapiclient.NebiusAccountBindingInput
+	Name                         string
+	AwsAccountID                 string
+	GcpProjectID                 string
+	GcpProjectNumber             string
+	AzureSubscriptionID          string
+	AzureTenantID                string
+	NebiusTenantID               string
+	NebiusBindings               []openapiclient.NebiusAccountBindingInput
+	BYOCOnPremClusterName        string
+	BYOCOnPremClusterRegion      string
+	BYOCOnPremClusterDescription string
 }
 
 // CreateCloudAccount creates a cloud provider account and returns the account config ID and account details
@@ -243,12 +247,15 @@ func validateCloudAccountParams(params CloudAccountParams) error {
 	if params.NebiusTenantID != "" || len(params.NebiusBindings) > 0 {
 		providerCount++
 	}
+	if params.BYOCOnPremClusterName != "" || params.BYOCOnPremClusterRegion != "" || params.BYOCOnPremClusterDescription != "" {
+		providerCount++
+	}
 
 	if providerCount == 0 {
 		return fmt.Errorf("one cloud provider account configuration must be provided")
 	}
 	if providerCount > 1 {
-		return fmt.Errorf("only one of --aws-account-id, --gcp-project-id, --azure-subscription-id, or --nebius-tenant-id can be used at a time")
+		return fmt.Errorf("only one of --aws-account-id, --gcp-project-id, --azure-subscription-id, --nebius-tenant-id, or --cluster-name can be used at a time")
 	}
 
 	if (params.GcpProjectID != "" && params.GcpProjectNumber == "") || (params.GcpProjectID == "" && params.GcpProjectNumber != "") {
@@ -259,6 +266,9 @@ func validateCloudAccountParams(params CloudAccountParams) error {
 	}
 	if (params.NebiusTenantID != "" && len(params.NebiusBindings) == 0) || (params.NebiusTenantID == "" && len(params.NebiusBindings) > 0) {
 		return fmt.Errorf("both --nebius-tenant-id and --nebius-bindings-file must be provided together")
+	}
+	if params.BYOCOnPremClusterName == "" && (params.BYOCOnPremClusterRegion != "" || params.BYOCOnPremClusterDescription != "") {
+		return fmt.Errorf("--cluster-name must be provided when using BYOC On-Premise cluster flags")
 	}
 
 	return nil

--- a/cmd/account/create_test.go
+++ b/cmd/account/create_test.go
@@ -48,7 +48,22 @@ func TestValidateCloudAccountParams_Nebius(t *testing.T) {
 				NebiusTenantID: "tenant-1",
 				NebiusBindings: []openapiclient.NebiusAccountBindingInput{validBinding},
 			},
-			wantErr: "only one of --aws-account-id, --gcp-project-id, --azure-subscription-id, or --nebius-tenant-id can be used at a time",
+			wantErr: "only one of --aws-account-id, --gcp-project-id, --azure-subscription-id, --nebius-tenant-id, or --cluster-name can be used at a time",
+		},
+		{
+			name: "valid BYOC On-Prem params",
+			params: CloudAccountParams{
+				Name:                  "customer-k8s",
+				BYOCOnPremClusterName: "customer-k8s",
+			},
+		},
+		{
+			name: "BYOC On-Prem region requires cluster name",
+			params: CloudAccountParams{
+				Name:                    "customer-k8s",
+				BYOCOnPremClusterRegion: "us-west-2",
+			},
+			wantErr: "--cluster-name must be provided when using BYOC On-Premise cluster flags",
 		},
 	}
 

--- a/cmd/account/customer_create.go
+++ b/cmd/account/customer_create.go
@@ -24,25 +24,39 @@ const (
 	  --plan=customer-hosted \
 	  --customer-email=customer@example.com \
 	  --nebius-tenant-id=tenant-xxxx \
-	  --nebius-bindings-file=./nebius-bindings.yaml`
+	  --nebius-bindings-file=./nebius-bindings.yaml
 
-	customerAccountResourceName          = "Cloud Provider Account"
-	customerAccountResourceKey           = "omnistrateCloudAccountConfig"
-	customerAccountResultAccountIDKey    = "cloud_provider_account_config_id"
-	customerAccountIacToolName           = "Account Configuration Method"
-	customerAccountAWSAccountIDName      = "AWS Account ID"
-	customerAccountAWSBootstrapRoleName  = "AWS Bootstrap Role ARN"
-	customerAccountGCPProjectIDName      = "GCP Project ID"
-	customerAccountGCPProjectNumberName  = "GCP Project Number"
-	customerAccountGCPServiceAccountName = "GCP Service Account Email"
-	customerAccountAzureSubIDName        = "Azure Subscription ID"
-	customerAccountAzureTenantIDName     = "Azure Tenant ID"
-	customerAccountNebiusTenantIDName    = "Nebius Tenant ID"
-	customerAccountNebiusBindingsName    = "Nebius Bindings"
-	customerAccountReadyTimeout          = 10 * time.Minute
-	customerAccountReadyPollInterval     = 10 * time.Second
-	customerEmailFlag                    = "customer-email"
-	customerAccountDefaultVersion        = "preferred"
+# Onboard a BYOC On-Premise Kubernetes cluster into a service plan
+	omnistrate-ctl account customer create \
+	  --service=postgres \
+	  --environment=dev \
+	  --plan=customer-hosted \
+	  --cluster-name=customer-k8s \
+	  --cluster-region=us-west-2 \
+	  --cluster-description="Customer Kubernetes cluster" \
+	  --skip-wait`
+
+	customerAccountResourceName                 = "Cloud Provider Account"
+	customerAccountResourceKey                  = "omnistrateCloudAccountConfig"
+	customerAccountResultAccountIDKey           = "cloud_provider_account_config_id"
+	customerAccountIacToolName                  = "Account Configuration Method"
+	customerAccountAWSAccountIDName             = "AWS Account ID"
+	customerAccountAWSBootstrapRoleName         = "AWS Bootstrap Role ARN"
+	customerAccountGCPProjectIDName             = "GCP Project ID"
+	customerAccountGCPProjectNumberName         = "GCP Project Number"
+	customerAccountGCPServiceAccountName        = "GCP Service Account Email"
+	customerAccountAzureSubIDName               = "Azure Subscription ID"
+	customerAccountAzureTenantIDName            = "Azure Tenant ID"
+	customerAccountNebiusTenantIDName           = "Nebius Tenant ID"
+	customerAccountNebiusBindingsName           = "Nebius Bindings"
+	customerAccountCloudProviderName            = "Cloud Provider"
+	customerAccountBYOCOnPremClusterName        = "Cluster Name"
+	customerAccountBYOCOnPremClusterRegion      = "Cluster Region"
+	customerAccountBYOCOnPremClusterDescription = "Cluster Description"
+	customerAccountReadyTimeout                 = 10 * time.Minute
+	customerAccountReadyPollInterval            = 10 * time.Second
+	customerEmailFlag                           = "customer-email"
+	customerAccountDefaultVersion               = "preferred"
 )
 
 type customerCreateOutput struct {
@@ -99,6 +113,7 @@ func init() {
 	customerCreateCmd.Args = cobra.NoArgs
 
 	addCloudAccountProviderFlags(customerCreateCmd)
+	addBYOCOnPremCustomerProviderFlags(customerCreateCmd)
 
 	customerCreateCmd.Flags().String("service", "", "Service name or ID")
 	customerCreateCmd.Flags().String("environment", "", "Environment name or ID")
@@ -493,6 +508,10 @@ func customerAccountInputParameters() []openapiclient.DescribeInputParameterResu
 		{Name: customerAccountAzureTenantIDName, Key: "azure_tenant_id"},
 		{Name: customerAccountNebiusTenantIDName, Key: "nebius_tenant_id"},
 		{Name: customerAccountNebiusBindingsName, Key: "nebius_bindings"},
+		{Name: customerAccountCloudProviderName, Key: "cloud_provider"},
+		{Name: customerAccountBYOCOnPremClusterName, Key: "cluster_name"},
+		{Name: customerAccountBYOCOnPremClusterRegion, Key: "cluster_region"},
+		{Name: customerAccountBYOCOnPremClusterDescription, Key: "cluster_description"},
 	}
 }
 
@@ -655,6 +674,23 @@ func buildCustomerAccountRequestParamsWithDerivedValues(
 		if err := setParam(customerAccountNebiusBindingsName, toCustomerNebiusBindingParams(params.NebiusBindings)); err != nil {
 			return nil, err
 		}
+	case "byoc-onprem":
+		if err := setParam(customerAccountCloudProviderName, "byoc-onprem"); err != nil {
+			return nil, err
+		}
+		if err := setParam(customerAccountBYOCOnPremClusterName, params.BYOCOnPremClusterName); err != nil {
+			return nil, err
+		}
+		if params.BYOCOnPremClusterRegion != "" {
+			if err := setParam(customerAccountBYOCOnPremClusterRegion, params.BYOCOnPremClusterRegion); err != nil {
+				return nil, err
+			}
+		}
+		if params.BYOCOnPremClusterDescription != "" {
+			if err := setParam(customerAccountBYOCOnPremClusterDescription, params.BYOCOnPremClusterDescription); err != nil {
+				return nil, err
+			}
+		}
 	default:
 		return nil, fmt.Errorf("unsupported cloud provider request")
 	}
@@ -685,6 +721,8 @@ func requestedCloudProvider(params CloudAccountParams) string {
 		return "azure"
 	case params.NebiusTenantID != "":
 		return "nebius"
+	case params.BYOCOnPremClusterName != "":
+		return "byoc-onprem"
 	default:
 		return ""
 	}

--- a/cmd/account/customer_create_test.go
+++ b/cmd/account/customer_create_test.go
@@ -23,6 +23,7 @@ func TestCustomerCreateCommandDoesNotExposePlacementFlags(t *testing.T) {
 	require.NotNil(t, customerCreateCmd.Flags().Lookup("environment"))
 	require.NotNil(t, customerCreateCmd.Flags().Lookup("plan"))
 	require.NotNil(t, customerCreateCmd.Flags().Lookup(customerEmailFlag))
+	require.NotNil(t, customerCreateCmd.Flags().Lookup(byocOnPremClusterNameFlag))
 }
 
 func TestCloudAccountParamsFromFlags_SharesProviderParsing(t *testing.T) {
@@ -114,6 +115,30 @@ func TestBuildCustomerAccountRequestParamsWithDerivedValues_Nebius(t *testing.T)
 	assert.False(t, hasRegion)
 }
 
+func TestBuildCustomerAccountRequestParamsWithDerivedValues_BYOCOnPrem(t *testing.T) {
+	params := CloudAccountParams{
+		Name:                         "customer-k8s",
+		BYOCOnPremClusterName:        "customer-k8s",
+		BYOCOnPremClusterRegion:      "us-west-2",
+		BYOCOnPremClusterDescription: "Customer Kubernetes cluster",
+	}
+
+	inputParameters := []openapiclient.DescribeInputParameterResult{
+		{Name: customerAccountCloudProviderName, Key: "cloud_provider"},
+		{Name: customerAccountBYOCOnPremClusterName, Key: "cluster_name"},
+		{Name: customerAccountBYOCOnPremClusterRegion, Key: "cluster_region"},
+		{Name: customerAccountBYOCOnPremClusterDescription, Key: "cluster_description"},
+	}
+
+	requestParams, err := buildCustomerAccountRequestParamsWithDerivedValues(params, inputParameters, "")
+	require.NoError(t, err)
+	assert.Equal(t, "byoc-onprem", requestParams["cloud_provider"])
+	assert.Equal(t, "customer-k8s", requestParams["cluster_name"])
+	assert.Equal(t, "us-west-2", requestParams["cluster_region"])
+	assert.Equal(t, "Customer Kubernetes cluster", requestParams["cluster_description"])
+	assert.Equal(t, "byoc-onprem", requestedCloudProvider(params))
+}
+
 func TestBuildCustomerAccountRequestParamsWithDerivedValues_AWS(t *testing.T) {
 	params := CloudAccountParams{
 		Name:         "customer-aws",
@@ -150,6 +175,10 @@ func TestCustomerAccountInputParameters(t *testing.T) {
 	assert.Equal(t, "azure_tenant_id", keysByName[customerAccountAzureTenantIDName])
 	assert.Equal(t, "nebius_tenant_id", keysByName[customerAccountNebiusTenantIDName])
 	assert.Equal(t, "nebius_bindings", keysByName[customerAccountNebiusBindingsName])
+	assert.Equal(t, "cloud_provider", keysByName[customerAccountCloudProviderName])
+	assert.Equal(t, "cluster_name", keysByName[customerAccountBYOCOnPremClusterName])
+	assert.Equal(t, "cluster_region", keysByName[customerAccountBYOCOnPremClusterRegion])
+	assert.Equal(t, "cluster_description", keysByName[customerAccountBYOCOnPremClusterDescription])
 }
 
 func TestExtractCustomerAccountConfigID(t *testing.T) {
@@ -221,7 +250,7 @@ func TestResolveCustomerAccountSubscription_ProductionDefaultsToCallingUserSubsc
 	describeCurrentUserFn = func(ctx context.Context, token string) (*openapiclient.DescribeUserResult, error) {
 		assert.Equal(t, "token", token)
 		return &openapiclient.DescribeUserResult{
-			Email: strPtr("caller@example.com"),
+			Email: ptr("caller@example.com"),
 		}, nil
 	}
 	resolveCustomerSubscriptionByEmail = func(ctx context.Context, token, serviceID, environmentID, planID, customerEmail string) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {

--- a/cmd/account/provider_flags.go
+++ b/cmd/account/provider_flags.go
@@ -5,14 +5,17 @@ import (
 )
 
 const (
-	awsAccountIDFlag        = "aws-account-id"
-	gcpProjectIDFlag        = "gcp-project-id"
-	gcpProjectNumberFlag    = "gcp-project-number"
-	azureSubscriptionIDFlag = "azure-subscription-id"
-	azureTenantIDFlag       = "azure-tenant-id"
-	nebiusTenantIDFlag      = "nebius-tenant-id"
-	nebiusBindingsFileFlag  = "nebius-bindings-file"
-	skipWaitFlag            = "skip-wait"
+	awsAccountIDFlag                 = "aws-account-id"
+	gcpProjectIDFlag                 = "gcp-project-id"
+	gcpProjectNumberFlag             = "gcp-project-number"
+	azureSubscriptionIDFlag          = "azure-subscription-id"
+	azureTenantIDFlag                = "azure-tenant-id"
+	nebiusTenantIDFlag               = "nebius-tenant-id"
+	nebiusBindingsFileFlag           = "nebius-bindings-file"
+	byocOnPremClusterNameFlag        = "cluster-name"
+	byocOnPremClusterRegionFlag      = "cluster-region"
+	byocOnPremClusterDescriptionFlag = "cluster-description"
+	skipWaitFlag                     = "skip-wait"
 )
 
 func addCloudAccountProviderFlags(cmd *cobra.Command) {
@@ -25,16 +28,33 @@ func addCloudAccountProviderFlags(cmd *cobra.Command) {
 	cmd.Flags().String(nebiusBindingsFileFlag, "", "Path to a YAML file describing Nebius bindings")
 	cmd.Flags().Bool(skipWaitFlag, false, "Skip waiting for the account to become READY")
 
+	cmd.MarkFlagsRequiredTogether(gcpProjectIDFlag, gcpProjectNumberFlag)
+	cmd.MarkFlagsRequiredTogether(azureSubscriptionIDFlag, azureTenantIDFlag)
+	cmd.MarkFlagsRequiredTogether(nebiusTenantIDFlag, nebiusBindingsFileFlag)
+	_ = cmd.MarkFlagFilename(nebiusBindingsFileFlag)
+}
+
+func markCloudAccountProviderRequired(cmd *cobra.Command) {
 	cmd.MarkFlagsOneRequired(
 		awsAccountIDFlag,
 		gcpProjectIDFlag,
 		azureSubscriptionIDFlag,
 		nebiusTenantIDFlag,
 	)
-	cmd.MarkFlagsRequiredTogether(gcpProjectIDFlag, gcpProjectNumberFlag)
-	cmd.MarkFlagsRequiredTogether(azureSubscriptionIDFlag, azureTenantIDFlag)
-	cmd.MarkFlagsRequiredTogether(nebiusTenantIDFlag, nebiusBindingsFileFlag)
-	_ = cmd.MarkFlagFilename(nebiusBindingsFileFlag)
+}
+
+func addBYOCOnPremCustomerProviderFlags(cmd *cobra.Command) {
+	cmd.Flags().String(byocOnPremClusterNameFlag, "", "Customer Kubernetes cluster name for BYOC On-Premise")
+	cmd.Flags().String(byocOnPremClusterRegionFlag, "", "Customer Kubernetes cluster region or location label for BYOC On-Premise")
+	cmd.Flags().String(byocOnPremClusterDescriptionFlag, "", "Customer Kubernetes cluster description for BYOC On-Premise")
+
+	cmd.MarkFlagsOneRequired(
+		awsAccountIDFlag,
+		gcpProjectIDFlag,
+		azureSubscriptionIDFlag,
+		nebiusTenantIDFlag,
+		byocOnPremClusterNameFlag,
+	)
 }
 
 func cloudAccountParamsFromFlags(cmd *cobra.Command, name string) (CloudAccountParams, error) {
@@ -45,15 +65,21 @@ func cloudAccountParamsFromFlags(cmd *cobra.Command, name string) (CloudAccountP
 	azureTenantID, _ := cmd.Flags().GetString(azureTenantIDFlag)
 	nebiusTenantID, _ := cmd.Flags().GetString(nebiusTenantIDFlag)
 	nebiusBindingsFile, _ := cmd.Flags().GetString(nebiusBindingsFileFlag)
+	byocOnPremClusterName, _ := cmd.Flags().GetString(byocOnPremClusterNameFlag)
+	byocOnPremClusterRegion, _ := cmd.Flags().GetString(byocOnPremClusterRegionFlag)
+	byocOnPremClusterDescription, _ := cmd.Flags().GetString(byocOnPremClusterDescriptionFlag)
 
 	params := CloudAccountParams{
-		Name:                name,
-		AwsAccountID:        awsAccountID,
-		GcpProjectID:        gcpProjectID,
-		GcpProjectNumber:    gcpProjectNumber,
-		AzureSubscriptionID: azureSubscriptionID,
-		AzureTenantID:       azureTenantID,
-		NebiusTenantID:      nebiusTenantID,
+		Name:                         name,
+		AwsAccountID:                 awsAccountID,
+		GcpProjectID:                 gcpProjectID,
+		GcpProjectNumber:             gcpProjectNumber,
+		AzureSubscriptionID:          azureSubscriptionID,
+		AzureTenantID:                azureTenantID,
+		NebiusTenantID:               nebiusTenantID,
+		BYOCOnPremClusterName:        byocOnPremClusterName,
+		BYOCOnPremClusterRegion:      byocOnPremClusterRegion,
+		BYOCOnPremClusterDescription: byocOnPremClusterDescription,
 	}
 
 	if nebiusBindingsFile != "" {


### PR DESCRIPTION
## Summary
- add BYOC On-Premise cluster flags to `account customer create`
- map `cloud_provider=byoc-onprem`, `cluster_name`, `cluster_region`, and `cluster_description` into customer onboarding request params
- keep generic `account create` provider validation unchanged

## Verification
- go test -mod=mod cmd/account/create.go cmd/account/provider_flags.go cmd/account/customer_create.go cmd/account/nebius_bindings.go cmd/account/list.go cmd/account/customer_common.go cmd/account/create_test.go cmd/account/customer_create_test.go -run 'Test(ValidateCloudAccountParams|BuildCustomerAccountRequestParamsWithDerivedValues_BYOCOnPrem|CustomerAccountInputParameters|CustomerCreateCommandDoesNotExposePlacementFlags|CloudAccountParamsFromFlags)' -count=1\n\n## Note\nFull local `go test ./cmd/account` is currently blocked by unrelated untracked local WIP in `cmd/account/vpc_sync_import.go`; that file is not part of this PR.