### PR TITLE
Add snapshot list filters

### DIFF
--- a/cmd/snapshot/list.go
+++ b/cmd/snapshot/list.go
@@ -2,6 +2,7 @@ package snapshot
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
@@ -14,6 +15,10 @@ import (
 const (
 	listExample = `# List all snapshots for a service environment
 omnistrate-ctl snapshot list --service-id service-abcd --environment-id env-1234`
+
+	snapshotTypeManual    = "ManualSnapshot"
+	snapshotTypeAutomated = "AutomatedSnapshot"
+	snapshotTypeAll       = "all"
 )
 
 var listCmd = &cobra.Command{
@@ -29,6 +34,8 @@ func init() {
 	listCmd.Args = cobra.NoArgs
 	listCmd.Flags().String("service-id", "", "The ID of the service (required)")
 	listCmd.Flags().String("environment-id", "", "The ID of the environment (required)")
+	listCmd.Flags().String("snapshot-type", snapshotTypeManual, "Filter by snapshot type: ManualSnapshot, AutomatedSnapshot, or all")
+	listCmd.Flags().String("product-tier-id", "", "Filter snapshots by product tier ID")
 
 	if err := listCmd.MarkFlagRequired("service-id"); err != nil {
 		return
@@ -69,6 +76,23 @@ func runList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	snapshotType, err := cmd.Flags().GetString("snapshot-type")
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+	snapshotType, err = normalizeSnapshotType(snapshotType)
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	productTierID, err := cmd.Flags().GetString("product-tier-id")
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
 	output, err := cmd.Flags().GetString("output")
 	if err != nil {
 		utils.PrintError(err)
@@ -89,7 +113,10 @@ func runList(cmd *cobra.Command, args []string) error {
 		sm.Start()
 	}
 
-	result, err := dataaccess.ListAllSnapshots(cmd.Context(), token, serviceID, environmentID)
+	result, err := dataaccess.ListAllSnapshots(cmd.Context(), token, serviceID, environmentID, dataaccess.ListAllSnapshotsOptions{
+		ProductTierID: productTierID,
+		SnapshotType:  snapshotType,
+	})
 	if err != nil {
 		utils.HandleSpinnerError(spinner, sm, err)
 		return err
@@ -137,4 +164,17 @@ func formatSnapshotDisplayTime(raw string) string {
 	}
 
 	return parsed.UTC().Format(snapshotDisplayTimeLayout)
+}
+
+func normalizeSnapshotType(raw string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", strings.ToLower(snapshotTypeManual), "manual":
+		return snapshotTypeManual, nil
+	case strings.ToLower(snapshotTypeAutomated), "automated":
+		return snapshotTypeAutomated, nil
+	case snapshotTypeAll:
+		return "", nil
+	default:
+		return "", fmt.Errorf("invalid snapshot type %q (supported: ManualSnapshot, AutomatedSnapshot, all)", raw)
+	}
 }

--- a/cmd/snapshot/snapshot_test.go
+++ b/cmd/snapshot/snapshot_test.go
@@ -52,6 +52,45 @@ func TestListCommandFlags(t *testing.T) {
 
 	environmentIDFlag := listCmd.Flags().Lookup("environment-id")
 	require.NotNil(environmentIDFlag, "Expected flag 'environment-id' not found")
+
+	snapshotTypeFlag := listCmd.Flags().Lookup("snapshot-type")
+	require.NotNil(snapshotTypeFlag, "Expected flag 'snapshot-type' not found")
+	require.Equal("ManualSnapshot", snapshotTypeFlag.DefValue)
+
+	productTierIDFlag := listCmd.Flags().Lookup("product-tier-id")
+	require.NotNil(productTierIDFlag, "Expected flag 'product-tier-id' not found")
+}
+
+func TestNormalizeSnapshotType(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expected      string
+		expectError   bool
+		errorContains string
+	}{
+		{"empty defaults to manual", "", "ManualSnapshot", false, ""},
+		{"manual exact", "ManualSnapshot", "ManualSnapshot", false, ""},
+		{"manual shorthand", "manual", "ManualSnapshot", false, ""},
+		{"automated exact", "AutomatedSnapshot", "AutomatedSnapshot", false, ""},
+		{"automated shorthand", "automated", "AutomatedSnapshot", false, ""},
+		{"all disables snapshot type filter", "all", "", false, ""},
+		{"invalid snapshot type", "FinalSnapshot", "", true, "invalid snapshot type"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := normalizeSnapshotType(tt.input)
+			if tt.expectError {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorContains)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
 }
 
 func TestRestoreCommandFlags(t *testing.T) {

--- a/internal/dataaccess/snapshot.go
+++ b/internal/dataaccess/snapshot.go
@@ -85,8 +85,14 @@ func CreateInstanceSnapshot(ctx context.Context, token, serviceID, environmentID
 	return
 }
 
-// ListAllSnapshots lists all snapshots for a service environment (no instance ID required).
-func ListAllSnapshots(ctx context.Context, token, serviceID, environmentID string) (res *openapiclientfleet.FleetListInstanceSnapshotResult, err error) {
+// ListAllSnapshotsOptions controls optional filters for service environment snapshot listing.
+type ListAllSnapshotsOptions struct {
+	ProductTierID string
+	SnapshotType  string
+}
+
+// ListAllSnapshots lists snapshots for a service environment (no instance ID required).
+func ListAllSnapshots(ctx context.Context, token, serviceID, environmentID string, opts ListAllSnapshotsOptions) (res *openapiclientfleet.FleetListInstanceSnapshotResult, err error) {
 	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
 	apiClient := getFleetClient()
 
@@ -95,6 +101,12 @@ func ListAllSnapshots(ctx context.Context, token, serviceID, environmentID strin
 		serviceID,
 		environmentID,
 	)
+	if opts.ProductTierID != "" {
+		req = req.ProductTierId(opts.ProductTierID)
+	}
+	if opts.SnapshotType != "" {
+		req = req.SnapshotType(opts.SnapshotType)
+	}
 
 	var r *http.Response
 	defer func() {

--- a/internal/dataaccess/snapshot_test.go
+++ b/internal/dataaccess/snapshot_test.go
@@ -83,6 +83,6 @@ func TestListAllSnapshotsOmitsEmptyFilters(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, result)
-	assert.Empty(t, capturedQuery.Get("productTierId"))
-	assert.Empty(t, capturedQuery.Get("snapshotType"))
+	assert.NotContains(t, capturedQuery, "productTierId")
+	assert.NotContains(t, capturedQuery, "snapshotType")
 }

--- a/internal/dataaccess/snapshot_test.go
+++ b/internal/dataaccess/snapshot_test.go
@@ -1,0 +1,88 @@
+package dataaccess
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListAllSnapshotsAppliesFilters(t *testing.T) {
+	var capturedMethod string
+	var capturedPath string
+	var capturedAuth string
+	var capturedQuery url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		capturedAuth = r.Header.Get("Authorization")
+		capturedQuery = r.URL.Query()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"snapshots":[]}`))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	t.Setenv("OMNISTRATE_HOST", serverURL.Host)
+	t.Setenv("OMNISTRATE_HOST_SCHEME", serverURL.Scheme)
+	t.Setenv("CLIENT_TIMEOUT_IN_SECONDS", "5")
+
+	result, err := ListAllSnapshots(
+		context.Background(),
+		"test-token",
+		"s-123",
+		"env-123",
+		ListAllSnapshotsOptions{
+			ProductTierID: "pt-123",
+			SnapshotType:  "ManualSnapshot",
+		},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, http.MethodGet, capturedMethod)
+	assert.Equal(t, "/2022-09-01-00/fleet/service/s-123/environment/env-123/snapshot", capturedPath)
+	assert.Equal(t, "Bearer test-token", capturedAuth)
+	assert.Equal(t, "pt-123", capturedQuery.Get("productTierId"))
+	assert.Equal(t, "ManualSnapshot", capturedQuery.Get("snapshotType"))
+}
+
+func TestListAllSnapshotsOmitsEmptyFilters(t *testing.T) {
+	var capturedQuery url.Values
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedQuery = r.URL.Query()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"snapshots":[]}`))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	t.Setenv("OMNISTRATE_HOST", serverURL.Host)
+	t.Setenv("OMNISTRATE_HOST_SCHEME", serverURL.Scheme)
+	t.Setenv("CLIENT_TIMEOUT_IN_SECONDS", "5")
+
+	result, err := ListAllSnapshots(
+		context.Background(),
+		"test-token",
+		"s-123",
+		"env-123",
+		ListAllSnapshotsOptions{},
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, capturedQuery.Get("productTierId"))
+	assert.Empty(t, capturedQuery.Get("snapshotType"))
+}

--- a/mkdocs/docs/omnistrate-ctl_snapshot_list.md
+++ b/mkdocs/docs/omnistrate-ctl_snapshot_list.md
@@ -20,9 +20,11 @@ omnistrate-ctl snapshot list --service-id service-abcd --environment-id env-1234
 ### Options
 
 ```
-      --environment-id string   The ID of the environment (required)
-  -h, --help                    help for list
-      --service-id string       The ID of the service (required)
+      --environment-id string    The ID of the environment (required)
+  -h, --help                     help for list
+      --product-tier-id string   Filter snapshots by product tier ID
+      --service-id string        The ID of the service (required)
+      --snapshot-type string     Filter by snapshot type: ManualSnapshot, AutomatedSnapshot, or all (default "ManualSnapshot")
 ```
 
 ### Options inherited from parent commands

--- a/test/integration_test/dataaccess/snapshot_test.go
+++ b/test/integration_test/dataaccess/snapshot_test.go
@@ -1,0 +1,42 @@
+package dataaccess
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/test/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListAllSnapshotsWithOptions(t *testing.T) {
+	testutils.IntegrationTest(t)
+
+	serviceID := os.Getenv("SNAPSHOT_LIST_TEST_SERVICE_ID")
+	environmentID := os.Getenv("SNAPSHOT_LIST_TEST_ENVIRONMENT_ID")
+	productTierID := os.Getenv("SNAPSHOT_LIST_TEST_PRODUCT_TIER_ID")
+	if serviceID == "" || environmentID == "" || productTierID == "" {
+		t.Skip("set SNAPSHOT_LIST_TEST_SERVICE_ID, SNAPSHOT_LIST_TEST_ENVIRONMENT_ID, and SNAPSHOT_LIST_TEST_PRODUCT_TIER_ID")
+	}
+
+	ctx := context.TODO()
+	testEmail, testPassword, err := testutils.GetTestAccount()
+	require.NoError(t, err)
+
+	login, err := dataaccess.LoginWithPassword(ctx, testEmail, testPassword)
+	require.NoError(t, err)
+	require.NotEmpty(t, login.JWTToken)
+
+	result, err := dataaccess.ListAllSnapshots(ctx, login.JWTToken, serviceID, environmentID, dataaccess.ListAllSnapshotsOptions{
+		ProductTierID: productTierID,
+		SnapshotType:  "ManualSnapshot",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	for _, snapshot := range result.Snapshots {
+		require.Equal(t, "ManualSnapshot", snapshot.GetSnapshotType())
+		require.Equal(t, productTierID, snapshot.GetProductTierId())
+	}
+}

--- a/test/smoke_test/snapshot/snapshot_test.go
+++ b/test/smoke_test/snapshot/snapshot_test.go
@@ -33,9 +33,22 @@ func TestSnapshotListEmpty(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, build.ServiceID)
 	require.NotEmpty(t, build.EnvironmentID)
+	require.NotEmpty(t, build.ProductTierID)
 
 	// List snapshots — should succeed with empty results
 	cmd.RootCmd.SetArgs([]string{"snapshot", "list", "--service-id", build.ServiceID, "--environment-id", build.EnvironmentID, "--output", "json"})
+	err = cmd.RootCmd.ExecuteContext(ctx)
+	require.NoError(t, err)
+
+	// List all snapshot types with a product tier filter — should also succeed with empty results
+	cmd.RootCmd.SetArgs([]string{
+		"snapshot", "list",
+		"--service-id", build.ServiceID,
+		"--environment-id", build.EnvironmentID,
+		"--snapshot-type", "all",
+		"--product-tier-id", build.ProductTierID,
+		"--output", "json",
+	})
 	err = cmd.RootCmd.ExecuteContext(ctx)
 	require.NoError(t, err)
 


### PR DESCRIPTION
This pull request enhances the snapshot listing functionality by adding new filtering options and improving test coverage. The most significant changes are the introduction of `--snapshot-type` and `--product-tier-id` filters to the `snapshot list` command, along with robust validation and testing for these features.

### Command-line interface improvements
* Added `--snapshot-type` and `--product-tier-id` flags to the `snapshot list` command, allowing users to filter snapshots by type (ManualSnapshot, AutomatedSnapshot, or all) and product tier ID. The default snapshot type is now `ManualSnapshot`. [[1]](diffhunk://#diff-70b92caaeb962fdbcbf730d9cd96ac1f982bb282b0b8144af01877f47e874490R18-R21) [[2]](diffhunk://#diff-70b92caaeb962fdbcbf730d9cd96ac1f982bb282b0b8144af01877f47e874490R37-R38) [[3]](diffhunk://#diff-70b92caaeb962fdbcbf730d9cd96ac1f982bb282b0b8144af01877f47e874490R79-R95) [[4]](diffhunk://#diff-70b92caaeb962fdbcbf730d9cd96ac1f982bb282b0b8144af01877f47e874490L92-R119) [[5]](diffhunk://#diff-de0bdcfa9de816e7888d0ae772ad7a998393c63428d4c614d5fab811d1df340cR25-R27)

### Input validation and normalization
* Implemented the `normalizeSnapshotType` function to handle different user inputs for snapshot type, supporting shorthands and validating values.
* Added comprehensive unit tests for `normalizeSnapshotType` to ensure correct behavior and error handling.

### Data access and backend integration
* Updated the `ListAllSnapshots` function in `dataaccess` to accept a new `ListAllSnapshotsOptions` struct, applying the new filters to API requests only when provided. [[1]](diffhunk://#diff-4bda56fb3afbae181a37447c0cac5b19ba181c5bed105cf7ffda70d6ad07ab2cL88-R95) [[2]](diffhunk://#diff-4bda56fb3afbae181a37447c0cac5b19ba181c5bed105cf7ffda70d6ad07ab2cR104-R109)

### Test coverage
* Added end-to-end tests for the `ListAllSnapshots` function to verify that filters are correctly applied to outgoing API requests and omitted when empty.