### PR TITLE
Support multi-document YAML files in KubernetesManifest amenities

### DIFF
--- a/internal/model/manifest_amenity.go
+++ b/internal/model/manifest_amenity.go
@@ -1,8 +1,11 @@
 package model
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -97,14 +100,15 @@ func processAmenity(amenity Amenity, baseDir string) (Amenity, error) {
 		return amenity, err
 	}
 
-	// Process each manifest entry and convert file references to inline definitions
+	// Process each manifest entry and convert file references to inline definitions.
+	// A single file entry may produce multiple entries if the file contains multiple YAML documents.
 	processedEntries := make([]ManifestEntry, 0, len(manifestProps.Manifests))
 	for i, entry := range manifestProps.Manifests {
 		processed, err := processManifestEntry(entry, baseDir, i)
 		if err != nil {
 			return amenity, err
 		}
-		processedEntries = append(processedEntries, processed)
+		processedEntries = append(processedEntries, processed...)
 	}
 
 	// Create a new amenity with processed properties
@@ -147,11 +151,13 @@ func parseManifestProperties(properties map[string]interface{}) (ManifestPropert
 	return manifestProps, nil
 }
 
-// processManifestEntry processes a single manifest entry, reading file content if necessary
-func processManifestEntry(entry ManifestEntry, baseDir string, index int) (ManifestEntry, error) {
+// processManifestEntry processes a single manifest entry, reading file content if necessary.
+// A file may contain multiple YAML documents separated by '---', in which case multiple
+// ManifestEntry values are returned.
+func processManifestEntry(entry ManifestEntry, baseDir string, index int) ([]ManifestEntry, error) {
 	// If it already has a def, return as-is
 	if len(entry.Def) > 0 {
-		return ManifestEntry{Def: entry.Def}, nil
+		return []ManifestEntry{{Def: entry.Def}}, nil
 	}
 
 	// Read the file and parse YAML to map
@@ -162,14 +168,32 @@ func processManifestEntry(entry ManifestEntry, baseDir string, index int) (Manif
 
 	content, err := os.ReadFile(filePath)
 	if err != nil {
-		return ManifestEntry{}, fmt.Errorf("manifest entry %d: failed to read file '%s': %w", index, filePath, err)
+		return nil, fmt.Errorf("manifest entry %d: failed to read file '%s': %w", index, filePath, err)
 	}
 
-	// Parse YAML content into a map
-	var defMap map[string]interface{}
-	if err := yaml.Unmarshal(content, &defMap); err != nil {
-		return ManifestEntry{}, fmt.Errorf("manifest entry %d: failed to parse YAML from file '%s': %w", index, filePath, err)
+	// Parse all YAML documents from the file
+	decoder := yaml.NewDecoder(bytes.NewReader(content))
+	var entries []ManifestEntry
+
+	for {
+		var defMap map[string]interface{}
+		err := decoder.Decode(&defMap)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("manifest entry %d: failed to parse YAML from file '%s': %w", index, filePath, err)
+		}
+		// Skip empty documents (e.g. from trailing '---')
+		if len(defMap) == 0 {
+			continue
+		}
+		entries = append(entries, ManifestEntry{Def: defMap})
 	}
 
-	return ManifestEntry{Def: defMap}, nil
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("manifest entry %d: file '%s' contains no valid YAML documents", index, filePath)
+	}
+
+	return entries, nil
 }

--- a/internal/model/manifest_amenity_test.go
+++ b/internal/model/manifest_amenity_test.go
@@ -3,6 +3,7 @@ package model
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -379,6 +380,42 @@ func TestProcessManifestAmenities_InvalidYAML(t *testing.T) {
 	_, err := ProcessManifestAmenities(amenities, tmpDir)
 	if err == nil {
 		t.Fatal("expected error for invalid YAML, got nil")
+	}
+}
+
+func TestProcessManifestAmenities_OnlyEmptyDocuments(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	// Create a YAML file that contains only document separators (no actual content)
+	emptyDocsYAML := "---\n---\n---\n"
+	if err := os.WriteFile(filepath.Join(tmpDir, "empty-docs.yaml"), []byte(emptyDocsYAML), 0600); err != nil {
+		t.Fatalf("failed to create empty-docs.yaml: %v", err)
+	}
+
+	manifestType := AmenityTypeKubernetesManifest
+	amenities := []Amenity{
+		{
+			Name: "empty-docs",
+			Type: &manifestType,
+			Properties: map[string]interface{}{
+				"manifests": []interface{}{
+					map[string]interface{}{"file": "empty-docs.yaml"},
+				},
+			},
+		},
+	}
+
+	// Process the amenities - should fail because file contains no valid YAML documents
+	_, err := ProcessManifestAmenities(amenities, tmpDir)
+	if err == nil {
+		t.Fatal("expected error for file with only empty YAML documents, got nil")
+	}
+
+	// Verify the error message is descriptive
+	expectedSubstring := "contains no valid YAML documents"
+	if !strings.Contains(err.Error(), expectedSubstring) {
+		t.Errorf("expected error to contain %q, got: %v", expectedSubstring, err)
 	}
 }
 

--- a/internal/model/manifest_amenity_test.go
+++ b/internal/model/manifest_amenity_test.go
@@ -382,6 +382,230 @@ func TestProcessManifestAmenities_InvalidYAML(t *testing.T) {
 	}
 }
 
