### PR TITLE
Add cloud native network sync helpers

### DIFF
--- a/internal/dataaccess/account_cloud_native_network.go
+++ b/internal/dataaccess/account_cloud_native_network.go
@@ -1,149 +1,142 @@
 package dataaccess
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
-	"fmt"
-	"io"
-	"net/http"
-	"net/url"
 
 	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
-
-	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
 )
 
-// CloudNativeNetworkResult is a convenience alias for the fleet response type.
-type CloudNativeNetworkResult = openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult
-
-// The cloud-native-network endpoints are exposed by consumption-service under the
-// fleet path so that ingress routes them correctly. The v1 SDK currently only
-// generates the AccountConfigApi paths (/accountconfig/...), which are not
-// served, so we call the fleet routes directly. Result JSON shape matches
-// openapiclientv1.ListAccountConfigCloudNativeNetworksResult.
-func cnnFleetURL(accountConfigID string, suffix ...string) string {
-	base := fmt.Sprintf("%s://%s/2022-09-01-00/fleet/account-config/%s/cloud-native-networks",
-		config.GetHostScheme(), config.GetHost(), url.PathEscape(accountConfigID))
-	for _, s := range suffix {
-		base += "/" + url.PathEscape(s)
-	}
-	return base
-}
-
-func doCNNRequest(ctx context.Context, token, method, requestURL string, body any) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
-	var reqBody io.Reader
-	if body != nil {
-		b, err := json.Marshal(body)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal request body: %w", err)
-		}
-		reqBody = bytes.NewReader(b)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, method, requestURL, reqBody)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
-	req.Header.Set("Authorization", "Bearer "+token)
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", config.GetUserAgent())
-
-	client := getRetryableHttpClient()
-	resp, err := client.Do(req) //nolint:gosec // CLI intentionally targets the configured Omnistrate API host
-	if err != nil {
-		return nil, fmt.Errorf("cloud-native-network request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read response body: %w", err)
-	}
-	if resp.StatusCode >= 400 {
-		return nil, fmt.Errorf("cloud-native-network API returned %d: %s", resp.StatusCode, string(respBody))
-	}
-
-	var result openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult
-	if len(respBody) > 0 {
-		if err := json.Unmarshal(respBody, &result); err != nil {
-			return nil, fmt.Errorf("failed to decode response: %w (body: %s)", err, string(respBody))
-		}
-	}
-	return &result, nil
-}
-
-// CloudNativeNetworkTarget identifies a specific cloud-native network by region and optional network ID.
 type CloudNativeNetworkTarget struct {
 	Region    string
 	NetworkID string
 }
 
