### PR TITLE
Add cloud-native network account commands

### DIFF
--- a/cmd/account/cloudnativenetwork/cloudnativenetwork.go
+++ b/cmd/account/cloudnativenetwork/cloudnativenetwork.go
@@ -14,6 +14,9 @@ var Cmd = &cobra.Command{
 }
 
 func init() {
+	Cmd.AddCommand(listCmd)
+	Cmd.AddCommand(syncCmd)
+	Cmd.AddCommand(importCmd)
 	Cmd.AddCommand(removeCmd)
 }
 

--- a/cmd/account/cloudnativenetwork/cloudnativenetwork_test.go
+++ b/cmd/account/cloudnativenetwork/cloudnativenetwork_test.go
@@ -17,9 +17,35 @@ func TestCloudNativeNetworkCommandStructure(t *testing.T) {
 		subCmds[sub.Name()] = true
 	}
 
+	assert.True(t, subCmds["list"], "expected list subcommand")
+	assert.True(t, subCmds["sync"], "expected sync subcommand")
+	assert.True(t, subCmds["import"], "expected import subcommand")
 	assert.True(t, subCmds["remove"], "expected remove subcommand")
 }
 
 func TestRemoveCommandRequiresNetworkIDFlag(t *testing.T) {
 	require.NotNil(t, removeCmd.Flags().Lookup("network-id"))
+}
+
+func TestImportCommandRequiresNetworkIDFlag(t *testing.T) {
+	require.NotNil(t, importCmd.Flags().Lookup("network-id"))
+}
+
+func TestSyncTargetsFromFlags(t *testing.T) {
+	targets, err := syncTargetsFromFlags(
+		[]string{"us-east-1"},
+		[]string{"us-west-2:vpc-abc123"},
+	)
+	require.NoError(t, err)
+	require.Len(t, targets, 2)
+	assert.Equal(t, "us-east-1", targets[0].Region)
+	assert.Empty(t, targets[0].NetworkID)
+	assert.Equal(t, "us-west-2", targets[1].Region)
+	assert.Equal(t, "vpc-abc123", targets[1].NetworkID)
+}
+
+func TestSyncTargetsFromFlagsRejectsMalformedNetwork(t *testing.T) {
+	_, err := syncTargetsFromFlags(nil, []string{"vpc-abc123"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected region:network-id")
 }

--- a/cmd/account/cloudnativenetwork/import.go
+++ b/cmd/account/cloudnativenetwork/import.go
@@ -1,0 +1,58 @@
+package cloudnativenetwork
+
+import (
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+const importExample = `# Import cloud-native networks for deployments
+omnistrate-ctl account customer cloud-native-network import [account-id] --network-id=vpc-abc123 --network-id=vpc-def456`
+
+var importCmd = &cobra.Command{
+	Use:          "import [account-id] --network-id=[network-id]",
+	Short:        "Import cloud-native networks for deployments",
+	Long:         `Marks discovered cloud-native networks as READY so they can be used as deployment targets.`,
+	Example:      importExample,
+	Args:         cobra.ExactArgs(1),
+	RunE:         runImport,
+	SilenceUsage: true,
+}
+
+func init() {
+	importCmd.Flags().StringSlice("network-id", nil, "Cloud-native network ID to import (repeatable)")
+	_ = importCmd.MarkFlagRequired("network-id")
+}
+
+func runImport(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	accountID := args[0]
+	networkIDs, _ := cmd.Flags().GetStringSlice("network-id")
+	output, _ := cmd.Flags().GetString("output")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	var sm utils.SpinnerManager
+	var spinner *utils.Spinner
+	if output != "json" {
+		sm = utils.NewSpinnerManager()
+		spinner = sm.AddSpinner("Importing cloud-native network...")
+		sm.Start()
+	}
+
+	result, err := dataaccess.BulkImportAccountConfigCloudNativeNetworks(cmd.Context(), token, accountID, networkIDs)
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+
+	utils.HandleSpinnerSuccess(spinner, sm, "Cloud-native network imported successfully")
+	return printCloudNativeNetworkOutput(output, result)
+}

--- a/cmd/account/cloudnativenetwork/list.go
+++ b/cmd/account/cloudnativenetwork/list.go
@@ -1,0 +1,52 @@
+package cloudnativenetwork
+
+import (
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+const listExample = `# List cloud-native networks registered under an account
+omnistrate-ctl account customer cloud-native-network list [account-id]`
+
+var listCmd = &cobra.Command{
+	Use:          "list [account-id]",
+	Short:        "List cloud-native networks for a BYOA account",
+	Long:         `Lists the cloud-native networks registered under a BYOA account configuration, including import and in-use status.`,
+	Example:      listExample,
+	Args:         cobra.ExactArgs(1),
+	RunE:         runList,
+	SilenceUsage: true,
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	accountID := args[0]
+	output, _ := cmd.Flags().GetString("output")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	var sm utils.SpinnerManager
+	var spinner *utils.Spinner
+	if output != "json" {
+		sm = utils.NewSpinnerManager()
+		spinner = sm.AddSpinner("Listing cloud-native networks...")
+		sm.Start()
+	}
+
+	result, err := dataaccess.ListAccountConfigCloudNativeNetworks(cmd.Context(), token, accountID)
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+
+	utils.HandleSpinnerSuccess(spinner, sm, "Cloud-native networks listed successfully")
+	return printCloudNativeNetworkOutput(output, result)
+}

--- a/cmd/account/cloudnativenetwork/sync.go
+++ b/cmd/account/cloudnativenetwork/sync.go
@@ -1,0 +1,98 @@
+package cloudnativenetwork
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+const syncExample = `# Sync all cloud-native networks for an account
+omnistrate-ctl account customer cloud-native-network sync [account-id]
+
+# Sync all networks in specific regions
+omnistrate-ctl account customer cloud-native-network sync [account-id] --region=us-east-1 --region=us-west-2
+
+# Sync specific networks
+omnistrate-ctl account customer cloud-native-network sync [account-id] --network=us-east-1:vpc-abc123`
+
+var syncCmd = &cobra.Command{
+	Use:          "sync [account-id]",
+	Short:        "Sync cloud-native networks from the cloud provider",
+	Long:         `Discovers or re-validates cloud-native networks for a BYOA account configuration.`,
+	Example:      syncExample,
+	Args:         cobra.ExactArgs(1),
+	RunE:         runSync,
+	SilenceUsage: true,
+}
+
+func init() {
+	syncCmd.Flags().StringSlice("region", nil, "Cloud region to discover (repeatable)")
+	syncCmd.Flags().StringSlice("network", nil, "Specific network to sync in region:network-id format (repeatable)")
+}
+
+func runSync(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	accountID := args[0]
+	output, _ := cmd.Flags().GetString("output")
+	regions, _ := cmd.Flags().GetStringSlice("region")
+	networks, _ := cmd.Flags().GetStringSlice("network")
+
+	targets, err := syncTargetsFromFlags(regions, networks)
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	var sm utils.SpinnerManager
+	var spinner *utils.Spinner
+	if output != "json" {
+		sm = utils.NewSpinnerManager()
+		spinner = sm.AddSpinner("Syncing cloud-native networks...")
+		sm.Start()
+	}
+
+	result, err := dataaccess.SyncAccountConfigCloudNativeNetworksByTarget(cmd.Context(), token, accountID, targets)
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+
+	utils.HandleSpinnerSuccess(spinner, sm, "Cloud-native networks synced successfully")
+	return printCloudNativeNetworkOutput(output, result)
+}
+
+func syncTargetsFromFlags(regions, networks []string) ([]dataaccess.CloudNativeNetworkTarget, error) {
+	targets := make([]dataaccess.CloudNativeNetworkTarget, 0, len(regions)+len(networks))
+	for _, region := range regions {
+		region = strings.TrimSpace(region)
+		if region == "" {
+			return nil, fmt.Errorf("region cannot be empty")
+		}
+		targets = append(targets, dataaccess.CloudNativeNetworkTarget{Region: region})
+	}
+
+	for _, network := range networks {
+		parts := strings.SplitN(strings.TrimSpace(network), ":", 2)
+		if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+			return nil, fmt.Errorf("invalid --network value %q: expected region:network-id", network)
+		}
+		targets = append(targets, dataaccess.CloudNativeNetworkTarget{
+			Region:    strings.TrimSpace(parts[0]),
+			NetworkID: strings.TrimSpace(parts[1]),
+		})
+	}
+
+	return targets, nil
+}


### PR DESCRIPTION
## Summary
- Add account customer cloud-native-network list, sync, and import commands
- Keep remove as the unimport command and reuse existing fleet dataaccess helpers
- Add parser and command structure tests

## Tests
- go test ./cmd/account/cloudnativenetwork ./internal/dataaccess