### PR TITLE
Add restore target subscription flags

### DIFF
--- a/cmd/snapshot/restore.go
+++ b/cmd/snapshot/restore.go
@@ -19,7 +19,7 @@ omnistrate-ctl snapshot restore --service-id service-abcd --environment-id env-1
 )
 
 var restoreCmd = &cobra.Command{
-	Use:          "restore --service-id <service-id> --environment-id <environment-id> --snapshot-id <snapshot-id> [--restore-to-source]",
+	Use:          "restore --service-id <service-id> --environment-id <environment-id> --snapshot-id <snapshot-id> [--subscription-id <subscription-id>] [--restore-to-source]",
 	Short:        "Create an instance by restoring from a snapshot",
 	Long:         `This command helps you create an instance by restoring from a snapshot.`,
 	Example:      restoreExample,
@@ -36,6 +36,8 @@ func init() {
 	restoreCmd.Flags().String("param-file", "", "Json file containing parameters override for the instance deployment")
 	restoreCmd.Flags().String("tierversion-override", "", "Override the tier version for the restored instance")
 	restoreCmd.Flags().String("network-type", "", "Optional network type change for the instance deployment (PUBLIC / INTERNAL)")
+	restoreCmd.Flags().String("custom-network-id", "", "Optional custom network ID for the restored instance")
+	restoreCmd.Flags().String("subscription-id", "", "Optional target subscription ID for the restored instance")
 	restoreCmd.Flags().Bool("restore-to-source", false, "Restore to the original source instance, preserving its ID and endpoint")
 
 	if err := restoreCmd.MarkFlagRequired("service-id"); err != nil {
@@ -125,6 +127,18 @@ func runRestore(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	customNetworkID, err := cmd.Flags().GetString("custom-network-id")
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
+	subscriptionID, err := cmd.Flags().GetString("subscription-id")
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+
 	restoreToSource, err := cmd.Flags().GetBool("restore-to-source")
 	if err != nil {
 		utils.PrintError(err)
@@ -141,7 +155,7 @@ func runRestore(cmd *cobra.Command, args []string) error {
 		sm.Start()
 	}
 
-	result, err := dataaccess.RestoreSnapshot(cmd.Context(), token, serviceID, environmentID, snapshotID, formattedParams, tierVersionOverride, networkType, restoreToSource)
+	result, err := dataaccess.RestoreSnapshot(cmd.Context(), token, serviceID, environmentID, snapshotID, formattedParams, tierVersionOverride, networkType, customNetworkID, subscriptionID, restoreToSource)
 	if err != nil {
 		utils.HandleSpinnerError(spinner, sm, err)
 		return err

--- a/cmd/snapshot/restore.go
+++ b/cmd/snapshot/restore.go
@@ -19,7 +19,7 @@ omnistrate-ctl snapshot restore --service-id service-abcd --environment-id env-1
 )
 
 var restoreCmd = &cobra.Command{
-	Use:          "restore --service-id <service-id> --environment-id <environment-id> --snapshot-id <snapshot-id> [--subscription-id <subscription-id>] [--restore-to-source]",
+	Use:          "restore --service-id <service-id> --environment-id <environment-id> --snapshot-id <snapshot-id> [--custom-network-id <custom-network-id>] [--subscription-id <subscription-id>] [--restore-to-source]",
 	Short:        "Create an instance by restoring from a snapshot",
 	Long:         `This command helps you create an instance by restoring from a snapshot.`,
 	Example:      restoreExample,
@@ -155,7 +155,14 @@ func runRestore(cmd *cobra.Command, args []string) error {
 		sm.Start()
 	}
 
-	result, err := dataaccess.RestoreSnapshot(cmd.Context(), token, serviceID, environmentID, snapshotID, formattedParams, tierVersionOverride, networkType, customNetworkID, subscriptionID, restoreToSource)
+	result, err := dataaccess.RestoreSnapshot(cmd.Context(), token, serviceID, environmentID, snapshotID, dataaccess.RestoreSnapshotOptions{
+		InputParametersOverride:    formattedParams,
+		ProductTierVersionOverride: tierVersionOverride,
+		NetworkType:                networkType,
+		CustomNetworkID:            customNetworkID,
+		SubscriptionID:             subscriptionID,
+		RestoreToSource:            restoreToSource,
+	})
 	if err != nil {
 		utils.HandleSpinnerError(spinner, sm, err)
 		return err

--- a/cmd/snapshot/snapshot_test.go
+++ b/cmd/snapshot/snapshot_test.go
@@ -128,24 +128,3 @@ func TestRestoreCommandUse_IncludesSubscriptionID(t *testing.T) {
 func TestRestoreCommandUse_IncludesCustomNetworkID(t *testing.T) {
 	assert.Contains(t, restoreCmd.Use, "--custom-network-id")
 }
-
-func TestFormatSnapshotDisplayTime(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{"valid RFC3339", "2024-01-15T10:30:00Z", "2024-01-15 10:30:00 UTC"},
-		{"empty string", "", ""},
-		{"invalid format returns raw", "not-a-date", "not-a-date"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := formatSnapshotDisplayTime(tt.input)
-			if result != tt.expected {
-				t.Errorf("expected %q, got %q", tt.expected, result)
-			}
-		})
-	}
-}

--- a/cmd/snapshot/snapshot_test.go
+++ b/cmd/snapshot/snapshot_test.go
@@ -125,6 +125,10 @@ func TestRestoreCommandUse_IncludesSubscriptionID(t *testing.T) {
 	assert.Contains(t, restoreCmd.Use, "--subscription-id")
 }
 
+func TestRestoreCommandUse_IncludesCustomNetworkID(t *testing.T) {
+	assert.Contains(t, restoreCmd.Use, "--custom-network-id")
+}
+
 func TestFormatSnapshotDisplayTime(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/cmd/snapshot/snapshot_test.go
+++ b/cmd/snapshot/snapshot_test.go
@@ -99,7 +99,7 @@ func TestRestoreCommandFlags(t *testing.T) {
 	require.Contains(restoreCmd.Use, "restore")
 	require.NotEmpty(restoreCmd.Example)
 
-	flags := []string{"service-id", "environment-id", "snapshot-id", "param", "param-file", "tierversion-override", "network-type", "restore-to-source"}
+	flags := []string{"service-id", "environment-id", "snapshot-id", "param", "param-file", "tierversion-override", "network-type", "custom-network-id", "subscription-id", "restore-to-source"}
 	for _, flagName := range flags {
 		flag := restoreCmd.Flags().Lookup(flagName)
 		require.NotNil(flag, "Expected flag '%s' not found", flagName)
@@ -119,6 +119,10 @@ func TestRestoreCommandHelpText(t *testing.T) {
 
 func TestRestoreCommandUse_IncludesRestoreToSource(t *testing.T) {
 	assert.Contains(t, restoreCmd.Use, "--restore-to-source")
+}
+
+func TestRestoreCommandUse_IncludesSubscriptionID(t *testing.T) {
+	assert.Contains(t, restoreCmd.Use, "--subscription-id")
 }
 
 func TestFormatSnapshotDisplayTime(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/muesli/cancelreader v0.2.2
 	github.com/njayp/ophis v1.1.4
-	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.118
+	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.119
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/njayp/ophis v1.1.4 h1:6aq3UdU6MlGIjpg//IzKc2yIxHYMf6Rg1A5MLovM9gg=
 github.com/njayp/ophis v1.1.4/go.mod h1:F9KEnfeCJzCWo3e0JP2QqSCN04bXptXl1ico5lcLeYg=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.118 h1:Nhvn/DAWds1f5FnNsg2RrezG0IPL8NfLj0eWdt71FqY=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.118/go.mod h1:q0FPYLbtm+Aw6GW0xbeaMPHR4WGzoV61iTGFoOhO72M=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.119 h1:f7d1YEtXNbZb5eqEaO3G8VQgG6Nv9p7QpN3D5YXiaB0=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.119/go.mod h1:q0FPYLbtm+Aw6GW0xbeaMPHR4WGzoV61iTGFoOhO72M=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=

--- a/internal/dataaccess/snapshot.go
+++ b/internal/dataaccess/snapshot.go
@@ -149,7 +149,7 @@ func DeleteSnapshot(ctx context.Context, token, serviceID, environmentID, snapsh
 }
 
 // RestoreSnapshot restores a snapshot either to a new instance or, when restoreToSource is true, to the original source instance.
-func RestoreSnapshot(ctx context.Context, token, serviceID, environmentID, snapshotID string, formattedParams map[string]any, tierVersionOverride string, networkType string, restoreToSource bool) (res *openapiclientfleet.FleetRestoreResourceInstanceResult, err error) {
+func RestoreSnapshot(ctx context.Context, token, serviceID, environmentID, snapshotID string, formattedParams map[string]any, tierVersionOverride string, networkType string, customNetworkID string, subscriptionID string, restoreToSource bool) (res *openapiclientfleet.FleetRestoreResourceInstanceResult, err error) {
 	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
 	apiClient := getFleetClient()
 
@@ -164,6 +164,16 @@ func RestoreSnapshot(ctx context.Context, token, serviceID, environmentID, snaps
 
 	if tierVersionOverride != "" {
 		reqBody.ProductTierVersionOverride = &tierVersionOverride
+	}
+
+	if customNetworkID != "" {
+		reqBody.CustomNetworkId = &customNetworkID
+	}
+
+	if subscriptionID != "" {
+		reqBody.AdditionalProperties = map[string]interface{}{
+			"subscriptionId": subscriptionID,
+		}
 	}
 
 	if restoreToSource {

--- a/internal/dataaccess/snapshot.go
+++ b/internal/dataaccess/snapshot.go
@@ -156,7 +156,6 @@ type RestoreSnapshotOptions struct {
 	CustomNetworkID            string
 	SubscriptionID             string
 	RestoreToSource            bool
-	AdditionalProperties       map[string]any
 }
 
 // RestoreSnapshot restores a snapshot either to a new instance or, when RestoreToSource is true, to the original source instance.
@@ -169,36 +168,8 @@ func RestoreSnapshot(ctx context.Context, token, serviceID, environmentID, snaps
 		networkType = "PUBLIC"
 	}
 
-	reqBody := openapiclientfleet.FleetRestoreResourceInstanceFromSnapshotRequest2{
-		InputParametersOverride: opts.InputParametersOverride,
-		NetworkType:             utils.ToPtr(networkType),
-	}
-
-	if opts.ProductTierVersionOverride != "" {
-		reqBody.ProductTierVersionOverride = &opts.ProductTierVersionOverride
-	}
-
-	if opts.CustomNetworkID != "" {
-		reqBody.CustomNetworkId = &opts.CustomNetworkID
-	}
-
-	if len(opts.AdditionalProperties) > 0 {
-		reqBody.AdditionalProperties = make(map[string]interface{}, len(opts.AdditionalProperties)+1)
-		for key, value := range opts.AdditionalProperties {
-			reqBody.AdditionalProperties[key] = value
-		}
-	}
-
-	if opts.SubscriptionID != "" {
-		if reqBody.AdditionalProperties == nil {
-			reqBody.AdditionalProperties = make(map[string]interface{}, 1)
-		}
-		reqBody.AdditionalProperties["subscriptionId"] = opts.SubscriptionID
-	}
-
-	if opts.RestoreToSource {
-		reqBody.RestoreToSourceInstance = utils.ToPtr(true)
-	}
+	reqBody := buildRestoreSnapshotRequestBody(opts)
+	reqBody.NetworkType = utils.ToPtr(networkType)
 
 	req := apiClient.InventoryApiAPI.InventoryApiRestoreResourceInstanceFromSnapshot(
 		ctxWithToken,
@@ -219,4 +190,28 @@ func RestoreSnapshot(ctx context.Context, token, serviceID, environmentID, snaps
 		return nil, handleFleetError(err)
 	}
 	return
+}
+
+func buildRestoreSnapshotRequestBody(opts RestoreSnapshotOptions) openapiclientfleet.FleetRestoreResourceInstanceFromSnapshotRequest2 {
+	reqBody := openapiclientfleet.FleetRestoreResourceInstanceFromSnapshotRequest2{
+		InputParametersOverride: opts.InputParametersOverride,
+	}
+
+	if opts.ProductTierVersionOverride != "" {
+		reqBody.ProductTierVersionOverride = &opts.ProductTierVersionOverride
+	}
+
+	if opts.CustomNetworkID != "" {
+		reqBody.CustomNetworkId = &opts.CustomNetworkID
+	}
+
+	if opts.SubscriptionID != "" {
+		reqBody.SubscriptionId = &opts.SubscriptionID
+	}
+
+	if opts.RestoreToSource {
+		reqBody.RestoreToSourceInstance = utils.ToPtr(true)
+	}
+
+	return reqBody
 }

--- a/internal/dataaccess/snapshot.go
+++ b/internal/dataaccess/snapshot.go
@@ -148,35 +148,55 @@ func DeleteSnapshot(ctx context.Context, token, serviceID, environmentID, snapsh
 	return
 }
 
-// RestoreSnapshot restores a snapshot either to a new instance or, when restoreToSource is true, to the original source instance.
-func RestoreSnapshot(ctx context.Context, token, serviceID, environmentID, snapshotID string, formattedParams map[string]any, tierVersionOverride string, networkType string, customNetworkID string, subscriptionID string, restoreToSource bool) (res *openapiclientfleet.FleetRestoreResourceInstanceResult, err error) {
+// RestoreSnapshotOptions controls optional restore behavior.
+type RestoreSnapshotOptions struct {
+	InputParametersOverride    map[string]any
+	ProductTierVersionOverride string
+	NetworkType                string
+	CustomNetworkID            string
+	SubscriptionID             string
+	RestoreToSource            bool
+	AdditionalProperties       map[string]any
+}
+
+// RestoreSnapshot restores a snapshot either to a new instance or, when RestoreToSource is true, to the original source instance.
+func RestoreSnapshot(ctx context.Context, token, serviceID, environmentID, snapshotID string, opts RestoreSnapshotOptions) (res *openapiclientfleet.FleetRestoreResourceInstanceResult, err error) {
 	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
 	apiClient := getFleetClient()
 
+	networkType := opts.NetworkType
 	if networkType == "" {
 		networkType = "PUBLIC"
 	}
 
 	reqBody := openapiclientfleet.FleetRestoreResourceInstanceFromSnapshotRequest2{
-		InputParametersOverride: formattedParams,
+		InputParametersOverride: opts.InputParametersOverride,
 		NetworkType:             utils.ToPtr(networkType),
 	}
 
-	if tierVersionOverride != "" {
-		reqBody.ProductTierVersionOverride = &tierVersionOverride
+	if opts.ProductTierVersionOverride != "" {
+		reqBody.ProductTierVersionOverride = &opts.ProductTierVersionOverride
 	}
 
-	if customNetworkID != "" {
-		reqBody.CustomNetworkId = &customNetworkID
+	if opts.CustomNetworkID != "" {
+		reqBody.CustomNetworkId = &opts.CustomNetworkID
 	}
 
-	if subscriptionID != "" {
-		reqBody.AdditionalProperties = map[string]interface{}{
-			"subscriptionId": subscriptionID,
+	if len(opts.AdditionalProperties) > 0 {
+		reqBody.AdditionalProperties = make(map[string]interface{}, len(opts.AdditionalProperties)+1)
+		for key, value := range opts.AdditionalProperties {
+			reqBody.AdditionalProperties[key] = value
 		}
 	}
 
-	if restoreToSource {
+	if opts.SubscriptionID != "" {
+		if reqBody.AdditionalProperties == nil {
+			reqBody.AdditionalProperties = make(map[string]interface{}, 1)
+		}
+		reqBody.AdditionalProperties["subscriptionId"] = opts.SubscriptionID
+	}
+
+	if opts.RestoreToSource {
 		reqBody.RestoreToSourceInstance = utils.ToPtr(true)
 	}
 

--- a/internal/dataaccess/snapshot_test.go
+++ b/internal/dataaccess/snapshot_test.go
@@ -118,12 +118,16 @@ func TestRestoreSnapshotSendsSubscriptionAndCustomNetwork(t *testing.T) {
 		"s-123",
 		"env-123",
 		"instance-ss-123",
-		map[string]any{"size": "large"},
-		"2.0",
-		"INTERNAL",
-		"cn-123",
-		"sub-target",
-		false,
+		RestoreSnapshotOptions{
+			InputParametersOverride:    map[string]any{"size": "large"},
+			ProductTierVersionOverride: "2.0",
+			NetworkType:                "INTERNAL",
+			CustomNetworkID:            "cn-123",
+			SubscriptionID:             "sub-target",
+			AdditionalProperties: map[string]any{
+				"requestSource": "unit-test",
+			},
+		},
 	)
 
 	require.NoError(t, err)
@@ -136,6 +140,7 @@ func TestRestoreSnapshotSendsSubscriptionAndCustomNetwork(t *testing.T) {
 	assert.Equal(t, "cn-123", capturedBody["custom_network_id"])
 	assert.Equal(t, "INTERNAL", capturedBody["network_type"])
 	assert.Equal(t, "2.0", capturedBody["productTierVersionOverride"])
+	assert.Equal(t, "unit-test", capturedBody["requestSource"])
 	assert.Equal(t, map[string]any{"size": "large"}, capturedBody["inputParametersOverride"])
 	assert.NotContains(t, capturedBody, "restoreToSourceInstance")
 }

--- a/internal/dataaccess/snapshot_test.go
+++ b/internal/dataaccess/snapshot_test.go
@@ -124,9 +124,6 @@ func TestRestoreSnapshotSendsSubscriptionAndCustomNetwork(t *testing.T) {
 			NetworkType:                "INTERNAL",
 			CustomNetworkID:            "cn-123",
 			SubscriptionID:             "sub-target",
-			AdditionalProperties: map[string]any{
-				"requestSource": "unit-test",
-			},
 		},
 	)
 
@@ -140,7 +137,16 @@ func TestRestoreSnapshotSendsSubscriptionAndCustomNetwork(t *testing.T) {
 	assert.Equal(t, "cn-123", capturedBody["custom_network_id"])
 	assert.Equal(t, "INTERNAL", capturedBody["network_type"])
 	assert.Equal(t, "2.0", capturedBody["productTierVersionOverride"])
-	assert.Equal(t, "unit-test", capturedBody["requestSource"])
 	assert.Equal(t, map[string]any{"size": "large"}, capturedBody["inputParametersOverride"])
 	assert.NotContains(t, capturedBody, "restoreToSourceInstance")
+}
+
+func TestBuildRestoreSnapshotRequestBodyUsesTypedSubscriptionID(t *testing.T) {
+	reqBody := buildRestoreSnapshotRequestBody(RestoreSnapshotOptions{
+		SubscriptionID: "sub-target",
+	})
+
+	require.NotNil(t, reqBody.SubscriptionId)
+	assert.Equal(t, "sub-target", *reqBody.SubscriptionId)
+	assert.Nil(t, reqBody.AdditionalProperties)
 }

--- a/internal/dataaccess/snapshot_test.go
+++ b/internal/dataaccess/snapshot_test.go
@@ -2,6 +2,7 @@ package dataaccess
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -85,4 +86,56 @@ func TestListAllSnapshotsOmitsEmptyFilters(t *testing.T) {
 	require.NotNil(t, result)
 	assert.NotContains(t, capturedQuery, "productTierId")
 	assert.NotContains(t, capturedQuery, "snapshotType")
+}
+
+func TestRestoreSnapshotSendsSubscriptionAndCustomNetwork(t *testing.T) {
+	var capturedMethod string
+	var capturedPath string
+	var capturedAuth string
+	var capturedBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		capturedAuth = r.Header.Get("Authorization")
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"instance-restored"}`))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	t.Setenv("OMNISTRATE_HOST", serverURL.Host)
+	t.Setenv("OMNISTRATE_HOST_SCHEME", serverURL.Scheme)
+	t.Setenv("CLIENT_TIMEOUT_IN_SECONDS", "5")
+
+	result, err := RestoreSnapshot(
+		context.Background(),
+		"test-token",
+		"s-123",
+		"env-123",
+		"instance-ss-123",
+		map[string]any{"size": "large"},
+		"2.0",
+		"INTERNAL",
+		"cn-123",
+		"sub-target",
+		false,
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "instance-restored", result.GetId())
+	assert.Equal(t, http.MethodPost, capturedMethod)
+	assert.Equal(t, "/2022-09-01-00/fleet/service/s-123/environment/env-123/snapshot/instance-ss-123/restore", capturedPath)
+	assert.Equal(t, "Bearer test-token", capturedAuth)
+	assert.Equal(t, "sub-target", capturedBody["subscriptionId"])
+	assert.Equal(t, "cn-123", capturedBody["custom_network_id"])
+	assert.Equal(t, "INTERNAL", capturedBody["network_type"])
+	assert.Equal(t, "2.0", capturedBody["productTierVersionOverride"])
+	assert.Equal(t, map[string]any{"size": "large"}, capturedBody["inputParametersOverride"])
+	assert.NotContains(t, capturedBody, "restoreToSourceInstance")
 }

--- a/mkdocs/docs/omnistrate-ctl_snapshot_restore.md
+++ b/mkdocs/docs/omnistrate-ctl_snapshot_restore.md
@@ -7,7 +7,7 @@ Create an instance by restoring from a snapshot
 This command helps you create an instance by restoring from a snapshot.
 
 ```
-omnistrate-ctl snapshot restore --service-id <service-id> --environment-id <environment-id> --snapshot-id <snapshot-id> [--subscription-id <subscription-id>] [--restore-to-source] [flags]
+omnistrate-ctl snapshot restore --service-id <service-id> --environment-id <environment-id> --snapshot-id <snapshot-id> [--custom-network-id <custom-network-id>] [--subscription-id <subscription-id>] [--restore-to-source] [flags]
 ```
 
 ### Examples

--- a/mkdocs/docs/omnistrate-ctl_snapshot_restore.md
+++ b/mkdocs/docs/omnistrate-ctl_snapshot_restore.md
@@ -7,7 +7,7 @@ Create an instance by restoring from a snapshot
 This command helps you create an instance by restoring from a snapshot.
 
 ```
-omnistrate-ctl snapshot restore --service-id <service-id> --environment-id <environment-id> --snapshot-id <snapshot-id> [--restore-to-source] [flags]
+omnistrate-ctl snapshot restore --service-id <service-id> --environment-id <environment-id> --snapshot-id <snapshot-id> [--subscription-id <subscription-id>] [--restore-to-source] [flags]
 ```
 
 ### Examples
@@ -23,6 +23,7 @@ omnistrate-ctl snapshot restore --service-id service-abcd --environment-id env-1
 ### Options
 
 ```
+      --custom-network-id string      Optional custom network ID for the restored instance
       --environment-id string         The ID of the environment (required)
   -h, --help                          help for restore
       --network-type string           Optional network type change for the instance deployment (PUBLIC / INTERNAL)
@@ -31,6 +32,7 @@ omnistrate-ctl snapshot restore --service-id service-abcd --environment-id env-1
       --restore-to-source             Restore to the original source instance, preserving its ID and endpoint
       --service-id string             The ID of the service (required)
       --snapshot-id string            The ID of the snapshot to restore from (required)
+      --subscription-id string        Optional target subscription ID for the restored instance
       --tierversion-override string   Override the tier version for the restored instance
 ```
 
@@ -44,4 +46,3 @@ omnistrate-ctl snapshot restore --service-id service-abcd --environment-id env-1
 ### SEE ALSO
 
 * [omnistrate-ctl snapshot](omnistrate-ctl_snapshot.md)	 - Manage instance snapshots and backups
-

--- a/mkdocs/docs/omnistrate-ctl_snapshot_restore.md
+++ b/mkdocs/docs/omnistrate-ctl_snapshot_restore.md
@@ -46,3 +46,4 @@ omnistrate-ctl snapshot restore --service-id service-abcd --environment-id env-1
 ### SEE ALSO
 
 * [omnistrate-ctl snapshot](omnistrate-ctl_snapshot.md)	 - Manage instance snapshots and backups
+

--- a/test/integration_test/dataaccess/snapshot_test.go
+++ b/test/integration_test/dataaccess/snapshot_test.go
@@ -2,6 +2,7 @@ package dataaccess
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"testing"
 
@@ -39,4 +40,38 @@ func TestListAllSnapshotsWithOptions(t *testing.T) {
 		require.Equal(t, "ManualSnapshot", snapshot.GetSnapshotType())
 		require.Equal(t, productTierID, snapshot.GetProductTierId())
 	}
+}
+
+func TestRestoreSnapshotWithTargetingOptions(t *testing.T) {
+	testutils.IntegrationTest(t)
+
+	serviceID := os.Getenv("SNAPSHOT_RESTORE_TEST_SERVICE_ID")
+	environmentID := os.Getenv("SNAPSHOT_RESTORE_TEST_ENVIRONMENT_ID")
+	snapshotID := os.Getenv("SNAPSHOT_RESTORE_TEST_SNAPSHOT_ID")
+	customNetworkID := os.Getenv("SNAPSHOT_RESTORE_TEST_CUSTOM_NETWORK_ID")
+	subscriptionID := os.Getenv("SNAPSHOT_RESTORE_TEST_SUBSCRIPTION_ID")
+	if serviceID == "" || environmentID == "" || snapshotID == "" || customNetworkID == "" || subscriptionID == "" {
+		t.Skip("set SNAPSHOT_RESTORE_TEST_SERVICE_ID, SNAPSHOT_RESTORE_TEST_ENVIRONMENT_ID, SNAPSHOT_RESTORE_TEST_SNAPSHOT_ID, SNAPSHOT_RESTORE_TEST_CUSTOM_NETWORK_ID, and SNAPSHOT_RESTORE_TEST_SUBSCRIPTION_ID")
+	}
+
+	var params map[string]any
+	if rawParams := os.Getenv("SNAPSHOT_RESTORE_TEST_PARAM_JSON"); rawParams != "" {
+		require.NoError(t, json.Unmarshal([]byte(rawParams), &params))
+	}
+
+	ctx := context.TODO()
+	testEmail, testPassword, err := testutils.GetTestAccount()
+	require.NoError(t, err)
+
+	login, err := dataaccess.LoginWithPassword(ctx, testEmail, testPassword)
+	require.NoError(t, err)
+	require.NotEmpty(t, login.JWTToken)
+
+	result, err := dataaccess.RestoreSnapshot(ctx, login.JWTToken, serviceID, environmentID, snapshotID, dataaccess.RestoreSnapshotOptions{
+		InputParametersOverride: params,
+		CustomNetworkID:         customNetworkID,
+		SubscriptionID:          subscriptionID,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
 }

--- a/test/smoke_test/snapshot/snapshot_test.go
+++ b/test/smoke_test/snapshot/snapshot_test.go
@@ -3,6 +3,7 @@ package snapshot
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/google/uuid"
@@ -54,6 +55,45 @@ func TestSnapshotListEmpty(t *testing.T) {
 
 	// Cleanup: delete the service
 	cmd.RootCmd.SetArgs([]string{"service", "delete", serviceName})
+	err = cmd.RootCmd.ExecuteContext(ctx)
+	require.NoError(t, err)
+}
+
+func TestSnapshotRestoreWithTargetingFlags(t *testing.T) {
+	testutils.SmokeTest(t)
+
+	serviceID := os.Getenv("SNAPSHOT_RESTORE_TEST_SERVICE_ID")
+	environmentID := os.Getenv("SNAPSHOT_RESTORE_TEST_ENVIRONMENT_ID")
+	snapshotID := os.Getenv("SNAPSHOT_RESTORE_TEST_SNAPSHOT_ID")
+	customNetworkID := os.Getenv("SNAPSHOT_RESTORE_TEST_CUSTOM_NETWORK_ID")
+	subscriptionID := os.Getenv("SNAPSHOT_RESTORE_TEST_SUBSCRIPTION_ID")
+	if serviceID == "" || environmentID == "" || snapshotID == "" || customNetworkID == "" || subscriptionID == "" {
+		t.Skip("set SNAPSHOT_RESTORE_TEST_SERVICE_ID, SNAPSHOT_RESTORE_TEST_ENVIRONMENT_ID, SNAPSHOT_RESTORE_TEST_SNAPSHOT_ID, SNAPSHOT_RESTORE_TEST_CUSTOM_NETWORK_ID, and SNAPSHOT_RESTORE_TEST_SUBSCRIPTION_ID")
+	}
+
+	ctx := context.TODO()
+	defer testutils.Cleanup()
+
+	testEmail, testPassword, err := testutils.GetTestAccount()
+	require.NoError(t, err)
+	cmd.RootCmd.SetArgs([]string{"login", fmt.Sprintf("--email=%s", testEmail), fmt.Sprintf("--password=%s", testPassword)})
+	err = cmd.RootCmd.ExecuteContext(ctx)
+	require.NoError(t, err)
+
+	restoreArgs := []string{
+		"snapshot", "restore",
+		"--service-id", serviceID,
+		"--environment-id", environmentID,
+		"--snapshot-id", snapshotID,
+		"--custom-network-id", customNetworkID,
+		"--subscription-id", subscriptionID,
+		"--output", "json",
+	}
+	if rawParams := os.Getenv("SNAPSHOT_RESTORE_TEST_PARAM_JSON"); rawParams != "" {
+		restoreArgs = append(restoreArgs, "--param", rawParams)
+	}
+
+	cmd.RootCmd.SetArgs(restoreArgs)
 	err = cmd.RootCmd.ExecuteContext(ctx)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
This pull request enhances the `omnistrate-ctl snapshot restore` command by adding support for specifying a custom network ID and a target subscription ID when restoring a snapshot. The changes include updates to the CLI, backend logic, documentation, and tests to ensure these new options are handled correctly.

**CLI and User Experience Improvements:**

* Added `--custom-network-id` and `--subscription-id` flags to the `snapshot restore` command, allowing users to specify a custom network and target subscription for the restored instance. The command usage string, help text, and documentation were updated to reflect these new options. [[1]](diffhunk://#diff-0435f4a30f27a22b258d42ba3dbed7ac421b5e5998d3b1bf0099b0e644df5cb0L22-R22) [[2]](diffhunk://#diff-0435f4a30f27a22b258d42ba3dbed7ac421b5e5998d3b1bf0099b0e644df5cb0R39-R40) [[3]](diffhunk://#diff-77542023e436e2fddc5892e831bf1595b6148d679a26ba5e96c0e68f5af3b9c2L10-R10) [[4]](diffhunk://#diff-77542023e436e2fddc5892e831bf1595b6148d679a26ba5e96c0e68f5af3b9c2R26) [[5]](diffhunk://#diff-77542023e436e2fddc5892e831bf1595b6148d679a26ba5e96c0e68f5af3b9c2R35)

**Backend and Data Handling:**

* Modified the `RestoreSnapshot` function to accept and process the new `customNetworkID` and `subscriptionID` parameters, ensuring they are included in the request body sent to the API. [[1]](diffhunk://#diff-4bda56fb3afbae181a37447c0cac5b19ba181c5bed105cf7ffda70d6ad07ab2cL152-R152) [[2]](diffhunk://#diff-4bda56fb3afbae181a37447c0cac5b19ba181c5bed105cf7ffda70d6ad07ab2cR169-R178) [[3]](diffhunk://#diff-0435f4a30f27a22b258d42ba3dbed7ac421b5e5998d3b1bf0099b0e644df5cb0L144-R158) [[4]](diffhunk://#diff-0435f4a30f27a22b258d42ba3dbed7ac421b5e5998d3b1bf0099b0e644df5cb0R130-R141)

**Testing Enhancements:**

* Expanded unit tests to verify that the new flags are registered, included in the command usage, and that the backend receives the correct payload when these options are used. [[1]](diffhunk://#diff-a417e8e7cb43e9515f728e4962e0b3677787b3987f942a4bb196a57f50b15df2L102-R102) [[2]](diffhunk://#diff-a417e8e7cb43e9515f728e4962e0b3677787b3987f942a4bb196a57f50b15df2R124-R127) [[3]](diffhunk://#diff-b3586573d2879527f3b3cc942f270c015310e445c7db1707cd8dc8b16c88cf87R90-R141) [[4]](diffhunk://#diff-b3586573d2879527f3b3cc942f270c015310e445c7db1707cd8dc8b16c88cf87R5)

These changes provide users with greater flexibility when restoring snapshots, supporting more advanced deployment scenarios.