-// SyncAccountConfigCloudNativeNetworks triggers cloud-native network discovery for an account configuration.
-// Optional regions narrow the discovery; when empty the platform uses all regions from the service plan.
-// The request body uses the cloudNativeNetworks[{region, cloudNativeNetworkId?}] shape so individual VPC
-// IDs can be re-validated. When only regions are passed we send a target per region with cloudNativeNetworkId
-// omitted, which sweeps every VPC in that region.
-func SyncAccountConfigCloudNativeNetworks(ctx context.Context, token, accountConfigID string, regions []string) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
-	type target struct {
-		Region               string `json:"region"`
-		CloudNativeNetworkID string `json:"cloudNativeNetworkId,omitempty"`
-	}
-	body := map[string]any{}
-	if len(regions) > 0 {
-		targets := make([]target, len(regions))
-		for i, r := range regions {
-			targets[i] = target{Region: r}
+func SyncAccountConfigCloudNativeNetworks(
+	ctx context.Context,
+	token string,
+	accountConfigID string,
+	targets []CloudNativeNetworkTarget,
+) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+
+	apiTargets := make([]openapiclientfleet.FleetSyncAccountConfigCloudNativeNetworkTarget, 0, len(targets))
+	for _, target := range targets {
+		apiTarget := openapiclientfleet.FleetSyncAccountConfigCloudNativeNetworkTarget{
+			Region: target.Region,
 		}
-		body["cloudNativeNetworks"] = targets
-	}
-	return doCNNRequest(ctx, token, http.MethodPost, cnnFleetURL(accountConfigID, "sync"), body)
-}
-
-// SyncAccountConfigCloudNativeNetworksByTarget triggers cloud-native network discovery for specific
-// region+networkId pairs. Each target must have a Region; NetworkID is optional (when omitted,
-// all networks in that region are discovered).
-func SyncAccountConfigCloudNativeNetworksByTarget(ctx context.Context, token, accountConfigID string, targets []CloudNativeNetworkTarget) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
-	type syncTarget struct {
-		Region               string `json:"region"`
-		CloudNativeNetworkID string `json:"cloudNativeNetworkId,omitempty"`
-	}
-	body := map[string]any{}
-	if len(targets) > 0 {
-		st := make([]syncTarget, len(targets))
-		for i, t := range targets {
-			st[i] = syncTarget{Region: t.Region, CloudNativeNetworkID: t.NetworkID}
+		if target.NetworkID != "" {
+			apiTarget.CloudNativeNetworkId = &target.NetworkID
 		}
-		body["cloudNativeNetworks"] = st
+		apiTargets = append(apiTargets, apiTarget)
 	}
-	return doCNNRequest(ctx, token, http.MethodPost, cnnFleetURL(accountConfigID, "sync"), body)
-}
 
-// ListAccountConfigCloudNativeNetworks lists registered cloud-native networks for an account configuration.
-func ListAccountConfigCloudNativeNetworks(ctx context.Context, token, accountConfigID string) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
-	return doCNNRequest(ctx, token, http.MethodGet, cnnFleetURL(accountConfigID), nil)
-}
-
-// ImportAccountConfigCloudNativeNetwork marks a cloud-native network as READY for deployments.
-func ImportAccountConfigCloudNativeNetwork(ctx context.Context, token, accountConfigID, networkID string) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
-	return doCNNRequest(ctx, token, http.MethodPost, cnnFleetURL(accountConfigID, networkID, "import"), nil)
-}
-
-// UnimportAccountConfigCloudNativeNetwork reverts a cloud-native network back to AVAILABLE.
-func UnimportAccountConfigCloudNativeNetwork(ctx context.Context, token, accountConfigID, networkID string) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
-	return doCNNRequest(ctx, token, http.MethodPost, cnnFleetURL(accountConfigID, networkID, "unimport"), nil)
-}
-
-// BulkImportAccountConfigCloudNativeNetworks imports multiple cloud-native networks in a single request.
-func BulkImportAccountConfigCloudNativeNetworks(ctx context.Context, token, accountConfigID string, networkIDs []string) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
-	type op struct {
-		CloudNativeNetworkID string `json:"cloudNativeNetworkId"`
-		Import               bool   `json:"import"`
+	request := openapiclientfleet.FleetSyncAccountConfigCloudNativeNetworksRequest2{
+		CloudNativeNetworks: apiTargets,
 	}
-	ops := make([]op, len(networkIDs))
-	for i, id := range networkIDs {
-		ops[i] = op{CloudNativeNetworkID: id, Import: true}
+
+	apiClient := getFleetClient()
+	res, r, err := apiClient.InventoryApiAPI.InventoryApiSyncAccountConfigCloudNativeNetworks(
+		ctxWithToken,
+		accountConfigID,
+	).FleetSyncAccountConfigCloudNativeNetworksRequest2(request).Execute()
+
+	err = handleFleetError(err)
+	if err != nil {
+		return nil, err
 	}
-	body := map[string]any{"cloudNativeNetworks": ops}
-	return doCNNRequest(ctx, token, http.MethodPost, cnnFleetURL(accountConfigID, "import"), body)
+
+	r.Body.Close()
+	return res, nil
+}
+
+func SyncAccountConfigCloudNativeNetworksByTarget(
+	ctx context.Context,
+	token string,
+	accountConfigID string,
+	targets []CloudNativeNetworkTarget,
+) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
+	return SyncAccountConfigCloudNativeNetworks(ctx, token, accountConfigID, targets)
+}
+
+func ImportAccountConfigCloudNativeNetwork(
+	ctx context.Context,
+	token string,
+	accountConfigID string,
+	cloudNativeNetworkID string,
+) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+
+	apiClient := getFleetClient()
+	res, r, err := apiClient.InventoryApiAPI.InventoryApiImportAccountConfigCloudNativeNetwork(
+		ctxWithToken,
+		accountConfigID,
+		cloudNativeNetworkID,
+	).Execute()
+
+	err = handleFleetError(err)
+	if err != nil {
+		return nil, err
+	}
+
+	r.Body.Close()
+	return res, nil
+}
+
+func BulkImportAccountConfigCloudNativeNetworks(
+	ctx context.Context,
+	token string,
+	accountConfigID string,
+	cloudNativeNetworkIDs []string,
+) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+
+	operations := make([]openapiclientfleet.FleetAccountConfigCloudNativeNetworkOperation, 0, len(cloudNativeNetworkIDs))
+	for _, id := range cloudNativeNetworkIDs {
+		operations = append(operations, openapiclientfleet.FleetAccountConfigCloudNativeNetworkOperation{
+			CloudNativeNetworkId: id,
+			Import:               true,
+		})
+	}
+
+	request := openapiclientfleet.FleetBulkImportAccountConfigCloudNativeNetworksRequest2{
+		CloudNativeNetworks: operations,
+	}
+
+	apiClient := getFleetClient()
+	res, r, err := apiClient.InventoryApiAPI.InventoryApiBulkImportAccountConfigCloudNativeNetworks(
+		ctxWithToken,
+		accountConfigID,
+	).FleetBulkImportAccountConfigCloudNativeNetworksRequest2(request).Execute()
+
+	err = handleFleetError(err)
+	if err != nil {
+		return nil, err
+	}
+
+	r.Body.Close()
+	return res, nil
+}
+
+func UnimportAccountConfigCloudNativeNetwork(
+	ctx context.Context,
+	token string,
+	accountConfigID string,
+	cloudNativeNetworkID string,
+) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+
+	apiClient := getFleetClient()
+	res, r, err := apiClient.InventoryApiAPI.InventoryApiUnimportAccountConfigCloudNativeNetwork(
+		ctxWithToken,
+		accountConfigID,
+		cloudNativeNetworkID,
+	).Execute()
+
+	err = handleFleetError(err)
+	if err != nil {
+		return nil, err
+	}
+
+	r.Body.Close()
+	return res, nil
 }

