### PR TITLE
Adjust "omnistrate-ctl instance deployment-parameters template" command to include rendered BYOA parameters

### DIFF
--- a/cmd/instance/deployment_parameters.go
+++ b/cmd/instance/deployment_parameters.go
@@ -220,6 +220,17 @@ func fetchDeploymentParameters(ctx context.Context, token, serviceName, planName
 		})
 	}
 
+	serviceOfferingResourceInstanceIDPlaceholder := "none"
+	resourceParametersResult, serviceOfferingErr := dataaccess.DescribeServiceOfferingResource(
+		ctx, token, serviceID, resourceID, serviceOfferingResourceInstanceIDPlaceholder, productTierID, productTierVersion)
+	if serviceOfferingErr != nil {
+		return DeploymentParametersOutput{}, fmt.Errorf("failed to describe service offering resource: %w", serviceOfferingErr)
+	}
+	if resourceParametersResult != nil {
+		resourceDescription := resourceParametersResult.GetConsumptionDescribeServiceOfferingResourceResult()
+		parameters = mergeRenderedCreateAPIParameters(parameters, resourceDescription.GetApis())
+	}
+
 	sort.Slice(parameters, func(i, j int) bool {
 		return parameters[i].Key < parameters[j].Key
 	})
@@ -231,6 +242,68 @@ func fetchDeploymentParameters(ctx context.Context, token, serviceName, planName
 		ResourceName: resourceName,
 		Parameters:   parameters,
 	}, nil
+}
+
+// mergeRenderedCreateAPIParameters adds rendered custom create parameters that
+// are not returned by ListInputParameters, such as injected BYOA parameters.
+func mergeRenderedCreateAPIParameters(parameters []ParameterInfo, apis []openapiclientfleet.APIEntity) []ParameterInfo {
+	seen := make(map[string]struct{}, len(parameters))
+	for _, parameter := range parameters {
+		seen[parameter.Key] = struct{}{}
+	}
+
+	for _, api := range apis {
+		if !strings.EqualFold(api.GetVerb(), "CREATE") {
+			continue
+		}
+
+		for _, inputParameter := range api.GetInputParameters() {
+			if !inputParameter.GetCustom() || inputParameter.GetKey() == "" {
+				continue
+			}
+			if _, exists := seen[inputParameter.GetKey()]; exists {
+				continue
+			}
+
+			parameters = append(parameters, parameterInfoFromRenderedInputParameter(inputParameter))
+			seen[inputParameter.GetKey()] = struct{}{}
+		}
+		break
+	}
+
+	return parameters
+}
+
+func parameterInfoFromRenderedInputParameter(param openapiclientfleet.InputParameterEntity) ParameterInfo {
+	var defaultValue *string
+	if val, ok := param.GetDefaultValueOk(); ok && val != nil {
+		defaultValue = val
+	}
+
+	var regex *string
+	if val, ok := param.GetRegexOk(); ok && val != nil {
+		regex = val
+	}
+
+	var options []string
+	if param.GetOptions() != nil {
+		options = param.GetOptions()
+	}
+
+	return ParameterInfo{
+		Key:          param.GetKey(),
+		DisplayName:  param.GetDisplayName(),
+		Description:  param.GetDescription(),
+		Type:         param.GetType(),
+		Required:     param.GetRequired(),
+		Modifiable:   param.GetModifiable(),
+		IsList:       param.GetIsList(),
+		DefaultValue: defaultValue,
+		Options:      options,
+		Regex:        regex,
+		Custom:       param.GetCustom(),
+		API:          "create",
+	}
 }
 
 var templateCmd = &cobra.Command{

--- a/cmd/instance/deployment_parameters_test.go
+++ b/cmd/instance/deployment_parameters_test.go
@@ -115,6 +115,73 @@ func TestBuildParamTemplate(t *testing.T) {
 	require.Equal(int64(3306), template["port"])
 }
 
+func TestMergeRenderedCreateAPIParametersAddsCustomCreateParams(t *testing.T) {
+	require := require.New(t)
+
+	params := []ParameterInfo{
+		{Key: "databaseName", Type: "String", DisplayName: "Database Name"},
+	}
+	apis := []openapiclientfleet.APIEntity{
+		{
+			Verb: "DESCRIBE",
+			InputParameters: []openapiclientfleet.InputParameterEntity{
+				{
+					Custom:      true,
+					Key:         "describe_only",
+					DisplayName: "Describe Only",
+					Description: "Not a create parameter",
+					Type:        "String",
+				},
+			},
+		},
+		{
+			Verb: "CREATE",
+			InputParameters: []openapiclientfleet.InputParameterEntity{
+				{
+					Custom:      false,
+					Key:         "cloud_provider",
+					DisplayName: "Cloud Provider",
+					Description: "Top-level create request field",
+					Type:        "String",
+					Required:    true,
+				},
+				{
+					Custom:      false,
+					Key:         "region",
+					DisplayName: "Region",
+					Description: "Top-level create request field",
+					Type:        "String",
+					Required:    true,
+				},
+				{
+					Custom:      true,
+					Key:         "databaseName",
+					DisplayName: "Database Name",
+					Description: "Already returned by ListInputParameters",
+					Type:        "String",
+				},
+				{
+					Custom:      true,
+					Key:         "cloud_provider_native_network_id",
+					DisplayName: "Cloud Provider Native Network ID",
+					Description: "Cloud provider native network ID to use for the account",
+					Type:        "String",
+				},
+			},
+		},
+	}
+
+	merged := mergeRenderedCreateAPIParameters(params, apis)
+	template := buildParamTemplate(merged)
+
+	require.Len(merged, 2)
+	require.Contains(template, "databaseName")
+	require.Contains(template, "cloud_provider_native_network_id")
+	require.NotContains(template, "cloud_provider")
+	require.NotContains(template, "region")
+	require.NotContains(template, "describe_only")
+}
+
 func TestDeploymentParametersTemplateCommand(t *testing.T) {
 	require := require.New(t)
 


### PR DESCRIPTION
Testing:
```
omnistrate-ctl instance deployment-parameters template \
  --environment "dev" \
  --service "DataRobot STS" \
  --plan "byoa" \
  --resource "datarobot-chart" > params.json
```

Now includes 2 additional parameters `cloud_provider_account_config_id` and `cloud_provider_native_network_id`:
```
{
  "access_type": "public",
  "admin_password": "",
  "asymmetric_key": "",
  "aws_buzok_credentials": "",
  "azure_buzok_credentials": "",
  "cloud_provider_account_config_id": "",
  "cloud_provider_native_network_id": "",
  "container_registry_repo_prefix": "",
  "custom_chart_values_1": {
    "dummyField1": {},
    "dummyField2": {}
  },
  "custom_private_endpoints": [],
  "customer_account_ids": "",
  "drsecure_key": "",
  "existing_ecr_repos": "",
  "external_bucket_encryption_key": "",
  "external_full_storage_account_id": "",
  "external_storage_account_name": "",
  "external_storage_id": "",
  "gcp_buzok_credentials": "",
  "genai_enabled": false,
  "gpu_enabled": false,
  "helmNamespace": "",
  "helmReleaseName": "",
  "license": "",
  "mongo_atlas_disk_size_gb": "20",
  "mongo_atlas_instance_type": "M30",
  "mongo_atlas_version": "7.0",
  "nim_models_enabled": false,
  "postgres_disk_size_gb": "32",
  "postgres_max_disk_size_gb": "500",
  "private_link_dns": "",
  "sso_type": "None",
  "storage_prefix": "dr-core",
  "tenant_name": "",
  "tile_size": "small"
}
```