+func TestProcessManifestAmenities_MultiDocumentYAML(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	// Create a multi-document YAML file with three documents
+	multiDocYAML := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-1
+  namespace: default
+data:
+  key1: value1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-2
+  namespace: default
+data:
+  key2: value2
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-1
+  namespace: default
+type: Opaque
+stringData:
+  password: s3cr3t`
+
+	manifestFile := filepath.Join(tmpDir, "multi-doc.yaml")
+	if err := os.WriteFile(manifestFile, []byte(multiDocYAML), 0600); err != nil {
+		t.Fatalf("failed to create multi-doc.yaml: %v", err)
+	}
+
+	// Create an amenity with a file reference to the multi-document file
+	manifestType := AmenityTypeKubernetesManifest
+	amenities := []Amenity{
+		{
+			Name: "multi-doc-manifests",
+			Type: &manifestType,
+			Properties: map[string]interface{}{
+				"manifests": []interface{}{
+					map[string]interface{}{"file": "multi-doc.yaml"},
+				},
+			},
+		},
+	}
+
+	// Process the amenities
+	result, err := ProcessManifestAmenities(amenities, tmpDir)
+	if err != nil {
+		t.Fatalf("ProcessManifestAmenities failed: %v", err)
+	}
+
+	// Verify the result
+	if len(result) != 1 {
+		t.Fatalf("expected 1 amenity, got %d", len(result))
+	}
+
+	props := result[0].Properties
+	manifests, ok := props["manifests"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("manifests property is not []map[string]interface{}")
+	}
+
+	// Should have 3 manifests from the 3 documents
+	if len(manifests) != 3 {
+		t.Fatalf("expected 3 manifests from multi-document file, got %d", len(manifests))
+	}
+
+	// Check each document was parsed correctly
+	expectedKinds := []string{"ConfigMap", "ConfigMap", "Secret"}
+	expectedNames := []string{"config-1", "config-2", "secret-1"}
+	for i, expectedKind := range expectedKinds {
+		def, ok := manifests[i]["def"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("manifest %d: def property is not a map[string]interface{}", i)
+		}
+		if def["kind"] != expectedKind {
+			t.Errorf("manifest %d: expected kind '%s', got '%v'", i, expectedKind, def["kind"])
+		}
+		metadata, ok := def["metadata"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("manifest %d: metadata is not a map[string]interface{}", i)
+		}
+		if metadata["name"] != expectedNames[i] {
+			t.Errorf("manifest %d: expected name '%s', got '%v'", i, expectedNames[i], metadata["name"])
+		}
+	}
+}
+
+func TestProcessManifestAmenities_MultiDocumentWithTrailingSeparator(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	// Multi-document YAML with a trailing '---' (empty final document)
+	multiDocYAML := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-1
+data:
+  key: value
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-2
+data:
+  key: value
+---
+`
+
+	manifestFile := filepath.Join(tmpDir, "trailing-sep.yaml")
+	if err := os.WriteFile(manifestFile, []byte(multiDocYAML), 0600); err != nil {
+		t.Fatalf("failed to create trailing-sep.yaml: %v", err)
+	}
+
+	manifestType := AmenityTypeKubernetesManifest
+	amenities := []Amenity{
+		{
+			Name: "trailing-separator",
+			Type: &manifestType,
+			Properties: map[string]interface{}{
+				"manifests": []interface{}{
+					map[string]interface{}{"file": "trailing-sep.yaml"},
+				},
+			},
+		},
+	}
+
+	// Process the amenities - should succeed, ignoring the empty trailing document
+	result, err := ProcessManifestAmenities(amenities, tmpDir)
+	if err != nil {
+		t.Fatalf("ProcessManifestAmenities failed: %v", err)
+	}
+
+	props := result[0].Properties
+	manifests, ok := props["manifests"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("manifests property is not []map[string]interface{}")
+	}
+
+	// Should only have 2 valid documents (trailing empty document is skipped)
+	if len(manifests) != 2 {
+		t.Fatalf("expected 2 manifests (empty trailing doc skipped), got %d", len(manifests))
+	}
+}
+
+func TestProcessManifestAmenities_MultiDocumentMixedWithInline(t *testing.T) {
+	// Create a temporary directory for test files
+	tmpDir := t.TempDir()
+
+	// Multi-document file
+	multiDocYAML := `apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-ns
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ns-config
+  namespace: my-ns
+data:
+  key: value`
+
+	manifestFile := filepath.Join(tmpDir, "multi.yaml")
+	if err := os.WriteFile(manifestFile, []byte(multiDocYAML), 0600); err != nil {
+		t.Fatalf("failed to create multi.yaml: %v", err)
+	}
+
+	// Create an amenity with both a multi-doc file and an inline def
+	manifestType := AmenityTypeKubernetesManifest
+	inlineDef := map[string]interface{}{
+		"apiVersion": "v1",
+		"kind":       "Secret",
+		"metadata": map[string]interface{}{
+			"name": "my-secret",
+		},
+	}
+	amenities := []Amenity{
+		{
+			Name: "mixed-multi-doc",
+			Type: &manifestType,
+			Properties: map[string]interface{}{
+				"manifests": []interface{}{
+					map[string]interface{}{"file": "multi.yaml"},
+					map[string]interface{}{"def": inlineDef},
+				},
+			},
+		},
+	}
+
+	// Process the amenities
+	result, err := ProcessManifestAmenities(amenities, tmpDir)
+	if err != nil {
+		t.Fatalf("ProcessManifestAmenities failed: %v", err)
+	}
+
+	props := result[0].Properties
+	manifests, ok := props["manifests"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("manifests property is not []map[string]interface{}")
+	}
+
+	// Should have 3 manifests: 2 from the multi-doc file + 1 inline
+	if len(manifests) != 3 {
+		t.Fatalf("expected 3 manifests (2 from file + 1 inline), got %d", len(manifests))
+	}
+
+	// Verify order: Namespace, ConfigMap (from file), then Secret (inline)
+	expectedKinds := []string{"Namespace", "ConfigMap", "Secret"}
+	for i, expectedKind := range expectedKinds {
+		def, ok := manifests[i]["def"].(map[string]interface{})
+		if !ok {
+			t.Fatalf("manifest %d: def property is not a map[string]interface{}", i)
+		}
+		if def["kind"] != expectedKind {
+			t.Errorf("manifest %d: expected kind '%s', got '%v'", i, expectedKind, def["kind"])
+		}
+	}
+}
+
 func TestManifestEntry_Validate(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Previously, manifest file references using yaml.Unmarshal only parsed the
first YAML document in a file. Files with multiple documents separated by
'---' would silently drop all but the first resource.

Switch to yaml.NewDecoder to iterate over all documents in the file,
producing one ManifestEntry per document. Empty documents (e.g. from a
trailing '---') are skipped gracefully.

processManifestEntry now returns []ManifestEntry and the caller flattens
the results, so a single file entry can expand into multiple inline defs
sent to the API.