--- a/internal/dataaccess/account_cloud_native_network_test.go
+++ b/internal/dataaccess/account_cloud_native_network_test.go
@@ -1,0 +1,138 @@
+package dataaccess
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSyncAccountConfigCloudNativeNetworks_SendsTargetedAzureVNetID(t *testing.T) {
+	azureVNetID := "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/customer-rg/providers/Microsoft.Network/virtualNetworks/customer-vnet"
+	var capturedMethod string
+	var capturedPath string
+	var capturedAuth string
+	var capturedBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		capturedAuth = r.Header.Get("Authorization")
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"cloudNativeNetworks":[]}`))
+	}))
+	defer server.Close()
+	setTestHost(t, server.URL)
+
+	_, err := SyncAccountConfigCloudNativeNetworks(context.Background(), "test-token", "ac-test", []CloudNativeNetworkTarget{
+		{Region: "eastus", NetworkID: azureVNetID},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, http.MethodPost, capturedMethod)
+	assert.Equal(t, "/2022-09-01-00/fleet/account-config/ac-test/cloud-native-networks/sync", capturedPath)
+	assert.Equal(t, "Bearer test-token", capturedAuth)
+
+	targets, ok := capturedBody["cloudNativeNetworks"].([]any)
+	require.True(t, ok)
+	require.Len(t, targets, 1)
+	target, ok := targets[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "eastus", target["region"])
+	assert.Equal(t, azureVNetID, target["cloudNativeNetworkId"])
+}
+
+func TestImportAccountConfigCloudNativeNetwork_EscapesAzureVNetIDPath(t *testing.T) {
+	azureVNetID := "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/customer-rg/providers/Microsoft.Network/virtualNetworks/customer-vnet"
+	var capturedRequestURI string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequestURI = r.RequestURI
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"cloudNativeNetworks":[]}`))
+	}))
+	defer server.Close()
+	setTestHost(t, server.URL)
+
+	_, err := ImportAccountConfigCloudNativeNetwork(context.Background(), "test-token", "ac-test", azureVNetID)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"/2022-09-01-00/fleet/account-config/ac-test/cloud-native-networks/"+
+			url.PathEscape(azureVNetID)+"/import",
+		capturedRequestURI)
+}
+
+func TestBulkImportAccountConfigCloudNativeNetworks_SendsAzureVNetID(t *testing.T) {
+	azureVNetID := "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/customer-rg/providers/Microsoft.Network/virtualNetworks/customer-vnet"
+	var capturedPath string
+	var capturedBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"cloudNativeNetworks":[]}`))
+	}))
+	defer server.Close()
+	setTestHost(t, server.URL)
+
+	_, err := BulkImportAccountConfigCloudNativeNetworks(context.Background(), "test-token", "ac-test", []string{azureVNetID})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/2022-09-01-00/fleet/account-config/ac-test/cloud-native-networks/import", capturedPath)
+	operations, ok := capturedBody["cloudNativeNetworks"].([]any)
+	require.True(t, ok)
+	require.Len(t, operations, 1)
+	operation, ok := operations[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, azureVNetID, operation["cloudNativeNetworkId"])
+	assert.Equal(t, true, operation["import"])
+}
+
+func TestUnimportAccountConfigCloudNativeNetwork_EscapesAzureVNetIDPath(t *testing.T) {
+	azureVNetID := "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/customer-rg/providers/Microsoft.Network/virtualNetworks/customer-vnet"
+	var capturedRequestURI string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequestURI = r.RequestURI
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"cloudNativeNetworks":[]}`))
+	}))
+	defer server.Close()
+	setTestHost(t, server.URL)
+
+	_, err := UnimportAccountConfigCloudNativeNetwork(context.Background(), "test-token", "ac-test", azureVNetID)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"/2022-09-01-00/fleet/account-config/ac-test/cloud-native-networks/"+
+			url.PathEscape(azureVNetID)+"/unimport",
+		capturedRequestURI)
+}
+
+func setTestHost(t *testing.T, rawURL string) {
+	t.Helper()
+
+	serverURL, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	t.Setenv("OMNISTRATE_HOST", serverURL.Host)
+	t.Setenv("OMNISTRATE_HOST_SCHEME", serverURL.Scheme)
+	t.Setenv("CLIENT_TIMEOUT_IN_SECONDS", "5")
+}


