### PR TITLE
Fix cloud native network region calls

### DIFF
--- a/cmd/account/account.go
+++ b/cmd/account/account.go
@@ -1,6 +1,7 @@
 package account
 
 import (
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/account/cloudnativenetwork"
 	"github.com/spf13/cobra"
 )
 
@@ -14,6 +15,7 @@ var Cmd = &cobra.Command{
 
 func init() {
 	Cmd.AddCommand(createCmd)
+	Cmd.AddCommand(cloudnativenetwork.NewCommand("account cloud-native-network"))
 	Cmd.AddCommand(customerCmd)
 	Cmd.AddCommand(updateCmd)
 	Cmd.AddCommand(listCmd)

--- a/cmd/account/cloudnativenetwork/cloudnativenetwork.go
+++ b/cmd/account/cloudnativenetwork/cloudnativenetwork.go
@@ -22,6 +22,7 @@ func NewCommand(commandPath string) *cobra.Command {
 	cmd.AddCommand(newSyncCmd(commandPath))
 	cmd.AddCommand(newImportCmd(commandPath))
 	cmd.AddCommand(newRemoveCmd(commandPath))
+	cmd.AddCommand(newHostClusterCmd(commandPath))
 	return cmd
 }
 

--- a/cmd/account/cloudnativenetwork/cloudnativenetwork.go
+++ b/cmd/account/cloudnativenetwork/cloudnativenetwork.go
@@ -4,17 +4,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Cmd is the top-level "account cloud-native-network" subcommand.
-var Cmd = &cobra.Command{
-	Use:          "cloud-native-network [operation] [flags]",
-	Short:        "Manage cloud-native networks (VPCs) for a BYOA Cloud Provider Account",
-	Long:         `This command helps you manage cloud-native networks (VPCs) associated with your BYOA cloud provider accounts.`,
-	Run:          run,
-	SilenceUsage: true,
-}
+const defaultCommandPath = "account cloud-native-network"
 
-func init() {
-	Cmd.AddCommand(removeCmd)
+// Cmd is the top-level "account cloud-native-network" subcommand.
+var Cmd = NewCommand(defaultCommandPath)
+
+// NewCommand creates a fresh cloud-native-network command tree.
+func NewCommand(commandPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "cloud-native-network [operation] [flags]",
+		Short:        "Manage cloud-native networks (VPCs) for a BYOA Cloud Provider Account",
+		Long:         `This command helps you manage cloud-native networks (VPCs) associated with your BYOA cloud provider accounts.`,
+		Run:          run,
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newListCmd(commandPath))
+	cmd.AddCommand(newSyncCmd(commandPath))
+	cmd.AddCommand(newImportCmd(commandPath))
+	cmd.AddCommand(newRemoveCmd(commandPath))
+	return cmd
 }
 
 func run(cmd *cobra.Command, args []string) {

--- a/cmd/account/cloudnativenetwork/cloudnativenetwork_test.go
+++ b/cmd/account/cloudnativenetwork/cloudnativenetwork_test.go
@@ -3,6 +3,7 @@ package cloudnativenetwork
 import (
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -17,10 +18,73 @@ func TestCloudNativeNetworkCommandStructure(t *testing.T) {
 		subCmds[sub.Name()] = true
 	}
 
+	assert.True(t, subCmds["list"], "expected list subcommand")
+	assert.True(t, subCmds["sync"], "expected sync subcommand")
+	assert.True(t, subCmds["import"], "expected import subcommand")
 	assert.True(t, subCmds["remove"], "expected remove subcommand")
 }
 
 func TestRemoveCommandRequiresRegionAndNetworkIDFlags(t *testing.T) {
+	removeCmd := findSubCommand(t, Cmd, "remove")
 	require.NotNil(t, removeCmd.Flags().Lookup("region"))
 	require.NotNil(t, removeCmd.Flags().Lookup("network-id"))
+}
+
+func TestImportCommandRequiresRegionAndNetworkIDFlags(t *testing.T) {
+	importCmd := findSubCommand(t, Cmd, "import")
+	require.NotNil(t, importCmd.Flags().Lookup("region"))
+	require.NotNil(t, importCmd.Flags().Lookup("network-id"))
+}
+
+func TestImportTargetsFromFlags(t *testing.T) {
+	targets, err := importTargetsFromFlags("us-east-1", []string{"vpc-abc123", "vpc-def456"})
+	require.NoError(t, err)
+	require.Len(t, targets, 2)
+	assert.Equal(t, "us-east-1", targets[0].Region)
+	assert.Equal(t, "vpc-abc123", targets[0].NetworkID)
+	assert.Equal(t, "us-east-1", targets[1].Region)
+	assert.Equal(t, "vpc-def456", targets[1].NetworkID)
+}
+
+func TestImportTargetsFromFlagsRejectsMissingRegion(t *testing.T) {
+	_, err := importTargetsFromFlags("", []string{"vpc-abc123"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "region cannot be empty")
+}
+
+func TestImportTargetsFromFlagsRejectsMissingNetworkID(t *testing.T) {
+	_, err := importTargetsFromFlags("us-east-1", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one network-id is required")
+}
+
+func TestSyncTargetsFromFlags(t *testing.T) {
+	targets, err := syncTargetsFromFlags(
+		[]string{"us-east-1"},
+		[]string{"us-west-2:vpc-abc123"},
+	)
+	require.NoError(t, err)
+	require.Len(t, targets, 2)
+	assert.Equal(t, "us-east-1", targets[0].Region)
+	assert.Empty(t, targets[0].NetworkID)
+	assert.Equal(t, "us-west-2", targets[1].Region)
+	assert.Equal(t, "vpc-abc123", targets[1].NetworkID)
+}
+
+func TestSyncTargetsFromFlagsRejectsMalformedNetwork(t *testing.T) {
+	_, err := syncTargetsFromFlags(nil, []string{"vpc-abc123"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "expected region:network-id")
+}
+
+func findSubCommand(t *testing.T, parent *cobra.Command, name string) *cobra.Command {
+	t.Helper()
+
+	for _, sub := range parent.Commands() {
+		if sub.Name() == name {
+			return sub
+		}
+	}
+	t.Fatalf("expected %s subcommand", name)
+	return nil
 }

--- a/cmd/account/cloudnativenetwork/cloudnativenetwork_test.go
+++ b/cmd/account/cloudnativenetwork/cloudnativenetwork_test.go
@@ -22,6 +22,7 @@ func TestCloudNativeNetworkCommandStructure(t *testing.T) {
 	assert.True(t, subCmds["sync"], "expected sync subcommand")
 	assert.True(t, subCmds["import"], "expected import subcommand")
 	assert.True(t, subCmds["remove"], "expected remove subcommand")
+	assert.True(t, subCmds["host-cluster"], "expected host-cluster subcommand")
 }
 
 func TestRemoveCommandRequiresRegionAndNetworkIDFlags(t *testing.T) {
@@ -34,6 +35,30 @@ func TestImportCommandRequiresRegionAndNetworkIDFlags(t *testing.T) {
 	importCmd := findSubCommand(t, Cmd, "import")
 	require.NotNil(t, importCmd.Flags().Lookup("region"))
 	require.NotNil(t, importCmd.Flags().Lookup("network-id"))
+}
+
+func TestHostClusterImportCommandRequiresFlags(t *testing.T) {
+	hostClusterCmd := findSubCommand(t, Cmd, "host-cluster")
+	importCmd := findSubCommand(t, hostClusterCmd, "import")
+	require.NotNil(t, importCmd.Flags().Lookup("region"))
+	require.NotNil(t, importCmd.Flags().Lookup("network-id"))
+	require.NotNil(t, importCmd.Flags().Lookup("host-cluster-name"))
+}
+
+func TestValidateHostClusterImportFlags(t *testing.T) {
+	require.NoError(t, validateHostClusterImportFlags("us-east-1", "vpc-abc123", "customer-eks"))
+
+	err := validateHostClusterImportFlags("", "vpc-abc123", "customer-eks")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "region cannot be empty")
+
+	err = validateHostClusterImportFlags("us-east-1", "", "customer-eks")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "network-id cannot be empty")
+
+	err = validateHostClusterImportFlags("us-east-1", "vpc-abc123", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "host-cluster-name cannot be empty")
 }
 
 func TestImportTargetsFromFlags(t *testing.T) {

--- a/cmd/account/cloudnativenetwork/cloudnativenetwork_test.go
+++ b/cmd/account/cloudnativenetwork/cloudnativenetwork_test.go
@@ -37,6 +37,13 @@ func TestImportCommandRequiresRegionAndNetworkIDFlags(t *testing.T) {
 	require.NotNil(t, importCmd.Flags().Lookup("network-id"))
 }
 
+func TestSyncCommandSupportsRegionAndNetworkIDFlags(t *testing.T) {
+	syncCmd := findSubCommand(t, Cmd, "sync")
+	require.NotNil(t, syncCmd.Flags().Lookup("region"))
+	require.NotNil(t, syncCmd.Flags().Lookup("network-id"))
+	require.NotNil(t, syncCmd.Flags().Lookup("network"))
+}
+
 func TestHostClusterImportCommandRequiresFlags(t *testing.T) {
 	hostClusterCmd := findSubCommand(t, Cmd, "host-cluster")
 	importCmd := findSubCommand(t, hostClusterCmd, "import")
@@ -86,6 +93,7 @@ func TestImportTargetsFromFlagsRejectsMissingNetworkID(t *testing.T) {
 func TestSyncTargetsFromFlags(t *testing.T) {
 	targets, err := syncTargetsFromFlags(
 		[]string{"us-east-1"},
+		nil,
 		[]string{"us-west-2:vpc-abc123"},
 	)
 	require.NoError(t, err)
@@ -96,8 +104,32 @@ func TestSyncTargetsFromFlags(t *testing.T) {
 	assert.Equal(t, "vpc-abc123", targets[1].NetworkID)
 }
 
+func TestSyncTargetsFromFlagsWithRegionAndNetworkID(t *testing.T) {
+	targets, err := syncTargetsFromFlags(
+		[]string{"us-east-1"},
+		[]string{"vpc-abc123", "vpc-def456"},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Len(t, targets, 2)
+	assert.Equal(t, "us-east-1", targets[0].Region)
+	assert.Equal(t, "vpc-abc123", targets[0].NetworkID)
+	assert.Equal(t, "us-east-1", targets[1].Region)
+	assert.Equal(t, "vpc-def456", targets[1].NetworkID)
+}
+
+func TestSyncTargetsFromFlagsRejectsNetworkIDWithoutSingleRegion(t *testing.T) {
+	_, err := syncTargetsFromFlags(nil, []string{"vpc-abc123"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "network-id requires exactly one region")
+
+	_, err = syncTargetsFromFlags([]string{"us-east-1", "us-west-2"}, []string{"vpc-abc123"}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "network-id requires exactly one region")
+}
+
 func TestSyncTargetsFromFlagsRejectsMalformedNetwork(t *testing.T) {
-	_, err := syncTargetsFromFlags(nil, []string{"vpc-abc123"})
+	_, err := syncTargetsFromFlags(nil, nil, []string{"vpc-abc123"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "expected region:network-id")
 }

--- a/cmd/account/cloudnativenetwork/cloudnativenetwork_test.go
+++ b/cmd/account/cloudnativenetwork/cloudnativenetwork_test.go
@@ -20,6 +20,7 @@ func TestCloudNativeNetworkCommandStructure(t *testing.T) {
 	assert.True(t, subCmds["remove"], "expected remove subcommand")
 }
 
-func TestRemoveCommandRequiresNetworkIDFlag(t *testing.T) {
+func TestRemoveCommandRequiresRegionAndNetworkIDFlags(t *testing.T) {
+	require.NotNil(t, removeCmd.Flags().Lookup("region"))
 	require.NotNil(t, removeCmd.Flags().Lookup("network-id"))
 }

--- a/cmd/account/cloudnativenetwork/deployment_cell.go
+++ b/cmd/account/cloudnativenetwork/deployment_cell.go
@@ -15,8 +15,6 @@ const (
 omnistrate-ctl %s deployment-cell import ac-x9KpL2mQ7r --region=ap-south-1 --network-id=vpc-0f8a7c6d5e4b3a291 --name=imported-cell-r7x4q2`
 )
 
-var deploymentCellCmd = newDeploymentCellCmd(defaultCommandPath)
-
 func newDeploymentCellCmd(commandPath string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "deployment-cell [operation] [flags]",

--- a/cmd/account/cloudnativenetwork/hostcluster.go
+++ b/cmd/account/cloudnativenetwork/hostcluster.go
@@ -1,0 +1,123 @@
+package cloudnativenetwork
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+func newHostClusterCmd(commandPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "host-cluster [operation] [flags]",
+		Short:        "Manage imported host clusters for cloud-native networks",
+		Long:         `This command helps you manage provider host clusters imported from cloud-native networks.`,
+		Run:          run,
+		SilenceUsage: true,
+	}
+	cmd.AddCommand(newHostClusterImportCmd(commandPath + " host-cluster"))
+	return cmd
+}
+
+func newHostClusterImportCmd(commandPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "import [account-id] --region=[region] --network-id=[network-id] --host-cluster-name=[name]",
+		Short: "Import a host cluster from a cloud-native network",
+		Long:  `Imports a provider host cluster from an imported cloud-native network into Omnistrate.`,
+		Example: fmt.Sprintf(`# Import a host cluster from a cloud-native network
+omnistrate-ctl %s import [account-id] --region=[region] --network-id=[network-id] --host-cluster-name=[name]`, commandPath),
+		Args:         cobra.ExactArgs(1),
+		RunE:         runHostClusterImport,
+		SilenceUsage: true,
+	}
+	cmd.Flags().String("region", "", "The cloud provider region of the cloud-native network (required)")
+	cmd.Flags().String("network-id", "", "The cloud-native network ID that contains the host cluster (required)")
+	cmd.Flags().String("host-cluster-name", "", "The provider host cluster name to import (required)")
+	_ = cmd.MarkFlagRequired("region")
+	_ = cmd.MarkFlagRequired("network-id")
+	_ = cmd.MarkFlagRequired("host-cluster-name")
+	return cmd
+}
+
+func runHostClusterImport(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	accountID := args[0]
+	region, _ := cmd.Flags().GetString("region")
+	networkID, _ := cmd.Flags().GetString("network-id")
+	hostClusterName, _ := cmd.Flags().GetString("host-cluster-name")
+	output, _ := cmd.Flags().GetString("output")
+
+	if err := validateHostClusterImportFlags(region, networkID, hostClusterName); err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	var sm utils.SpinnerManager
+	var spinner *utils.Spinner
+	if output != "json" {
+		sm = utils.NewSpinnerManager()
+		spinner = sm.AddSpinner("Importing host cluster...")
+		sm.Start()
+	}
+
+	result, err := dataaccess.ImportAccountConfigCloudNativeNetworkHostCluster(
+		cmd.Context(), token, accountID, strings.TrimSpace(region), strings.TrimSpace(networkID), strings.TrimSpace(hostClusterName),
+	)
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+
+	utils.HandleSpinnerSuccess(spinner, sm, "Host cluster imported successfully")
+	return printHostClusterImportOutput(output, result)
+}
+
+func validateHostClusterImportFlags(region, networkID, hostClusterName string) error {
+	if strings.TrimSpace(region) == "" {
+		return fmt.Errorf("region cannot be empty")
+	}
+	if strings.TrimSpace(networkID) == "" {
+		return fmt.Errorf("network-id cannot be empty")
+	}
+	if strings.TrimSpace(hostClusterName) == "" {
+		return fmt.Errorf("host-cluster-name cannot be empty")
+	}
+	return nil
+}
+
+func printHostClusterImportOutput(output string, result *dataaccess.CloudNativeNetworkHostClusterImportResult) error {
+	switch output {
+	case "json":
+		return utils.PrintTextTableJsonOutput(output, result)
+	case "table", "":
+		return printHostClusterImportTable(result)
+	default:
+		return utils.PrintTextTableJsonOutput(output, result)
+	}
+}
+
+func printHostClusterImportTable(result *dataaccess.CloudNativeNetworkHostClusterImportResult) error {
+	if result == nil {
+		fmt.Println("No host cluster import result found.")
+		return nil
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "HOST CLUSTER ID\tCREATED")
+	fmt.Fprintln(w, "---------------\t-------")
+	fmt.Fprintf(w, "%s\t%t\n", result.HostClusterID, result.Created)
+	return w.Flush()
+}

--- a/cmd/account/cloudnativenetwork/import.go
+++ b/cmd/account/cloudnativenetwork/import.go
@@ -1,0 +1,102 @@
+package cloudnativenetwork
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+func newImportCmd(commandPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "import [account-id] --region=[region] --network-id=[network-id]",
+		Short: "Import cloud-native networks for deployments",
+		Long:  `Marks discovered cloud-native networks as READY so they can be used as deployment targets.`,
+		Example: fmt.Sprintf(`# Import a cloud-native network for deployments
+omnistrate-ctl %s import [account-id] --region=[region] --network-id=[network-id]
+
+# Import multiple cloud-native networks in the same region
+omnistrate-ctl %s import [account-id] --region=[region] --network-id=[network-id-1] --network-id=[network-id-2]`, commandPath, commandPath),
+		Args:         cobra.ExactArgs(1),
+		RunE:         runImport,
+		SilenceUsage: true,
+	}
+	cmd.Flags().String("region", "", "The cloud provider region of the cloud-native network to import (required)")
+	cmd.Flags().StringSlice("network-id", nil, "Cloud-native network ID to import (repeatable, required)")
+	_ = cmd.MarkFlagRequired("region")
+	_ = cmd.MarkFlagRequired("network-id")
+	return cmd
+}
+
+func runImport(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	accountID := args[0]
+	region, _ := cmd.Flags().GetString("region")
+	networkIDs, _ := cmd.Flags().GetStringSlice("network-id")
+	output, _ := cmd.Flags().GetString("output")
+
+	targets, err := importTargetsFromFlags(region, networkIDs)
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	var sm utils.SpinnerManager
+	var spinner *utils.Spinner
+	if output != "json" {
+		sm = utils.NewSpinnerManager()
+		spinner = sm.AddSpinner("Importing cloud-native network...")
+		sm.Start()
+	}
+
+	var result *dataaccess.CloudNativeNetworkResult
+	if len(targets) == 1 {
+		result, err = dataaccess.ImportAccountConfigCloudNativeNetwork(
+			cmd.Context(), token, accountID, targets[0].Region, targets[0].NetworkID,
+		)
+	} else {
+		result, err = dataaccess.BulkImportAccountConfigCloudNativeNetworks(cmd.Context(), token, accountID, targets)
+	}
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+
+	utils.HandleSpinnerSuccess(spinner, sm, "Cloud-native network imported successfully")
+	return printCloudNativeNetworkOutput(output, result)
+}
+
+func importTargetsFromFlags(region string, networkIDs []string) ([]dataaccess.CloudNativeNetworkTarget, error) {
+	region = strings.TrimSpace(region)
+	if region == "" {
+		return nil, fmt.Errorf("region cannot be empty")
+	}
+
+	targets := make([]dataaccess.CloudNativeNetworkTarget, 0, len(networkIDs))
+	for _, networkID := range networkIDs {
+		networkID = strings.TrimSpace(networkID)
+		if networkID == "" {
+			return nil, fmt.Errorf("network-id cannot be empty")
+		}
+		targets = append(targets, dataaccess.CloudNativeNetworkTarget{
+			Region:    region,
+			NetworkID: networkID,
+		})
+	}
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("at least one network-id is required")
+	}
+
+	return targets, nil
+}

--- a/cmd/account/cloudnativenetwork/import.go
+++ b/cmd/account/cloudnativenetwork/import.go
@@ -60,14 +60,7 @@ func runImport(cmd *cobra.Command, args []string) error {
 		sm.Start()
 	}
 
-	var result *dataaccess.CloudNativeNetworkResult
-	if len(targets) == 1 {
-		result, err = dataaccess.ImportAccountConfigCloudNativeNetwork(
-			cmd.Context(), token, accountID, targets[0].Region, targets[0].NetworkID,
-		)
-	} else {
-		result, err = dataaccess.BulkImportAccountConfigCloudNativeNetworks(cmd.Context(), token, accountID, targets)
-	}
+	result, err := dataaccess.BulkImportAccountConfigCloudNativeNetworks(cmd.Context(), token, accountID, targets)
 	if err != nil {
 		utils.HandleSpinnerError(spinner, sm, err)
 		return err

--- a/cmd/account/cloudnativenetwork/list.go
+++ b/cmd/account/cloudnativenetwork/list.go
@@ -1,0 +1,53 @@
+package cloudnativenetwork
+
+import (
+	"fmt"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+func newListCmd(commandPath string) *cobra.Command {
+	return &cobra.Command{
+		Use:          "list [account-id]",
+		Short:        "List cloud-native networks for a BYOA account",
+		Long:         `Lists the cloud-native networks registered under a BYOA account configuration, including import and in-use status.`,
+		Example:      fmt.Sprintf("# List cloud-native networks registered under an account\nomnistrate-ctl %s list [account-id]", commandPath),
+		Args:         cobra.ExactArgs(1),
+		RunE:         runList,
+		SilenceUsage: true,
+	}
+}
+
+func runList(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	accountID := args[0]
+	output, _ := cmd.Flags().GetString("output")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	var sm utils.SpinnerManager
+	var spinner *utils.Spinner
+	if output != "json" {
+		sm = utils.NewSpinnerManager()
+		spinner = sm.AddSpinner("Listing cloud-native networks...")
+		sm.Start()
+	}
+
+	result, err := dataaccess.ListAccountConfigCloudNativeNetworks(cmd.Context(), token, accountID)
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+
+	utils.HandleSpinnerSuccess(spinner, sm, "Cloud-native networks listed successfully")
+	return printCloudNativeNetworkOutput(output, result)
+}

--- a/cmd/account/cloudnativenetwork/remove.go
+++ b/cmd/account/cloudnativenetwork/remove.go
@@ -10,11 +10,11 @@ import (
 
 const (
 	removeExample = `# Remove a cloud-native network (revert to AVAILABLE)
-omnistrate-ctl account customer cloud-native-network remove [account-id] --network-id=[network-id]`
+omnistrate-ctl account customer cloud-native-network remove [account-id] --region=[region] --network-id=[network-id]`
 )
 
 var removeCmd = &cobra.Command{
-	Use:          "remove [account-id] --network-id=[network-id]",
+	Use:          "remove [account-id] --region=[region] --network-id=[network-id]",
 	Short:        "Remove an imported cloud-native network (revert to AVAILABLE)",
 	Long:         `Reverts a previously imported cloud-native network from READY back to AVAILABLE status, removing it from the deployment target pool.`,
 	Example:      removeExample,
@@ -24,7 +24,9 @@ var removeCmd = &cobra.Command{
 }
 
 func init() {
+	removeCmd.Flags().String("region", "", "The cloud provider region of the cloud-native network to remove (required)")
 	removeCmd.Flags().String("network-id", "", "The cloud-native network ID to remove (required)")
+	_ = removeCmd.MarkFlagRequired("region")
 	_ = removeCmd.MarkFlagRequired("network-id")
 }
 
@@ -32,6 +34,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	defer config.CleanupArgsAndFlags(cmd, &args)
 
 	accountID := args[0]
+	region, _ := cmd.Flags().GetString("region")
 	networkID, _ := cmd.Flags().GetString("network-id")
 	output, _ := cmd.Flags().GetString("output")
 
@@ -49,7 +52,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 		sm.Start()
 	}
 
-	result, err := dataaccess.UnimportAccountConfigCloudNativeNetwork(cmd.Context(), token, accountID, networkID)
+	result, err := dataaccess.UnimportAccountConfigCloudNativeNetwork(cmd.Context(), token, accountID, region, networkID)
 	if err != nil {
 		utils.HandleSpinnerError(spinner, sm, err)
 		return err

--- a/cmd/account/cloudnativenetwork/remove.go
+++ b/cmd/account/cloudnativenetwork/remove.go
@@ -1,6 +1,8 @@
 package cloudnativenetwork
 
 import (
+	"fmt"
+
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
@@ -8,26 +10,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	removeExample = `# Remove a cloud-native network (revert to AVAILABLE)
-omnistrate-ctl account customer cloud-native-network remove [account-id] --region=[region] --network-id=[network-id]`
-)
-
-var removeCmd = &cobra.Command{
-	Use:          "remove [account-id] --region=[region] --network-id=[network-id]",
-	Short:        "Remove an imported cloud-native network (revert to AVAILABLE)",
-	Long:         `Reverts a previously imported cloud-native network from READY back to AVAILABLE status, removing it from the deployment target pool.`,
-	Example:      removeExample,
-	Args:         cobra.ExactArgs(1),
-	RunE:         runRemove,
-	SilenceUsage: true,
-}
-
-func init() {
-	removeCmd.Flags().String("region", "", "The cloud provider region of the cloud-native network to remove (required)")
-	removeCmd.Flags().String("network-id", "", "The cloud-native network ID to remove (required)")
-	_ = removeCmd.MarkFlagRequired("region")
-	_ = removeCmd.MarkFlagRequired("network-id")
+func newRemoveCmd(commandPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "remove [account-id] --region=[region] --network-id=[network-id]",
+		Short:        "Remove an imported cloud-native network (revert to AVAILABLE)",
+		Long:         `Reverts a previously imported cloud-native network from READY back to AVAILABLE status, removing it from the deployment target pool.`,
+		Example:      fmt.Sprintf("# Remove a cloud-native network (revert to AVAILABLE)\nomnistrate-ctl %s remove [account-id] --region=[region] --network-id=[network-id]", commandPath),
+		Args:         cobra.ExactArgs(1),
+		RunE:         runRemove,
+		SilenceUsage: true,
+	}
+	cmd.Flags().String("region", "", "The cloud provider region of the cloud-native network to remove (required)")
+	cmd.Flags().String("network-id", "", "The cloud-native network ID to remove (required)")
+	_ = cmd.MarkFlagRequired("region")
+	_ = cmd.MarkFlagRequired("network-id")
+	return cmd
 }
 
 func runRemove(cmd *cobra.Command, args []string) error {

--- a/cmd/account/cloudnativenetwork/remove.go
+++ b/cmd/account/cloudnativenetwork/remove.go
@@ -34,6 +34,10 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	region, _ := cmd.Flags().GetString("region")
 	networkID, _ := cmd.Flags().GetString("network-id")
 	output, _ := cmd.Flags().GetString("output")
+	targets := []dataaccess.CloudNativeNetworkTarget{{
+		Region:    region,
+		NetworkID: networkID,
+	}}
 
 	token, err := common.GetTokenWithLogin()
 	if err != nil {
@@ -49,7 +53,7 @@ func runRemove(cmd *cobra.Command, args []string) error {
 		sm.Start()
 	}
 
-	result, err := dataaccess.UnimportAccountConfigCloudNativeNetwork(cmd.Context(), token, accountID, region, networkID)
+	result, err := dataaccess.BulkUnimportAccountConfigCloudNativeNetworks(cmd.Context(), token, accountID, targets)
 	if err != nil {
 		utils.HandleSpinnerError(spinner, sm, err)
 		return err

--- a/cmd/account/cloudnativenetwork/remove.go
+++ b/cmd/account/cloudnativenetwork/remove.go
@@ -34,6 +34,14 @@ func runRemove(cmd *cobra.Command, args []string) error {
 	region, _ := cmd.Flags().GetString("region")
 	networkID, _ := cmd.Flags().GetString("network-id")
 	output, _ := cmd.Flags().GetString("output")
+
+	if region == "" {
+		return fmt.Errorf("region cannot be empty")
+	}
+	if networkID == "" {
+		return fmt.Errorf("network-id cannot be empty")
+	}
+
 	targets := []dataaccess.CloudNativeNetworkTarget{{
 		Region:    region,
 		NetworkID: networkID,

--- a/cmd/account/cloudnativenetwork/sync.go
+++ b/cmd/account/cloudnativenetwork/sync.go
@@ -23,12 +23,13 @@ omnistrate-ctl %s sync [account-id]
 omnistrate-ctl %s sync [account-id] --region=us-east-1 --region=us-west-2
 
 # Sync specific networks
-omnistrate-ctl %s sync [account-id] --network=us-east-1:vpc-abc123`, commandPath, commandPath, commandPath),
+omnistrate-ctl %s sync [account-id] --region=us-east-1 --network-id=vpc-abc123`, commandPath, commandPath, commandPath),
 		Args:         cobra.ExactArgs(1),
 		RunE:         runSync,
 		SilenceUsage: true,
 	}
 	cmd.Flags().StringSlice("region", nil, "Cloud region to discover (repeatable)")
+	cmd.Flags().StringSlice("network-id", nil, "Cloud-native network ID to sync in the specified region (repeatable)")
 	cmd.Flags().StringSlice("network", nil, "Specific network to sync in region:network-id format (repeatable)")
 	return cmd
 }
@@ -39,9 +40,10 @@ func runSync(cmd *cobra.Command, args []string) error {
 	accountID := args[0]
 	output, _ := cmd.Flags().GetString("output")
 	regions, _ := cmd.Flags().GetStringSlice("region")
+	networkIDs, _ := cmd.Flags().GetStringSlice("network-id")
 	networks, _ := cmd.Flags().GetStringSlice("network")
 
-	targets, err := syncTargetsFromFlags(regions, networks)
+	targets, err := syncTargetsFromFlags(regions, networkIDs, networks)
 	if err != nil {
 		utils.PrintError(err)
 		return err
@@ -71,14 +73,36 @@ func runSync(cmd *cobra.Command, args []string) error {
 	return printCloudNativeNetworkOutput(output, result)
 }
 
-func syncTargetsFromFlags(regions, networks []string) ([]dataaccess.CloudNativeNetworkTarget, error) {
-	targets := make([]dataaccess.CloudNativeNetworkTarget, 0, len(regions)+len(networks))
+func syncTargetsFromFlags(regions, networkIDs, networks []string) ([]dataaccess.CloudNativeNetworkTarget, error) {
+	targets := make([]dataaccess.CloudNativeNetworkTarget, 0, len(regions)+len(networkIDs)+len(networks))
+
+	cleanRegions := make([]string, 0, len(regions))
 	for _, region := range regions {
 		region = strings.TrimSpace(region)
 		if region == "" {
 			return nil, fmt.Errorf("region cannot be empty")
 		}
-		targets = append(targets, dataaccess.CloudNativeNetworkTarget{Region: region})
+		cleanRegions = append(cleanRegions, region)
+	}
+
+	if len(networkIDs) > 0 {
+		if len(cleanRegions) != 1 {
+			return nil, fmt.Errorf("network-id requires exactly one region")
+		}
+		for _, networkID := range networkIDs {
+			networkID = strings.TrimSpace(networkID)
+			if networkID == "" {
+				return nil, fmt.Errorf("network-id cannot be empty")
+			}
+			targets = append(targets, dataaccess.CloudNativeNetworkTarget{
+				Region:    cleanRegions[0],
+				NetworkID: networkID,
+			})
+		}
+	} else {
+		for _, region := range cleanRegions {
+			targets = append(targets, dataaccess.CloudNativeNetworkTarget{Region: region})
+		}
 	}
 
 	for _, network := range networks {

--- a/cmd/account/cloudnativenetwork/sync.go
+++ b/cmd/account/cloudnativenetwork/sync.go
@@ -1,0 +1,96 @@
+package cloudnativenetwork
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+func newSyncCmd(commandPath string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sync [account-id]",
+		Short: "Sync cloud-native networks from the cloud provider",
+		Long:  `Discovers or re-validates cloud-native networks for a BYOA account configuration.`,
+		Example: fmt.Sprintf(`# Sync all cloud-native networks for an account
+omnistrate-ctl %s sync [account-id]
+
+# Sync all networks in specific regions
+omnistrate-ctl %s sync [account-id] --region=us-east-1 --region=us-west-2
+
+# Sync specific networks
+omnistrate-ctl %s sync [account-id] --network=us-east-1:vpc-abc123`, commandPath, commandPath, commandPath),
+		Args:         cobra.ExactArgs(1),
+		RunE:         runSync,
+		SilenceUsage: true,
+	}
+	cmd.Flags().StringSlice("region", nil, "Cloud region to discover (repeatable)")
+	cmd.Flags().StringSlice("network", nil, "Specific network to sync in region:network-id format (repeatable)")
+	return cmd
+}
+
+func runSync(cmd *cobra.Command, args []string) error {
+	defer config.CleanupArgsAndFlags(cmd, &args)
+
+	accountID := args[0]
+	output, _ := cmd.Flags().GetString("output")
+	regions, _ := cmd.Flags().GetStringSlice("region")
+	networks, _ := cmd.Flags().GetStringSlice("network")
+
+	targets, err := syncTargetsFromFlags(regions, networks)
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	var sm utils.SpinnerManager
+	var spinner *utils.Spinner
+	if output != "json" {
+		sm = utils.NewSpinnerManager()
+		spinner = sm.AddSpinner("Syncing cloud-native networks...")
+		sm.Start()
+	}
+
+	result, err := dataaccess.SyncAccountConfigCloudNativeNetworksByTarget(cmd.Context(), token, accountID, targets)
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+
+	utils.HandleSpinnerSuccess(spinner, sm, "Cloud-native networks synced successfully")
+	return printCloudNativeNetworkOutput(output, result)
+}
+
+func syncTargetsFromFlags(regions, networks []string) ([]dataaccess.CloudNativeNetworkTarget, error) {
+	targets := make([]dataaccess.CloudNativeNetworkTarget, 0, len(regions)+len(networks))
+	for _, region := range regions {
+		region = strings.TrimSpace(region)
+		if region == "" {
+			return nil, fmt.Errorf("region cannot be empty")
+		}
+		targets = append(targets, dataaccess.CloudNativeNetworkTarget{Region: region})
+	}
+
+	for _, network := range networks {
+		parts := strings.SplitN(strings.TrimSpace(network), ":", 2)
+		if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+			return nil, fmt.Errorf("invalid --network value %q: expected region:network-id", network)
+		}
+		targets = append(targets, dataaccess.CloudNativeNetworkTarget{
+			Region:    strings.TrimSpace(parts[0]),
+			NetworkID: strings.TrimSpace(parts[1]),
+		})
+	}
+
+	return targets, nil
+}

--- a/cmd/account/create.go
+++ b/cmd/account/create.go
@@ -357,7 +357,7 @@ func syncAndImportCloudNativeNetworks(ctx context.Context, token, accountID stri
 		sm.Start()
 	}
 
-	_, err = dataaccess.BulkImportAccountConfigCloudNativeNetworks(ctx, token, accountID, networkIDs)
+	_, err = dataaccess.BulkImportAccountConfigCloudNativeNetworks(ctx, token, accountID, targets)
 	if err != nil {
 		utils.HandleSpinnerError(spinner, sm, err)
 		return fmt.Errorf("failed to import cloud-native networks: %w", err)

--- a/cmd/account/customer.go
+++ b/cmd/account/customer.go
@@ -20,7 +20,7 @@ func init() {
 	customerCmd.AddCommand(customerListCmd)
 	customerCmd.AddCommand(customerDescribeCmd)
 	customerCmd.AddCommand(customerInstallKitCmd)
-	customerCmd.AddCommand(cloudnativenetwork.Cmd)
+	customerCmd.AddCommand(cloudnativenetwork.NewCommand("account customer cloud-native-network"))
 }
 
 func runCustomer(cmd *cobra.Command, args []string) {

--- a/internal/dataaccess/account_cloud_native_network.go
+++ b/internal/dataaccess/account_cloud_native_network.go
@@ -17,6 +17,12 @@ import (
 // CloudNativeNetworkResult is a convenience alias for the fleet response type.
 type CloudNativeNetworkResult = openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult
 
+// CloudNativeNetworkHostClusterImportResult describes the host cluster created or reused.
+type CloudNativeNetworkHostClusterImportResult struct {
+	HostClusterID string `json:"hostClusterId"`
+	Created       bool   `json:"created"`
+}
+
 // The cloud-native-network endpoints are exposed by consumption-service under the
 // fleet path so that ingress routes them correctly. The v1 SDK currently only
 // generates the AccountConfigApi paths (/accountconfig/...), which are not
@@ -65,6 +71,48 @@ func doCNNRequest(ctx context.Context, token, method, requestURL string, body an
 	}
 
 	var result openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult
+	if len(respBody) > 0 {
+		if err := json.Unmarshal(respBody, &result); err != nil {
+			return nil, fmt.Errorf("failed to decode response: %w (body: %s)", err, string(respBody))
+		}
+	}
+	return &result, nil
+}
+
+func doCNNHostClusterImportRequest(ctx context.Context, token, method, requestURL string, body any) (*CloudNativeNetworkHostClusterImportResult, error) {
+	var reqBody io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal request body: %w", err)
+		}
+		reqBody = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", config.GetUserAgent())
+
+	client := getRetryableHttpClient()
+	resp, err := client.Do(req) //nolint:gosec // CLI intentionally targets the configured Omnistrate API host
+	if err != nil {
+		return nil, fmt.Errorf("cloud-native-network request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("cloud-native-network API returned %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	var result CloudNativeNetworkHostClusterImportResult
 	if len(respBody) > 0 {
 		if err := json.Unmarshal(respBody, &result); err != nil {
 			return nil, fmt.Errorf("failed to decode response: %w (body: %s)", err, string(respBody))
@@ -134,8 +182,7 @@ func UnimportAccountConfigCloudNativeNetwork(ctx context.Context, token, account
 	return doCNNRequest(ctx, token, http.MethodPost, cnnFleetURL(accountConfigID, region, networkID, "unimport"), nil)
 }
 
-// BulkImportAccountConfigCloudNativeNetworks imports multiple cloud-native networks in a single request.
-func BulkImportAccountConfigCloudNativeNetworks(ctx context.Context, token, accountConfigID string, targets []CloudNativeNetworkTarget) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
+func bulkSetAccountConfigCloudNativeNetworksImported(ctx context.Context, token, accountConfigID string, targets []CloudNativeNetworkTarget, imported bool) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
 	type op struct {
 		CloudNativeNetworkID string `json:"cloudNativeNetworkId"`
 		Region               string `json:"region"`
@@ -146,9 +193,30 @@ func BulkImportAccountConfigCloudNativeNetworks(ctx context.Context, token, acco
 		ops[i] = op{
 			CloudNativeNetworkID: target.NetworkID,
 			Region:               target.Region,
-			Import:               true,
+			Import:               imported,
 		}
 	}
 	body := map[string]any{"cloudNativeNetworks": ops}
 	return doCNNRequest(ctx, token, http.MethodPost, cnnFleetURL(accountConfigID, "import"), body)
+}
+
+// BulkImportAccountConfigCloudNativeNetworks imports multiple cloud-native networks in a single request.
+func BulkImportAccountConfigCloudNativeNetworks(ctx context.Context, token, accountConfigID string, targets []CloudNativeNetworkTarget) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
+	return bulkSetAccountConfigCloudNativeNetworksImported(ctx, token, accountConfigID, targets, true)
+}
+
+// BulkUnimportAccountConfigCloudNativeNetworks removes multiple imported cloud-native networks in a single request.
+func BulkUnimportAccountConfigCloudNativeNetworks(ctx context.Context, token, accountConfigID string, targets []CloudNativeNetworkTarget) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
+	return bulkSetAccountConfigCloudNativeNetworksImported(ctx, token, accountConfigID, targets, false)
+}
+
+// ImportAccountConfigCloudNativeNetworkHostCluster imports a provider host cluster from an imported cloud-native network.
+func ImportAccountConfigCloudNativeNetworkHostCluster(ctx context.Context, token, accountConfigID, region, networkID, hostClusterName string) (*CloudNativeNetworkHostClusterImportResult, error) {
+	return doCNNHostClusterImportRequest(
+		ctx,
+		token,
+		http.MethodPost,
+		cnnFleetURL(accountConfigID, region, networkID, "host-clusters", hostClusterName, "import"),
+		nil,
+	)
 }

--- a/internal/dataaccess/account_cloud_native_network.go
+++ b/internal/dataaccess/account_cloud_native_network.go
@@ -125,24 +125,29 @@ func ListAccountConfigCloudNativeNetworks(ctx context.Context, token, accountCon
 }
 
 // ImportAccountConfigCloudNativeNetwork marks a cloud-native network as READY for deployments.
-func ImportAccountConfigCloudNativeNetwork(ctx context.Context, token, accountConfigID, networkID string) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
-	return doCNNRequest(ctx, token, http.MethodPost, cnnFleetURL(accountConfigID, networkID, "import"), nil)
+func ImportAccountConfigCloudNativeNetwork(ctx context.Context, token, accountConfigID, region, networkID string) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
+	return doCNNRequest(ctx, token, http.MethodPost, cnnFleetURL(accountConfigID, region, networkID, "import"), nil)
 }
 
 // UnimportAccountConfigCloudNativeNetwork reverts a cloud-native network back to AVAILABLE.
-func UnimportAccountConfigCloudNativeNetwork(ctx context.Context, token, accountConfigID, networkID string) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
-	return doCNNRequest(ctx, token, http.MethodPost, cnnFleetURL(accountConfigID, networkID, "unimport"), nil)
+func UnimportAccountConfigCloudNativeNetwork(ctx context.Context, token, accountConfigID, region, networkID string) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
+	return doCNNRequest(ctx, token, http.MethodPost, cnnFleetURL(accountConfigID, region, networkID, "unimport"), nil)
 }
 
 // BulkImportAccountConfigCloudNativeNetworks imports multiple cloud-native networks in a single request.
-func BulkImportAccountConfigCloudNativeNetworks(ctx context.Context, token, accountConfigID string, networkIDs []string) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
+func BulkImportAccountConfigCloudNativeNetworks(ctx context.Context, token, accountConfigID string, targets []CloudNativeNetworkTarget) (*openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult, error) {
 	type op struct {
 		CloudNativeNetworkID string `json:"cloudNativeNetworkId"`
+		Region               string `json:"region"`
 		Import               bool   `json:"import"`
 	}
-	ops := make([]op, len(networkIDs))
-	for i, id := range networkIDs {
-		ops[i] = op{CloudNativeNetworkID: id, Import: true}
+	ops := make([]op, len(targets))
+	for i, target := range targets {
+		ops[i] = op{
+			CloudNativeNetworkID: target.NetworkID,
+			Region:               target.Region,
+			Import:               true,
+		}
 	}
 	body := map[string]any{"cloudNativeNetworks": ops}
 	return doCNNRequest(ctx, token, http.MethodPost, cnnFleetURL(accountConfigID, "import"), body)

--- a/internal/dataaccess/account_cloud_native_network_test.go
+++ b/internal/dataaccess/account_cloud_native_network_test.go
@@ -36,6 +36,37 @@ func TestImportAccountConfigCloudNativeNetworkSendsRegionPath(t *testing.T) {
 		capturedRequestURI)
 }
 
+func TestSyncAccountConfigCloudNativeNetworksByTargetSendsRegionAndNetworkID(t *testing.T) {
+	azureVNetID := "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/customer-rg/providers/Microsoft.Network/virtualNetworks/customer-vnet"
+	var capturedPath string
+	var capturedBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"cloudNativeNetworks":[]}`))
+	}))
+	defer server.Close()
+	setAccountCloudNativeNetworkTestHost(t, server.URL)
+
+	_, err := SyncAccountConfigCloudNativeNetworksByTarget(context.Background(), "test-token", "ac-test", []CloudNativeNetworkTarget{
+		{Region: "eastus", NetworkID: azureVNetID},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/2022-09-01-00/fleet/account-config/ac-test/cloud-native-networks/sync", capturedPath)
+	targets, ok := capturedBody["cloudNativeNetworks"].([]any)
+	require.True(t, ok)
+	require.Len(t, targets, 1)
+	target, ok := targets[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, azureVNetID, target["cloudNativeNetworkId"])
+	assert.Equal(t, "eastus", target["region"])
+}
+
 func TestBulkImportAccountConfigCloudNativeNetworksSendsRegion(t *testing.T) {
 	azureVNetID := "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/customer-rg/providers/Microsoft.Network/virtualNetworks/customer-vnet"
 	var capturedPath string
@@ -68,6 +99,38 @@ func TestBulkImportAccountConfigCloudNativeNetworksSendsRegion(t *testing.T) {
 	assert.Equal(t, true, operation["import"])
 }
 
+func TestBulkUnimportAccountConfigCloudNativeNetworksSendsRegion(t *testing.T) {
+	azureVNetID := "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/customer-rg/providers/Microsoft.Network/virtualNetworks/customer-vnet"
+	var capturedPath string
+	var capturedBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"cloudNativeNetworks":[]}`))
+	}))
+	defer server.Close()
+	setAccountCloudNativeNetworkTestHost(t, server.URL)
+
+	_, err := BulkUnimportAccountConfigCloudNativeNetworks(context.Background(), "test-token", "ac-test", []CloudNativeNetworkTarget{
+		{Region: "eastus", NetworkID: azureVNetID},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/2022-09-01-00/fleet/account-config/ac-test/cloud-native-networks/import", capturedPath)
+	operations, ok := capturedBody["cloudNativeNetworks"].([]any)
+	require.True(t, ok)
+	require.Len(t, operations, 1)
+	operation, ok := operations[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, azureVNetID, operation["cloudNativeNetworkId"])
+	assert.Equal(t, "eastus", operation["region"])
+	assert.Equal(t, false, operation["import"])
+}
+
 func TestUnimportAccountConfigCloudNativeNetworkSendsRegionPath(t *testing.T) {
 	azureVNetID := "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/customer-rg/providers/Microsoft.Network/virtualNetworks/customer-vnet"
 	var capturedRequestURI string
@@ -90,6 +153,39 @@ func TestUnimportAccountConfigCloudNativeNetworkSendsRegionPath(t *testing.T) {
 		"/2022-09-01-00/fleet/account-config/ac-test/cloud-native-networks/eastus/"+
 			url.PathEscape(azureVNetID)+"/unimport",
 		capturedRequestURI)
+}
+
+func TestImportAccountConfigCloudNativeNetworkHostClusterSendsRegionPath(t *testing.T) {
+	azureVNetID := "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/customer-rg/providers/Microsoft.Network/virtualNetworks/customer-vnet"
+	var capturedRequestURI string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequestURI = r.RequestURI
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"hostClusterId":"hc-test","created":true}`))
+	}))
+	defer server.Close()
+	setAccountCloudNativeNetworkTestHost(t, server.URL)
+
+	res, err := ImportAccountConfigCloudNativeNetworkHostCluster(
+		context.Background(),
+		"test-token",
+		"ac-test",
+		"eastus",
+		azureVNetID,
+		"customer-aks",
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"/2022-09-01-00/fleet/account-config/ac-test/cloud-native-networks/eastus/"+
+			url.PathEscape(azureVNetID)+"/host-clusters/customer-aks/import",
+		capturedRequestURI)
+	assert.Equal(t, "hc-test", res.HostClusterID)
+	assert.True(t, res.Created)
 }
 
 func setAccountCloudNativeNetworkTestHost(t *testing.T, rawURL string) {

--- a/internal/dataaccess/account_cloud_native_network_test.go
+++ b/internal/dataaccess/account_cloud_native_network_test.go
@@ -1,0 +1,103 @@
+package dataaccess
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportAccountConfigCloudNativeNetworkSendsRegionPath(t *testing.T) {
+	azureVNetID := "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/customer-rg/providers/Microsoft.Network/virtualNetworks/customer-vnet"
+	var capturedRequestURI string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequestURI = r.RequestURI
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"cloudNativeNetworks":[]}`))
+	}))
+	defer server.Close()
+	setAccountCloudNativeNetworkTestHost(t, server.URL)
+
+	_, err := ImportAccountConfigCloudNativeNetwork(context.Background(), "test-token", "ac-test", "eastus", azureVNetID)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"/2022-09-01-00/fleet/account-config/ac-test/cloud-native-networks/eastus/"+
+			url.PathEscape(azureVNetID)+"/import",
+		capturedRequestURI)
+}
+
+func TestBulkImportAccountConfigCloudNativeNetworksSendsRegion(t *testing.T) {
+	azureVNetID := "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/customer-rg/providers/Microsoft.Network/virtualNetworks/customer-vnet"
+	var capturedPath string
+	var capturedBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"cloudNativeNetworks":[]}`))
+	}))
+	defer server.Close()
+	setAccountCloudNativeNetworkTestHost(t, server.URL)
+
+	_, err := BulkImportAccountConfigCloudNativeNetworks(context.Background(), "test-token", "ac-test", []CloudNativeNetworkTarget{
+		{Region: "eastus", NetworkID: azureVNetID},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/2022-09-01-00/fleet/account-config/ac-test/cloud-native-networks/import", capturedPath)
+	operations, ok := capturedBody["cloudNativeNetworks"].([]any)
+	require.True(t, ok)
+	require.Len(t, operations, 1)
+	operation, ok := operations[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, azureVNetID, operation["cloudNativeNetworkId"])
+	assert.Equal(t, "eastus", operation["region"])
+	assert.Equal(t, true, operation["import"])
+}
+
+func TestUnimportAccountConfigCloudNativeNetworkSendsRegionPath(t *testing.T) {
+	azureVNetID := "/subscriptions/12345678-1234-1234-1234-123456789abc/resourceGroups/customer-rg/providers/Microsoft.Network/virtualNetworks/customer-vnet"
+	var capturedRequestURI string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedRequestURI = r.RequestURI
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"cloudNativeNetworks":[]}`))
+	}))
+	defer server.Close()
+	setAccountCloudNativeNetworkTestHost(t, server.URL)
+
+	_, err := UnimportAccountConfigCloudNativeNetwork(context.Background(), "test-token", "ac-test", "eastus", azureVNetID)
+	require.NoError(t, err)
+
+	assert.Equal(t,
+		"/2022-09-01-00/fleet/account-config/ac-test/cloud-native-networks/eastus/"+
+			url.PathEscape(azureVNetID)+"/unimport",
+		capturedRequestURI)
+}
+
+func setAccountCloudNativeNetworkTestHost(t *testing.T, rawURL string) {
+	t.Helper()
+
+	serverURL, err := url.Parse(rawURL)
+	require.NoError(t, err)
+	t.Setenv("OMNISTRATE_HOST", serverURL.Host)
+	t.Setenv("OMNISTRATE_HOST_SCHEME", serverURL.Scheme)
+	t.Setenv("CLIENT_TIMEOUT_IN_SECONDS", "5")
+}

--- a/mkdocs/docs/omnistrate-ctl_account.md
+++ b/mkdocs/docs/omnistrate-ctl_account.md
@@ -26,6 +26,7 @@ omnistrate-ctl account [operation] [flags]
 ### SEE ALSO
 
 * [omnistrate-ctl](omnistrate-ctl.md)	 - Manage your Omnistrate SaaS from the command line
+* [omnistrate-ctl account cloud-native-network](omnistrate-ctl_account_cloud-native-network.md)	 - Manage cloud-native networks (VPCs) for a BYOA Cloud Provider Account
 * [omnistrate-ctl account create](omnistrate-ctl_account_create.md)	 - Create a Cloud Provider Account
 * [omnistrate-ctl account customer](omnistrate-ctl_account_customer.md)	 - Manage customer BYOA account onboarding
 * [omnistrate-ctl account delete](omnistrate-ctl_account_delete.md)	 - Delete a Cloud Provider Account

--- a/mkdocs/docs/omnistrate-ctl_account_cloud-native-network.md
+++ b/mkdocs/docs/omnistrate-ctl_account_cloud-native-network.md
@@ -26,6 +26,7 @@ omnistrate-ctl account cloud-native-network [operation] [flags]
 ### SEE ALSO
 
 * [omnistrate-ctl account](omnistrate-ctl_account.md)	 - Manage your Cloud Provider Accounts
+* [omnistrate-ctl account cloud-native-network host-cluster](omnistrate-ctl_account_cloud-native-network_host-cluster.md)	 - Manage imported host clusters for cloud-native networks
 * [omnistrate-ctl account cloud-native-network import](omnistrate-ctl_account_cloud-native-network_import.md)	 - Import cloud-native networks for deployments
 * [omnistrate-ctl account cloud-native-network list](omnistrate-ctl_account_cloud-native-network_list.md)	 - List cloud-native networks for a BYOA account
 * [omnistrate-ctl account cloud-native-network remove](omnistrate-ctl_account_cloud-native-network_remove.md)	 - Remove an imported cloud-native network (revert to AVAILABLE)

--- a/mkdocs/docs/omnistrate-ctl_account_cloud-native-network.md
+++ b/mkdocs/docs/omnistrate-ctl_account_cloud-native-network.md
@@ -1,0 +1,33 @@
+## omnistrate-ctl account cloud-native-network
+
+Manage cloud-native networks (VPCs) for a BYOA Cloud Provider Account
+
+### Synopsis
+
+This command helps you manage cloud-native networks (VPCs) associated with your BYOA cloud provider accounts.
+
+```
+omnistrate-ctl account cloud-native-network [operation] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for cloud-native-network
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl account](omnistrate-ctl_account.md)	 - Manage your Cloud Provider Accounts
+* [omnistrate-ctl account cloud-native-network import](omnistrate-ctl_account_cloud-native-network_import.md)	 - Import cloud-native networks for deployments
+* [omnistrate-ctl account cloud-native-network list](omnistrate-ctl_account_cloud-native-network_list.md)	 - List cloud-native networks for a BYOA account
+* [omnistrate-ctl account cloud-native-network remove](omnistrate-ctl_account_cloud-native-network_remove.md)	 - Remove an imported cloud-native network (revert to AVAILABLE)
+* [omnistrate-ctl account cloud-native-network sync](omnistrate-ctl_account_cloud-native-network_sync.md)	 - Sync cloud-native networks from the cloud provider
+

--- a/mkdocs/docs/omnistrate-ctl_account_cloud-native-network_host-cluster.md
+++ b/mkdocs/docs/omnistrate-ctl_account_cloud-native-network_host-cluster.md
@@ -1,0 +1,30 @@
+## omnistrate-ctl account cloud-native-network host-cluster
+
+Manage imported host clusters for cloud-native networks
+
+### Synopsis
+
+This command helps you manage provider host clusters imported from cloud-native networks.
+
+```
+omnistrate-ctl account cloud-native-network host-cluster [operation] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for host-cluster
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl account cloud-native-network](omnistrate-ctl_account_cloud-native-network.md)	 - Manage cloud-native networks (VPCs) for a BYOA Cloud Provider Account
+* [omnistrate-ctl account cloud-native-network host-cluster import](omnistrate-ctl_account_cloud-native-network_host-cluster_import.md)	 - Import a host cluster from a cloud-native network
+

--- a/mkdocs/docs/omnistrate-ctl_account_cloud-native-network_host-cluster_import.md
+++ b/mkdocs/docs/omnistrate-ctl_account_cloud-native-network_host-cluster_import.md
@@ -1,0 +1,39 @@
+## omnistrate-ctl account cloud-native-network host-cluster import
+
+Import a host cluster from a cloud-native network
+
+### Synopsis
+
+Imports a provider host cluster from an imported cloud-native network into Omnistrate.
+
+```
+omnistrate-ctl account cloud-native-network host-cluster import [account-id] --region=[region] --network-id=[network-id] --host-cluster-name=[name] [flags]
+```
+
+### Examples
+
+```
+# Import a host cluster from a cloud-native network
+omnistrate-ctl account cloud-native-network host-cluster import [account-id] --region=[region] --network-id=[network-id] --host-cluster-name=[name]
+```
+
+### Options
+
+```
+  -h, --help                       help for import
+      --host-cluster-name string   The provider host cluster name to import (required)
+      --network-id string          The cloud-native network ID that contains the host cluster (required)
+      --region string              The cloud provider region of the cloud-native network (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl account cloud-native-network host-cluster](omnistrate-ctl_account_cloud-native-network_host-cluster.md)	 - Manage imported host clusters for cloud-native networks
+

--- a/mkdocs/docs/omnistrate-ctl_account_cloud-native-network_import.md
+++ b/mkdocs/docs/omnistrate-ctl_account_cloud-native-network_import.md
@@ -1,0 +1,41 @@
+## omnistrate-ctl account cloud-native-network import
+
+Import cloud-native networks for deployments
+
+### Synopsis
+
+Marks discovered cloud-native networks as READY so they can be used as deployment targets.
+
+```
+omnistrate-ctl account cloud-native-network import [account-id] --region=[region] --network-id=[network-id] [flags]
+```
+
+### Examples
+
+```
+# Import a cloud-native network for deployments
+omnistrate-ctl account cloud-native-network import [account-id] --region=[region] --network-id=[network-id]
+
+# Import multiple cloud-native networks in the same region
+omnistrate-ctl account cloud-native-network import [account-id] --region=[region] --network-id=[network-id-1] --network-id=[network-id-2]
+```
+
+### Options
+
+```
+  -h, --help                 help for import
+      --network-id strings   Cloud-native network ID to import (repeatable, required)
+      --region string        The cloud provider region of the cloud-native network to import (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl account cloud-native-network](omnistrate-ctl_account_cloud-native-network.md)	 - Manage cloud-native networks (VPCs) for a BYOA Cloud Provider Account
+

--- a/mkdocs/docs/omnistrate-ctl_account_cloud-native-network_list.md
+++ b/mkdocs/docs/omnistrate-ctl_account_cloud-native-network_list.md
@@ -1,0 +1,36 @@
+## omnistrate-ctl account cloud-native-network list
+
+List cloud-native networks for a BYOA account
+
+### Synopsis
+
+Lists the cloud-native networks registered under a BYOA account configuration, including import and in-use status.
+
+```
+omnistrate-ctl account cloud-native-network list [account-id] [flags]
+```
+
+### Examples
+
+```
+# List cloud-native networks registered under an account
+omnistrate-ctl account cloud-native-network list [account-id]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl account cloud-native-network](omnistrate-ctl_account_cloud-native-network.md)	 - Manage cloud-native networks (VPCs) for a BYOA Cloud Provider Account
+

--- a/mkdocs/docs/omnistrate-ctl_account_cloud-native-network_remove.md
+++ b/mkdocs/docs/omnistrate-ctl_account_cloud-native-network_remove.md
@@ -1,0 +1,38 @@
+## omnistrate-ctl account cloud-native-network remove
+
+Remove an imported cloud-native network (revert to AVAILABLE)
+
+### Synopsis
+
+Reverts a previously imported cloud-native network from READY back to AVAILABLE status, removing it from the deployment target pool.
+
+```
+omnistrate-ctl account cloud-native-network remove [account-id] --region=[region] --network-id=[network-id] [flags]
+```
+
+### Examples
+
+```
+# Remove a cloud-native network (revert to AVAILABLE)
+omnistrate-ctl account cloud-native-network remove [account-id] --region=[region] --network-id=[network-id]
+```
+
+### Options
+
+```
+  -h, --help                help for remove
+      --network-id string   The cloud-native network ID to remove (required)
+      --region string       The cloud provider region of the cloud-native network to remove (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl account cloud-native-network](omnistrate-ctl_account_cloud-native-network.md)	 - Manage cloud-native networks (VPCs) for a BYOA Cloud Provider Account
+

--- a/mkdocs/docs/omnistrate-ctl_account_cloud-native-network_sync.md
+++ b/mkdocs/docs/omnistrate-ctl_account_cloud-native-network_sync.md
@@ -20,15 +20,16 @@ omnistrate-ctl account cloud-native-network sync [account-id]
 omnistrate-ctl account cloud-native-network sync [account-id] --region=us-east-1 --region=us-west-2
 
 # Sync specific networks
-omnistrate-ctl account cloud-native-network sync [account-id] --network=us-east-1:vpc-abc123
+omnistrate-ctl account cloud-native-network sync [account-id] --region=us-east-1 --network-id=vpc-abc123
 ```
 
 ### Options
 
 ```
-  -h, --help              help for sync
-      --network strings   Specific network to sync in region:network-id format (repeatable)
-      --region strings    Cloud region to discover (repeatable)
+  -h, --help                 help for sync
+      --network strings      Specific network to sync in region:network-id format (repeatable)
+      --network-id strings   Cloud-native network ID to sync in the specified region (repeatable)
+      --region strings       Cloud region to discover (repeatable)
 ```
 
 ### Options inherited from parent commands

--- a/mkdocs/docs/omnistrate-ctl_account_cloud-native-network_sync.md
+++ b/mkdocs/docs/omnistrate-ctl_account_cloud-native-network_sync.md
@@ -1,0 +1,44 @@
+## omnistrate-ctl account cloud-native-network sync
+
+Sync cloud-native networks from the cloud provider
+
+### Synopsis
+
+Discovers or re-validates cloud-native networks for a BYOA account configuration.
+
+```
+omnistrate-ctl account cloud-native-network sync [account-id] [flags]
+```
+
+### Examples
+
+```
+# Sync all cloud-native networks for an account
+omnistrate-ctl account cloud-native-network sync [account-id]
+
+# Sync all networks in specific regions
+omnistrate-ctl account cloud-native-network sync [account-id] --region=us-east-1 --region=us-west-2
+
+# Sync specific networks
+omnistrate-ctl account cloud-native-network sync [account-id] --network=us-east-1:vpc-abc123
+```
+
+### Options
+
+```
+  -h, --help              help for sync
+      --network strings   Specific network to sync in region:network-id format (repeatable)
+      --region strings    Cloud region to discover (repeatable)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl account cloud-native-network](omnistrate-ctl_account_cloud-native-network.md)	 - Manage cloud-native networks (VPCs) for a BYOA Cloud Provider Account
+

--- a/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network.md
+++ b/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network.md
@@ -26,5 +26,8 @@ omnistrate-ctl account customer cloud-native-network [operation] [flags]
 ### SEE ALSO
 
 * [omnistrate-ctl account customer](omnistrate-ctl_account_customer.md)	 - Manage customer BYOA account onboarding
+* [omnistrate-ctl account customer cloud-native-network import](omnistrate-ctl_account_customer_cloud-native-network_import.md)	 - Import cloud-native networks for deployments
+* [omnistrate-ctl account customer cloud-native-network list](omnistrate-ctl_account_customer_cloud-native-network_list.md)	 - List cloud-native networks for a BYOA account
 * [omnistrate-ctl account customer cloud-native-network remove](omnistrate-ctl_account_customer_cloud-native-network_remove.md)	 - Remove an imported cloud-native network (revert to AVAILABLE)
+* [omnistrate-ctl account customer cloud-native-network sync](omnistrate-ctl_account_customer_cloud-native-network_sync.md)	 - Sync cloud-native networks from the cloud provider
 

--- a/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network.md
+++ b/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network.md
@@ -26,6 +26,7 @@ omnistrate-ctl account customer cloud-native-network [operation] [flags]
 ### SEE ALSO
 
 * [omnistrate-ctl account customer](omnistrate-ctl_account_customer.md)	 - Manage customer BYOA account onboarding
+* [omnistrate-ctl account customer cloud-native-network host-cluster](omnistrate-ctl_account_customer_cloud-native-network_host-cluster.md)	 - Manage imported host clusters for cloud-native networks
 * [omnistrate-ctl account customer cloud-native-network import](omnistrate-ctl_account_customer_cloud-native-network_import.md)	 - Import cloud-native networks for deployments
 * [omnistrate-ctl account customer cloud-native-network list](omnistrate-ctl_account_customer_cloud-native-network_list.md)	 - List cloud-native networks for a BYOA account
 * [omnistrate-ctl account customer cloud-native-network remove](omnistrate-ctl_account_customer_cloud-native-network_remove.md)	 - Remove an imported cloud-native network (revert to AVAILABLE)

--- a/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network_host-cluster.md
+++ b/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network_host-cluster.md
@@ -1,0 +1,30 @@
+## omnistrate-ctl account customer cloud-native-network host-cluster
+
+Manage imported host clusters for cloud-native networks
+
+### Synopsis
+
+This command helps you manage provider host clusters imported from cloud-native networks.
+
+```
+omnistrate-ctl account customer cloud-native-network host-cluster [operation] [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for host-cluster
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl account customer cloud-native-network](omnistrate-ctl_account_customer_cloud-native-network.md)	 - Manage cloud-native networks (VPCs) for a BYOA Cloud Provider Account
+* [omnistrate-ctl account customer cloud-native-network host-cluster import](omnistrate-ctl_account_customer_cloud-native-network_host-cluster_import.md)	 - Import a host cluster from a cloud-native network
+

--- a/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network_host-cluster_import.md
+++ b/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network_host-cluster_import.md
@@ -1,0 +1,39 @@
+## omnistrate-ctl account customer cloud-native-network host-cluster import
+
+Import a host cluster from a cloud-native network
+
+### Synopsis
+
+Imports a provider host cluster from an imported cloud-native network into Omnistrate.
+
+```
+omnistrate-ctl account customer cloud-native-network host-cluster import [account-id] --region=[region] --network-id=[network-id] --host-cluster-name=[name] [flags]
+```
+
+### Examples
+
+```
+# Import a host cluster from a cloud-native network
+omnistrate-ctl account customer cloud-native-network host-cluster import [account-id] --region=[region] --network-id=[network-id] --host-cluster-name=[name]
+```
+
+### Options
+
+```
+  -h, --help                       help for import
+      --host-cluster-name string   The provider host cluster name to import (required)
+      --network-id string          The cloud-native network ID that contains the host cluster (required)
+      --region string              The cloud provider region of the cloud-native network (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl account customer cloud-native-network host-cluster](omnistrate-ctl_account_customer_cloud-native-network_host-cluster.md)	 - Manage imported host clusters for cloud-native networks
+

--- a/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network_import.md
+++ b/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network_import.md
@@ -1,0 +1,41 @@
+## omnistrate-ctl account customer cloud-native-network import
+
+Import cloud-native networks for deployments
+
+### Synopsis
+
+Marks discovered cloud-native networks as READY so they can be used as deployment targets.
+
+```
+omnistrate-ctl account customer cloud-native-network import [account-id] --region=[region] --network-id=[network-id] [flags]
+```
+
+### Examples
+
+```
+# Import a cloud-native network for deployments
+omnistrate-ctl account customer cloud-native-network import [account-id] --region=[region] --network-id=[network-id]
+
+# Import multiple cloud-native networks in the same region
+omnistrate-ctl account customer cloud-native-network import [account-id] --region=[region] --network-id=[network-id-1] --network-id=[network-id-2]
+```
+
+### Options
+
+```
+  -h, --help                 help for import
+      --network-id strings   Cloud-native network ID to import (repeatable, required)
+      --region string        The cloud provider region of the cloud-native network to import (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl account customer cloud-native-network](omnistrate-ctl_account_customer_cloud-native-network.md)	 - Manage cloud-native networks (VPCs) for a BYOA Cloud Provider Account
+

--- a/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network_list.md
+++ b/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network_list.md
@@ -1,0 +1,36 @@
+## omnistrate-ctl account customer cloud-native-network list
+
+List cloud-native networks for a BYOA account
+
+### Synopsis
+
+Lists the cloud-native networks registered under a BYOA account configuration, including import and in-use status.
+
+```
+omnistrate-ctl account customer cloud-native-network list [account-id] [flags]
+```
+
+### Examples
+
+```
+# List cloud-native networks registered under an account
+omnistrate-ctl account customer cloud-native-network list [account-id]
+```
+
+### Options
+
+```
+  -h, --help   help for list
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl account customer cloud-native-network](omnistrate-ctl_account_customer_cloud-native-network.md)	 - Manage cloud-native networks (VPCs) for a BYOA Cloud Provider Account
+

--- a/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network_remove.md
+++ b/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network_remove.md
@@ -7,14 +7,14 @@ Remove an imported cloud-native network (revert to AVAILABLE)
 Reverts a previously imported cloud-native network from READY back to AVAILABLE status, removing it from the deployment target pool.
 
 ```
-omnistrate-ctl account customer cloud-native-network remove [account-id] --network-id=[network-id] [flags]
+omnistrate-ctl account customer cloud-native-network remove [account-id] --region=[region] --network-id=[network-id] [flags]
 ```
 
 ### Examples
 
 ```
 # Remove a cloud-native network (revert to AVAILABLE)
-omnistrate-ctl account customer cloud-native-network remove [account-id] --network-id=[network-id]
+omnistrate-ctl account customer cloud-native-network remove [account-id] --region=[region] --network-id=[network-id]
 ```
 
 ### Options
@@ -22,6 +22,7 @@ omnistrate-ctl account customer cloud-native-network remove [account-id] --netwo
 ```
   -h, --help                help for remove
       --network-id string   The cloud-native network ID to remove (required)
+      --region string       The cloud provider region of the cloud-native network to remove (required)
 ```
 
 ### Options inherited from parent commands

--- a/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network_sync.md
+++ b/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network_sync.md
@@ -1,0 +1,44 @@
+## omnistrate-ctl account customer cloud-native-network sync
+
+Sync cloud-native networks from the cloud provider
+
+### Synopsis
+
+Discovers or re-validates cloud-native networks for a BYOA account configuration.
+
+```
+omnistrate-ctl account customer cloud-native-network sync [account-id] [flags]
+```
+
+### Examples
+
+```
+# Sync all cloud-native networks for an account
+omnistrate-ctl account customer cloud-native-network sync [account-id]
+
+# Sync all networks in specific regions
+omnistrate-ctl account customer cloud-native-network sync [account-id] --region=us-east-1 --region=us-west-2
+
+# Sync specific networks
+omnistrate-ctl account customer cloud-native-network sync [account-id] --network=us-east-1:vpc-abc123
+```
+
+### Options
+
+```
+  -h, --help              help for sync
+      --network strings   Specific network to sync in region:network-id format (repeatable)
+      --region strings    Cloud region to discover (repeatable)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl account customer cloud-native-network](omnistrate-ctl_account_customer_cloud-native-network.md)	 - Manage cloud-native networks (VPCs) for a BYOA Cloud Provider Account
+

--- a/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network_sync.md
+++ b/mkdocs/docs/omnistrate-ctl_account_customer_cloud-native-network_sync.md
@@ -20,15 +20,16 @@ omnistrate-ctl account customer cloud-native-network sync [account-id]
 omnistrate-ctl account customer cloud-native-network sync [account-id] --region=us-east-1 --region=us-west-2
 
 # Sync specific networks
-omnistrate-ctl account customer cloud-native-network sync [account-id] --network=us-east-1:vpc-abc123
+omnistrate-ctl account customer cloud-native-network sync [account-id] --region=us-east-1 --network-id=vpc-abc123
 ```
 
 ### Options
 
 ```
-  -h, --help              help for sync
-      --network strings   Specific network to sync in region:network-id format (repeatable)
-      --region strings    Cloud region to discover (repeatable)
+  -h, --help                 help for sync
+      --network strings      Specific network to sync in region:network-id format (repeatable)
+      --network-id strings   Cloud-native network ID to sync in the specified region (repeatable)
+      --region strings       Cloud region to discover (repeatable)
 ```
 
 ### Options inherited from parent commands

--- a/test/smoke_test/cloudnativenetwork/cloudnativenetwork_test.go
+++ b/test/smoke_test/cloudnativenetwork/cloudnativenetwork_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -24,11 +25,11 @@ import (
 //  1. logs in with the smoke-test account,
 //  2. resolves a BYOA AWS account-config (env TEST_BYOA_ACCOUNT_CONFIG_ID,
 //     or a freshly created throwaway account),
-//  3. triggers discovery via dataaccess.SyncAccountConfigCloudNativeNetworks,
+//  3. triggers discovery through both cloud-native-network CLI command paths,
 //  4. lists the discovered networks and asserts the fleet response carries the
 //     new IMPORTED / IN USE fields,
-//  5. imports one network and verifies Imported flips to true,
-//  6. removes it via the CLI and verifies the flag clears,
+//  5. imports and removes one network through both CLI command paths,
+//  6. verifies Imported flips true and back to false,
 //  7. cleans up the throwaway account-config (when it created one).
 //
 // The discovery + import/unimport phases are skipped when:
@@ -61,14 +62,17 @@ func Test_cloud_native_network_discovery(t *testing.T) {
 	if envRegions := config.GetEnv("TEST_BYOA_REGIONS", ""); envRegions != "" {
 		syncRegions = strings.Split(envRegions, ",")
 	}
-	// Call the dataaccess layer directly so we can inspect the error and
-	// skip cleanly without going through interactive CLI behavior.
+	// Call the dataaccess layer once so we can inspect the error and skip
+	// cleanly without going through interactive CLI behavior.
 	if _, err := dataaccess.SyncAccountConfigCloudNativeNetworks(ctx, token, accountConfigID, syncRegions); err != nil {
 		if strings.Contains(err.Error(), "regions") {
 			t.Skipf("sync requires a service-plan-registered account; set TEST_BYOA_ACCOUNT_CONFIG_ID to a registered account: %v", err)
 		}
 		require.NoError(err)
 	}
+
+	runCloudNativeNetworkCLI(t, ctx, cloudNativeNetworkCommandArgs([]string{"account", "cloud-native-network"}, syncArgs(accountConfigID, syncRegions))...)
+	runCloudNativeNetworkCLI(t, ctx, cloudNativeNetworkCommandArgs([]string{"account", "customer", "cloud-native-network"}, syncArgs(accountConfigID, syncRegions))...)
 
 	listResult, err := dataaccess.ListAccountConfigCloudNativeNetworks(ctx, token, accountConfigID)
 	require.NoError(err)
@@ -78,30 +82,74 @@ func Test_cloud_native_network_discovery(t *testing.T) {
 		require.NotNil(vpc.InUse, "fleet response missing 'inUse' for %s", vpc.CloudNativeNetworkId)
 	}
 
-	// Exercise the user-facing remove CLI command.
-	// Sync, list, and import are internal-only and exercised through the dataaccess layer above.
+	runCloudNativeNetworkCLI(t, ctx, "account", "cloud-native-network", "list", accountConfigID, "--output", "json")
+	runCloudNativeNetworkCLI(t, ctx, "account", "customer", "cloud-native-network", "list", accountConfigID, "--output", "json")
 
-	available := firstAvailableNetwork(listResult.CloudNativeNetworks)
+	available := firstImportableNetwork(listResult.CloudNativeNetworks)
 	if available == "" {
-		t.Logf("no AVAILABLE networks discovered for account-config %s; skipping import/unimport phase", accountConfigID)
+		t.Logf("no importable networks discovered for account-config %s; skipping import/unimport phase", accountConfigID)
 		return
 	}
 	availableRegion := networkRegion(listResult.CloudNativeNetworks, available)
 	require.NotEmpty(availableRegion, "network %s should include region", available)
 
-	_, err = dataaccess.ImportAccountConfigCloudNativeNetwork(ctx, token, accountConfigID, availableRegion, available)
-	require.NoError(err)
+	runCloudNativeNetworkCLI(t, ctx, "account", "cloud-native-network", "import", accountConfigID, "--region", availableRegion, "--network-id", available, "--output", "json")
 
 	postImport, err := dataaccess.ListAccountConfigCloudNativeNetworks(ctx, token, accountConfigID)
 	require.NoError(err)
 	require.True(networkImported(postImport.CloudNativeNetworks, available), "network %s should be imported after import call", available)
 
-	cmd.RootCmd.SetArgs([]string{"account", "customer", "cloud-native-network", "remove", accountConfigID, "--region", availableRegion, "--network-id", available, "--output", "json"})
-	require.NoError(cmd.RootCmd.ExecuteContext(ctx))
+	runCloudNativeNetworkCLI(t, ctx, "account", "customer", "cloud-native-network", "remove", accountConfigID, "--region", availableRegion, "--network-id", available, "--output", "json")
 
 	postUnimport, err := dataaccess.ListAccountConfigCloudNativeNetworks(ctx, token, accountConfigID)
 	require.NoError(err)
 	require.False(networkImported(postUnimport.CloudNativeNetworks, available), "network %s should not be imported after unimport call", available)
+
+	runCloudNativeNetworkCLI(t, ctx, "account", "customer", "cloud-native-network", "import", accountConfigID, "--region", availableRegion, "--network-id", available, "--output", "json")
+
+	postCustomerImport, err := dataaccess.ListAccountConfigCloudNativeNetworks(ctx, token, accountConfigID)
+	require.NoError(err)
+	require.True(networkImported(postCustomerImport.CloudNativeNetworks, available), "network %s should be imported after customer import command", available)
+
+	runCloudNativeNetworkCLI(t, ctx, "account", "cloud-native-network", "remove", accountConfigID, "--region", availableRegion, "--network-id", available, "--output", "json")
+
+	postDirectRemove, err := dataaccess.ListAccountConfigCloudNativeNetworks(ctx, token, accountConfigID)
+	require.NoError(err)
+	require.False(networkImported(postDirectRemove.CloudNativeNetworks, available), "network %s should not be imported after direct remove command", available)
+}
+
+func syncArgs(accountConfigID string, regions []string) []string {
+	args := []string{"sync", accountConfigID, "--output", "json"}
+	for _, region := range regions {
+		if region = strings.TrimSpace(region); region != "" {
+			args = append(args, "--region", region)
+		}
+	}
+	return args
+}
+
+func cloudNativeNetworkCommandArgs(prefix, args []string) []string {
+	combined := make([]string, 0, len(prefix)+len(args))
+	combined = append(combined, prefix...)
+	combined = append(combined, args...)
+	return combined
+}
+
+func runCloudNativeNetworkCLI(t *testing.T, ctx context.Context, prefix ...string) {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	devNull, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+	require.NoError(t, err)
+	os.Stdout = devNull
+	defer func() {
+		os.Stdout = oldStdout
+		_ = devNull.Close()
+	}()
+
+	cmd.RootCmd.SetArgs(prefix)
+	executeErr := cmd.RootCmd.ExecuteContext(ctx)
+	require.NoError(t, executeErr)
 }
 
 // createThrowawayAccount creates a BYOA AWS account-config and registers a
@@ -236,7 +284,9 @@ func Test_account_customer_create_cloud_native_networks(t *testing.T) {
 		for _, account := range accounts.AccountConfigs {
 			if account.AwsAccountID != nil && *account.AwsAccountID == awsAccountID {
 				t.Cleanup(func() {
-					_, _ = dataaccess.UnimportAccountConfigCloudNativeNetwork(ctx, token, account.Id, region, networkID)
+					_, _ = dataaccess.BulkUnimportAccountConfigCloudNativeNetworks(ctx, token, account.Id, []dataaccess.CloudNativeNetworkTarget{
+						{Region: region, NetworkID: networkID},
+					})
 					if delErr := dataaccess.DeleteAccount(ctx, token, account.Id); delErr != nil {
 						t.Logf("best-effort cleanup of account %s failed: %v", account.Id, delErr)
 					}
@@ -247,6 +297,47 @@ func Test_account_customer_create_cloud_native_networks(t *testing.T) {
 	}
 
 	require.NoError(createErr, "account customer create with --cloud-native-networks should succeed")
+}
+
+// Test_cloud_native_network_host_cluster_import exercises the host-cluster
+// import CLI path when a test environment points at an account/network/cluster
+// combination whose backend route is deployed.
+//
+// Required environment variables:
+//   - TEST_CNN_HOST_CLUSTER_ACCOUNT_CONFIG_ID
+//   - TEST_CNN_HOST_CLUSTER_REGION
+//   - TEST_CNN_HOST_CLUSTER_NETWORK_ID
+//   - TEST_CNN_HOST_CLUSTER_NAME
+//
+// When any of the required variables are missing, the test is skipped.
+func Test_cloud_native_network_host_cluster_import(t *testing.T) {
+	testutils.SmokeTest(t)
+
+	ctx := context.Background()
+	require := require.New(t)
+	defer testutils.Cleanup()
+
+	accountConfigID := config.GetEnv("TEST_CNN_HOST_CLUSTER_ACCOUNT_CONFIG_ID", "")
+	region := config.GetEnv("TEST_CNN_HOST_CLUSTER_REGION", "")
+	networkID := config.GetEnv("TEST_CNN_HOST_CLUSTER_NETWORK_ID", "")
+	hostClusterName := config.GetEnv("TEST_CNN_HOST_CLUSTER_NAME", "")
+	if accountConfigID == "" || region == "" || networkID == "" || hostClusterName == "" {
+		t.Skip("TEST_CNN_HOST_CLUSTER_ACCOUNT_CONFIG_ID, TEST_CNN_HOST_CLUSTER_REGION, TEST_CNN_HOST_CLUSTER_NETWORK_ID, and TEST_CNN_HOST_CLUSTER_NAME must all be set; skipping")
+	}
+
+	testEmail, testPassword, err := testutils.GetTestAccount()
+	require.NoError(err)
+	cmd.RootCmd.SetArgs([]string{"login", fmt.Sprintf("--email=%s", testEmail), fmt.Sprintf("--password=%s", testPassword)})
+	require.NoError(cmd.RootCmd.ExecuteContext(ctx))
+
+	runCloudNativeNetworkCLI(t, ctx,
+		"account", "customer", "cloud-native-network", "host-cluster", "import",
+		accountConfigID,
+		"--region", region,
+		"--network-id", networkID,
+		"--host-cluster-name", hostClusterName,
+		"--output", "json",
+	)
 }
 
 // Test_gcp_cloud_native_network_discovery exercises the same discovery /
@@ -309,7 +400,9 @@ func Test_gcp_cloud_native_network_discovery(t *testing.T) {
 	importedNetworkRegion := ""
 	t.Cleanup(func() {
 		if importedNetworkID != "" {
-			_, _ = dataaccess.UnimportAccountConfigCloudNativeNetwork(ctx, token, accountConfigID, importedNetworkRegion, importedNetworkID)
+			_, _ = dataaccess.BulkUnimportAccountConfigCloudNativeNetworks(ctx, token, accountConfigID, []dataaccess.CloudNativeNetworkTarget{
+				{Region: importedNetworkRegion, NetworkID: importedNetworkID},
+			})
 		}
 		_ = dataaccess.DeleteResourceInstance(ctx, token, ref.ServiceID, ref.EnvironmentID, ref.ResourceID, ref.InstanceID)
 	})
@@ -335,7 +428,9 @@ func Test_gcp_cloud_native_network_discovery(t *testing.T) {
 	targetNetworkRegion := networkRegion(listResult.CloudNativeNetworks, targetNetworkID)
 	require.NotEmpty(targetNetworkRegion, "network %s should include region", targetNetworkID)
 
-	_, err = dataaccess.ImportAccountConfigCloudNativeNetwork(ctx, token, accountConfigID, targetNetworkRegion, targetNetworkID)
+	_, err = dataaccess.BulkImportAccountConfigCloudNativeNetworks(ctx, token, accountConfigID, []dataaccess.CloudNativeNetworkTarget{
+		{Region: targetNetworkRegion, NetworkID: targetNetworkID},
+	})
 	require.NoError(err)
 	importedNetworkID = targetNetworkID
 	importedNetworkRegion = targetNetworkRegion

--- a/test/smoke_test/cloudnativenetwork/cloudnativenetwork_test.go
+++ b/test/smoke_test/cloudnativenetwork/cloudnativenetwork_test.go
@@ -86,15 +86,17 @@ func Test_cloud_native_network_discovery(t *testing.T) {
 		t.Logf("no AVAILABLE networks discovered for account-config %s; skipping import/unimport phase", accountConfigID)
 		return
 	}
+	availableRegion := networkRegion(listResult.CloudNativeNetworks, available)
+	require.NotEmpty(availableRegion, "network %s should include region", available)
 
-	_, err = dataaccess.ImportAccountConfigCloudNativeNetwork(ctx, token, accountConfigID, available)
+	_, err = dataaccess.ImportAccountConfigCloudNativeNetwork(ctx, token, accountConfigID, availableRegion, available)
 	require.NoError(err)
 
 	postImport, err := dataaccess.ListAccountConfigCloudNativeNetworks(ctx, token, accountConfigID)
 	require.NoError(err)
 	require.True(networkImported(postImport.CloudNativeNetworks, available), "network %s should be imported after import call", available)
 
-	cmd.RootCmd.SetArgs([]string{"account", "customer", "cloud-native-network", "remove", accountConfigID, "--network-id", available, "--output", "json"})
+	cmd.RootCmd.SetArgs([]string{"account", "customer", "cloud-native-network", "remove", accountConfigID, "--region", availableRegion, "--network-id", available, "--output", "json"})
 	require.NoError(cmd.RootCmd.ExecuteContext(ctx))
 
 	postUnimport, err := dataaccess.ListAccountConfigCloudNativeNetworks(ctx, token, accountConfigID)
@@ -157,6 +159,15 @@ func networkImported(vpcs []openapiclientfleet.FleetAccountConfigCloudNativeNetw
 		}
 	}
 	return false
+}
+
+func networkRegion(vpcs []openapiclientfleet.FleetAccountConfigCloudNativeNetworkResult, id string) string {
+	for _, vpc := range vpcs {
+		if vpc.CloudNativeNetworkId == id {
+			return vpc.Region
+		}
+	}
+	return ""
 }
 
 // Test_account_customer_create_cloud_native_networks verifies that passing
@@ -225,7 +236,7 @@ func Test_account_customer_create_cloud_native_networks(t *testing.T) {
 		for _, account := range accounts.AccountConfigs {
 			if account.AwsAccountID != nil && *account.AwsAccountID == awsAccountID {
 				t.Cleanup(func() {
-					_, _ = dataaccess.UnimportAccountConfigCloudNativeNetwork(ctx, token, account.Id, networkID)
+					_, _ = dataaccess.UnimportAccountConfigCloudNativeNetwork(ctx, token, account.Id, region, networkID)
 					if delErr := dataaccess.DeleteAccount(ctx, token, account.Id); delErr != nil {
 						t.Logf("best-effort cleanup of account %s failed: %v", account.Id, delErr)
 					}
@@ -295,9 +306,10 @@ func Test_gcp_cloud_native_network_discovery(t *testing.T) {
 	require.NotEmpty(accountConfigID)
 
 	importedNetworkID := ""
+	importedNetworkRegion := ""
 	t.Cleanup(func() {
 		if importedNetworkID != "" {
-			_, _ = dataaccess.UnimportAccountConfigCloudNativeNetwork(ctx, token, accountConfigID, importedNetworkID)
+			_, _ = dataaccess.UnimportAccountConfigCloudNativeNetwork(ctx, token, accountConfigID, importedNetworkRegion, importedNetworkID)
 		}
 		_ = dataaccess.DeleteResourceInstance(ctx, token, ref.ServiceID, ref.EnvironmentID, ref.ResourceID, ref.InstanceID)
 	})
@@ -320,18 +332,22 @@ func Test_gcp_cloud_native_network_discovery(t *testing.T) {
 		t.Logf("no importable networks discovered for GCP account-config %s; skipping import/remove phase", accountConfigID)
 		return
 	}
+	targetNetworkRegion := networkRegion(listResult.CloudNativeNetworks, targetNetworkID)
+	require.NotEmpty(targetNetworkRegion, "network %s should include region", targetNetworkID)
 
-	_, err = dataaccess.ImportAccountConfigCloudNativeNetwork(ctx, token, accountConfigID, targetNetworkID)
+	_, err = dataaccess.ImportAccountConfigCloudNativeNetwork(ctx, token, accountConfigID, targetNetworkRegion, targetNetworkID)
 	require.NoError(err)
 	importedNetworkID = targetNetworkID
+	importedNetworkRegion = targetNetworkRegion
 
 	postImport, err := dataaccess.ListAccountConfigCloudNativeNetworks(ctx, token, accountConfigID)
 	require.NoError(err)
 	require.True(networkImported(postImport.CloudNativeNetworks, targetNetworkID), "network %s should be imported after import call", targetNetworkID)
 
-	cmd.RootCmd.SetArgs([]string{"account", "customer", "cloud-native-network", "remove", accountConfigID, "--network-id", targetNetworkID, "--output", "json"})
+	cmd.RootCmd.SetArgs([]string{"account", "customer", "cloud-native-network", "remove", accountConfigID, "--region", targetNetworkRegion, "--network-id", targetNetworkID, "--output", "json"})
 	require.NoError(cmd.RootCmd.ExecuteContext(ctx))
 	importedNetworkID = ""
+	importedNetworkRegion = ""
 
 	postRemove, err := dataaccess.ListAccountConfigCloudNativeNetworks(ctx, token, accountConfigID)
 	require.NoError(err)


### PR DESCRIPTION
## Summary
- include region when importing/unimporting account cloud-native networks
- send region in bulk import operations for account customer create
- require --region on cloud-native-network remove and regenerate CLI docs

## Tests
- go test ./internal/dataaccess ./cmd/account ./cmd/account/cloudnativenetwork
- go test ./test/smoke_test/cloudnativenetwork -run '^$'
- go test github.com/omnistrate-oss/omnistrate-ctl
github.com/omnistrate-oss/omnistrate-ctl/cmd
github.com/omnistrate-oss/omnistrate-ctl/cmd/account
github.com/omnistrate-oss/omnistrate-ctl/cmd/account/cloudnativenetwork
github.com/omnistrate-oss/omnistrate-ctl/cmd/agent
github.com/omnistrate-oss/omnistrate-ctl/cmd/alarms
github.com/omnistrate-oss/omnistrate-ctl/cmd/alarms/notificationchannel
github.com/omnistrate-oss/omnistrate-ctl/cmd/audit
github.com/omnistrate-oss/omnistrate-ctl/cmd/auth/login
github.com/omnistrate-oss/omnistrate-ctl/cmd/auth/logout
github.com/omnistrate-oss/omnistrate-ctl/cmd/auth/refresh
github.com/omnistrate-oss/omnistrate-ctl/cmd/auth/revoke
github.com/omnistrate-oss/omnistrate-ctl/cmd/build
github.com/omnistrate-oss/omnistrate-ctl/cmd/common
github.com/omnistrate-oss/omnistrate-ctl/cmd/cost
github.com/omnistrate-oss/omnistrate-ctl/cmd/customer
github.com/omnistrate-oss/omnistrate-ctl/cmd/customnetwork
github.com/omnistrate-oss/omnistrate-ctl/cmd/deploy
github.com/omnistrate-oss/omnistrate-ctl/cmd/deploymentcell
github.com/omnistrate-oss/omnistrate-ctl/cmd/docs
github.com/omnistrate-oss/omnistrate-ctl/cmd/domain
github.com/omnistrate-oss/omnistrate-ctl/cmd/environment
github.com/omnistrate-oss/omnistrate-ctl/cmd/helm
github.com/omnistrate-oss/omnistrate-ctl/cmd/instance
github.com/omnistrate-oss/omnistrate-ctl/cmd/mcp
github.com/omnistrate-oss/omnistrate-ctl/cmd/mcp/cfgmgr
github.com/omnistrate-oss/omnistrate-ctl/cmd/mcp/claude
github.com/omnistrate-oss/omnistrate-ctl/cmd/mcp/vscode
github.com/omnistrate-oss/omnistrate-ctl/cmd/operations
github.com/omnistrate-oss/omnistrate-ctl/cmd/secret
github.com/omnistrate-oss/omnistrate-ctl/cmd/service
github.com/omnistrate-oss/omnistrate-ctl/cmd/serviceplan
github.com/omnistrate-oss/omnistrate-ctl/cmd/servicesorchestration
github.com/omnistrate-oss/omnistrate-ctl/cmd/snapshot
github.com/omnistrate-oss/omnistrate-ctl/cmd/subscription
github.com/omnistrate-oss/omnistrate-ctl/cmd/upgrade
github.com/omnistrate-oss/omnistrate-ctl/cmd/upgrade/manageupgradelifecycle
github.com/omnistrate-oss/omnistrate-ctl/cmd/upgrade/status
github.com/omnistrate-oss/omnistrate-ctl/cmd/upgrade/status/detail
github.com/omnistrate-oss/omnistrate-ctl/cmd/workflow
github.com/omnistrate-oss/omnistrate-ctl/doc-gen
github.com/omnistrate-oss/omnistrate-ctl/internal/config
github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess
github.com/omnistrate-oss/omnistrate-ctl/internal/model
github.com/omnistrate-oss/omnistrate-ctl/internal/utils
- go test ./... -run '^$'