### PR DESCRIPTION
# Draft PR: Azure BYOA Bring Your Own Network Support

## Summary

Adds Azure BYOA cloud-native network support using Azure VNet ARM resource IDs as the canonical network identity, matching the existing AWS/GCP CloudNativeNetwork discovery/import flow.

## Changes

- `bootstrap-service-go`
  - Adds Azure CloudNativeNetwork discovery and validation.
  - Discovers VNets by region, supports targeted sync by full VNet ARM ID, maps subnets, CIDR, and deployment capability flags.
  - Validates Azure BYON host-cluster bootstrap against customer VNets in arbitrary customer resource groups.
  - Keeps helper boundaries provider/value oriented; no helper methods pass SDK client pointers through the call chain.

- `service-orchestration`
  - Accepts Azure full VNet ARM resource IDs for `cloud_provider_native_network_id`.
  - Keeps legacy VNet-name acceptance during transition.
  - Confirms Azure system parameters already carry `virtual-network-id`; no shared schema or pseudo-version dependency is required.

- `ows-orchestration`
  - Treats CloudNativeNetwork IDs as provider-native opaque IDs in sync/import status paths.
  - Adds deterministic safe registration IDs for Azure ARM IDs instead of embedding slashes/long resource IDs into the internal row ID.
  - Keeps sync target pass-through generic for AWS/GCP/Azure.

- `api-design`
  - Updates CloudNativeNetwork API descriptions/examples from AWS-only VPC wording to provider-native network IDs, including Azure VNet ARM IDs.

- `ctl`
  - Adds SDK-backed CloudNativeNetwork sync/import dataaccess helpers.
  - Adds tests that verify Azure VNet ARM IDs are sent in targeted sync bodies and escaped correctly in import path parameters.

## Rollout

1. Deploy API/design consumers after generated clients are refreshed.
2. Deploy `ows-orchestration` before or alongside `bootstrap-service-go` so Azure ARM IDs get safe internal registration IDs.
3. Deploy `bootstrap-service-go` to enable Azure VNet discovery/validation in provisioner namespaces.
4. Deploy `service-orchestration` so instance placement accepts the same Azure ARM IDs returned by discovery.

## Rollback

- Existing AWS/GCP flows are unchanged.
- Azure legacy VNet-name bootstrap validation remains accepted during transition.
- If Azure discovery needs to be disabled, remove/disable Azure account sync/import usage while keeping existing account verification intact.

## Tests

- `bootstrap-service-go`: `go test ./pkg/hostcluster/remote/common/workflow/account ./pkg/hostcluster/remote/common/azure/infra`
- `service-orchestration`: `go test ./pkg/provisioning/workflows/generic/resource ./pkg/provisioning/workflows/generic/capacity/parameters`
- `ows-orchestration`: `go test ./v1/pkg/common/accountconfig`
- `api-design`: `go test ./v1/api/...`
- `ctl`: `go test -mod=readonly ./internal/dataaccess ./cmd/account`

Note: `ctl` currently has pre-existing inconsistent vendoring (`go.mod` uses `omnistrate-sdk-go v0.0.114`, `vendor/modules.txt` marks `v0.0.113`), so tests were run with `-mod=readonly` rather than modifying vendor state.
