### PR TITLE
Add upgrade change-target-version command

### DIFF
--- a/cmd/upgrade/change_target_version.go
+++ b/cmd/upgrade/change_target_version.go
@@ -1,9 +1,8 @@
 package upgrade
 
 import (
-	"context"
-
 	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
 	"github.com/spf13/cobra"
@@ -13,12 +12,13 @@ const changeTargetVersionExample = `# Change the target version for a scheduled 
 omnistrate-ctl upgrade change-target-version upgrade-abcd1234 --service-id s-abcd1234 --product-tier-id pt-abcd1234 --target-version 90.0`
 
 var changeTargetVersionCmd = &cobra.Command{
-	Use:     "change-target-version <upgrade-path-id>",
-	Short:   "Change the target version for a scheduled upgrade path",
-	Long:    "Change the target product tier version for a scheduled upgrade path before it starts.",
-	Example: changeTargetVersionExample,
-	Args:    cobra.ExactArgs(1),
-	RunE:    runChangeTargetVersion,
+	Use:          "change-target-version <upgrade-path-id>",
+	Short:        "Change the target version for a scheduled upgrade path",
+	Long:         "Change the target product tier version for a scheduled upgrade path before it starts.",
+	Example:      changeTargetVersionExample,
+	Args:         cobra.ExactArgs(1),
+	RunE:         runChangeTargetVersion,
+	SilenceUsage: true,
 }
 
 func init() {
@@ -32,7 +32,7 @@ func init() {
 }
 
 func runChangeTargetVersion(cmd *cobra.Command, args []string) error {
-	ctx := context.Background()
+	defer config.CleanupArgsAndFlags(cmd, &args)
 
 	upgradePathID := args[0]
 	serviceID, _ := cmd.Flags().GetString("service-id")
@@ -44,7 +44,7 @@ func runChangeTargetVersion(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	result, err := dataaccess.ChangeUpgradePathTargetVersion(ctx, token, serviceID, productTierID, upgradePathID, targetVersion)
+	result, err := dataaccess.ChangeUpgradePathTargetVersion(cmd.Context(), token, serviceID, productTierID, upgradePathID, targetVersion)
 	if err != nil {
 		return err
 	}

--- a/cmd/upgrade/change_target_version.go
+++ b/cmd/upgrade/change_target_version.go
@@ -1,0 +1,54 @@
+package upgrade
+
+import (
+	"context"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd/common"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+const changeTargetVersionExample = `# Change the target version for a scheduled upgrade path
+omnistrate-ctl upgrade change-target-version upgrade-abcd1234 --service-id s-abcd1234 --product-tier-id pt-abcd1234 --target-version 90.0`
+
+var changeTargetVersionCmd = &cobra.Command{
+	Use:     "change-target-version <upgrade-path-id>",
+	Short:   "Change the target version for a scheduled upgrade path",
+	Long:    "Change the target product tier version for a scheduled upgrade path before it starts.",
+	Example: changeTargetVersionExample,
+	Args:    cobra.ExactArgs(1),
+	RunE:    runChangeTargetVersion,
+}
+
+func init() {
+	changeTargetVersionCmd.Flags().StringP("service-id", "s", "", "Service ID (required)")
+	changeTargetVersionCmd.Flags().StringP("product-tier-id", "p", "", "Product tier ID (required)")
+	changeTargetVersionCmd.Flags().String("target-version", "", "New target product tier version (required)")
+
+	_ = changeTargetVersionCmd.MarkFlagRequired("service-id")
+	_ = changeTargetVersionCmd.MarkFlagRequired("product-tier-id")
+	_ = changeTargetVersionCmd.MarkFlagRequired("target-version")
+}
+
+func runChangeTargetVersion(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	upgradePathID := args[0]
+	serviceID, _ := cmd.Flags().GetString("service-id")
+	productTierID, _ := cmd.Flags().GetString("product-tier-id")
+	targetVersion, _ := cmd.Flags().GetString("target-version")
+
+	token, err := common.GetTokenWithLogin()
+	if err != nil {
+		return err
+	}
+
+	result, err := dataaccess.ChangeUpgradePathTargetVersion(ctx, token, serviceID, productTierID, upgradePathID, targetVersion)
+	if err != nil {
+		return err
+	}
+
+	output, _ := cmd.Flags().GetString("output")
+	return utils.PrintTextTableJsonArrayOutput(output, []interface{}{result})
+}

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -49,6 +49,7 @@ func init() {
 	Cmd.AddCommand(createCmd)
 	Cmd.AddCommand(listCmd)
 	Cmd.AddCommand(describeCmd)
+	Cmd.AddCommand(changeTargetVersionCmd)
 	Cmd.AddCommand(status.Cmd)
 	Cmd.AddCommand(manageupgradelifecycle.CancelCmd)
 	Cmd.AddCommand(manageupgradelifecycle.ResumeCmd)

--- a/cmd/upgrade/upgrade_test.go
+++ b/cmd/upgrade/upgrade_test.go
@@ -11,7 +11,7 @@ func TestUpgradeCommands(t *testing.T) {
 	require.Equal(t, "Upgrade Instance Deployments to a newer or older version", Cmd.Short)
 
 	// Check that subcommands are registered
-	subCommands := []string{"list", "describe", "create"}
+	subCommands := []string{"list", "describe", "create", "change-target-version"}
 	actualCommands := make([]string, 0)
 	for _, cmd := range Cmd.Commands() {
 		actualCommands = append(actualCommands, cmd.Name())
@@ -79,4 +79,33 @@ func TestDescribeCommandFlags(t *testing.T) {
 	productTierIDFlag := cmd.Flags().Lookup("product-tier-id")
 	require.NotNil(t, productTierIDFlag)
 	require.Equal(t, "p", productTierIDFlag.Shorthand)
+}
+
+func TestChangeTargetVersionCommandFlags(t *testing.T) {
+	var cmdFound bool
+	var cmdName string
+	for _, cmd := range Cmd.Commands() {
+		if cmd.Name() == "change-target-version" {
+			cmdFound = true
+			cmdName = cmd.Use
+
+			require.Equal(t, "change-target-version <upgrade-path-id>", cmd.Use)
+			require.Equal(t, "Change the target version for a scheduled upgrade path", cmd.Short)
+
+			serviceIDFlag := cmd.Flags().Lookup("service-id")
+			require.NotNil(t, serviceIDFlag)
+			require.Equal(t, "s", serviceIDFlag.Shorthand)
+
+			productTierIDFlag := cmd.Flags().Lookup("product-tier-id")
+			require.NotNil(t, productTierIDFlag)
+			require.Equal(t, "p", productTierIDFlag.Shorthand)
+
+			targetVersionFlag := cmd.Flags().Lookup("target-version")
+			require.NotNil(t, targetVersionFlag)
+			require.Empty(t, targetVersionFlag.Shorthand)
+			break
+		}
+	}
+
+	require.True(t, cmdFound, "Expected command change-target-version not found; found %s", cmdName)
 }

--- a/cmd/upgrade/upgrade_test.go
+++ b/cmd/upgrade/upgrade_test.go
@@ -91,6 +91,7 @@ func TestChangeTargetVersionCommandFlags(t *testing.T) {
 
 			require.Equal(t, "change-target-version <upgrade-path-id>", cmd.Use)
 			require.Equal(t, "Change the target version for a scheduled upgrade path", cmd.Short)
+			require.True(t, cmd.SilenceUsage)
 
 			serviceIDFlag := cmd.Flags().Lookup("service-id")
 			require.NotNil(t, serviceIDFlag)

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/muesli/cancelreader v0.2.2
 	github.com/njayp/ophis v1.1.4
-	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.119
+	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.120
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/njayp/ophis v1.1.4 h1:6aq3UdU6MlGIjpg//IzKc2yIxHYMf6Rg1A5MLovM9gg=
 github.com/njayp/ophis v1.1.4/go.mod h1:F9KEnfeCJzCWo3e0JP2QqSCN04bXptXl1ico5lcLeYg=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.119 h1:f7d1YEtXNbZb5eqEaO3G8VQgG6Nv9p7QpN3D5YXiaB0=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.119/go.mod h1:q0FPYLbtm+Aw6GW0xbeaMPHR4WGzoV61iTGFoOhO72M=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.120 h1:vcMcI39llSHLdUzrMjoCatcxh0v6m1DYaxib4DpPvJ0=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.120/go.mod h1:q0FPYLbtm+Aw6GW0xbeaMPHR4WGzoV61iTGFoOhO72M=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=

--- a/internal/dataaccess/upgradepath.go
+++ b/internal/dataaccess/upgradepath.go
@@ -76,6 +76,33 @@ func ManageLifecycleWithPayload(ctx context.Context, token, serviceID, productTi
 
 	return resp, nil
 }
+
+func ChangeUpgradePathTargetVersion(ctx context.Context, token, serviceID, productTierID, upgradePathID, targetVersion string) (*openapiclientfleet.UpgradePath, error) {
+	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
+	apiClient := getFleetClient()
+
+	req := apiClient.InventoryApiAPI.InventoryApiChangeUpgradePathTargetVersion(
+		ctxWithToken,
+		serviceID,
+		productTierID,
+		upgradePathID,
+	).ChangeUpgradePathTargetVersionRequest2(openapiclientfleet.ChangeUpgradePathTargetVersionRequest2{
+		TargetVersion: targetVersion,
+	})
+
+	resp, r, err := req.Execute()
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+	if err != nil {
+		return nil, handleFleetError(err)
+	}
+
+	return resp, nil
+}
+
 func DescribeUpgradePath(ctx context.Context, token, serviceID, productTierID, upgradePathID string) (*openapiclientfleet.UpgradePath, error) {
 	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
 	apiClient := getFleetClient()

--- a/internal/dataaccess/upgradepath_test.go
+++ b/internal/dataaccess/upgradepath_test.go
@@ -1,0 +1,76 @@
+package dataaccess
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangeUpgradePathTargetVersion_ConstructsSDKPayload(t *testing.T) {
+	var capturedMethod string
+	var capturedPath string
+	var capturedAuth string
+	var capturedBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		capturedAuth = r.Header.Get("Authorization")
+
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"completedCount":    0,
+			"createdAt":         "2026-06-30T00:00:00Z",
+			"failedCount":       0,
+			"inProgressCount":   0,
+			"pendingCount":      5,
+			"productTierId":     "pt-test",
+			"releasedAt":        "2026-06-30T00:00:00Z",
+			"serviceId":         "s-test",
+			"skippedCount":      0,
+			"sourceVersion":     "85.0",
+			"sourceVersionName": "85.0",
+			"status":            "SCHEDULED",
+			"targetVersion":     "90.0",
+			"targetVersionName": "90.0",
+			"totalCount":        5,
+			"type":              "ROLLING",
+			"updatedAt":         "2026-06-30T00:00:00Z",
+			"upgradePathId":     "upgrade-test",
+		})
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	t.Setenv("OMNISTRATE_HOST", serverURL.Host)
+	t.Setenv("OMNISTRATE_HOST_SCHEME", serverURL.Scheme)
+	t.Setenv("CLIENT_TIMEOUT_IN_SECONDS", "5")
+	t.Setenv("OMNISTRATE_RETRY_MAX", "0")
+
+	result, err := ChangeUpgradePathTargetVersion(
+		context.Background(),
+		"test-token",
+		"s-test",
+		"pt-test",
+		"upgrade-test",
+		"90.0",
+	)
+	require.NoError(t, err)
+
+	assert.Equal(t, "upgrade-test", result.UpgradePathId)
+	assert.Equal(t, "90.0", result.TargetVersion)
+	assert.Equal(t, http.MethodPost, capturedMethod)
+	assert.Equal(t, "/2022-09-01-00/fleet/service/s-test/productTier/pt-test/upgrade-path/upgrade-test/target-version", capturedPath)
+	assert.Equal(t, "Bearer test-token", capturedAuth)
+	assert.Equal(t, "90.0", capturedBody["targetVersion"])
+}

--- a/mkdocs/docs/omnistrate-ctl_upgrade.md
+++ b/mkdocs/docs/omnistrate-ctl_upgrade.md
@@ -53,6 +53,7 @@ omnistrate-ctl upgrade [instance-id] --version=2.0 --max-concurrent-upgrades=5
 
 * [omnistrate-ctl](omnistrate-ctl.md)	 - Manage your Omnistrate SaaS from the command line
 * [omnistrate-ctl upgrade cancel](omnistrate-ctl_upgrade_cancel.md)	 - Cancel an uncompleted upgrade
+* [omnistrate-ctl upgrade change-target-version](omnistrate-ctl_upgrade_change-target-version.md)	 - Change the target version for a scheduled upgrade path
 * [omnistrate-ctl upgrade create](omnistrate-ctl_upgrade_create.md)	 - Create an upgrade path for one or more instances
 * [omnistrate-ctl upgrade describe](omnistrate-ctl_upgrade_describe.md)	 - Describe an upgrade path
 * [omnistrate-ctl upgrade list](omnistrate-ctl_upgrade_list.md)	 - List upgrade paths

--- a/mkdocs/docs/omnistrate-ctl_upgrade_change-target-version.md
+++ b/mkdocs/docs/omnistrate-ctl_upgrade_change-target-version.md
@@ -1,0 +1,39 @@
+## omnistrate-ctl upgrade change-target-version
+
+Change the target version for a scheduled upgrade path
+
+### Synopsis
+
+Change the target product tier version for a scheduled upgrade path before it starts.
+
+```
+omnistrate-ctl upgrade change-target-version <upgrade-path-id> [flags]
+```
+
+### Examples
+
+```
+# Change the target version for a scheduled upgrade path
+omnistrate-ctl upgrade change-target-version upgrade-abcd1234 --service-id s-abcd1234 --product-tier-id pt-abcd1234 --target-version 90.0
+```
+
+### Options
+
+```
+  -h, --help                     help for change-target-version
+  -p, --product-tier-id string   Product tier ID (required)
+  -s, --service-id string        Service ID (required)
+      --target-version string    New target product tier version (required)
+```
+
+### Options inherited from parent commands
+
+```
+  -o, --output string   Output format (text|table|json) (default "table")
+  -v, --version         Print the version number of omnistrate-ctl
+```
+
+### SEE ALSO
+
+* [omnistrate-ctl upgrade](omnistrate-ctl_upgrade.md)	 - Upgrade Instance Deployments to a newer or older version
+

--- a/test/integration_test/dataaccess/upgradepath_test.go
+++ b/test/integration_test/dataaccess/upgradepath_test.go
@@ -1,0 +1,77 @@
+package dataaccess
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/test/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangeUpgradePathTargetVersion(t *testing.T) {
+	testutils.IntegrationTest(t)
+
+	var capturedMethod string
+	var capturedPath string
+	var capturedAuth string
+	var capturedBody map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedMethod = r.Method
+		capturedPath = r.URL.Path
+		capturedAuth = r.Header.Get("Authorization")
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&capturedBody))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"completedCount":    0,
+			"createdAt":         "2026-06-30T00:00:00Z",
+			"failedCount":       0,
+			"inProgressCount":   0,
+			"pendingCount":      5,
+			"productTierId":     "pt-test",
+			"releasedAt":        "2026-06-30T00:00:00Z",
+			"serviceId":         "s-test",
+			"skippedCount":      0,
+			"sourceVersion":     "85.0",
+			"sourceVersionName": "85.0",
+			"status":            "SCHEDULED",
+			"targetVersion":     "90.0",
+			"targetVersionName": "90.0",
+			"totalCount":        5,
+			"type":              "ROLLING",
+			"updatedAt":         "2026-06-30T00:00:00Z",
+			"upgradePathId":     "upgrade-test",
+		}))
+	}))
+	defer server.Close()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	t.Setenv("OMNISTRATE_HOST", serverURL.Host)
+	t.Setenv("OMNISTRATE_HOST_SCHEME", serverURL.Scheme)
+	t.Setenv("OMNISTRATE_RETRY_MAX", "0")
+
+	result, err := dataaccess.ChangeUpgradePathTargetVersion(
+		context.Background(),
+		"test-token",
+		"s-test",
+		"pt-test",
+		"upgrade-test",
+		"90.0",
+	)
+	require.NoError(t, err)
+
+	require.Equal(t, "upgrade-test", result.UpgradePathId)
+	require.Equal(t, "90.0", result.TargetVersion)
+	require.Equal(t, http.MethodPost, capturedMethod)
+	require.Equal(t, "/2022-09-01-00/fleet/service/s-test/productTier/pt-test/upgrade-path/upgrade-test/target-version", capturedPath)
+	require.Equal(t, "Bearer test-token", capturedAuth)
+	require.Equal(t, "90.0", capturedBody["targetVersion"])
+}

--- a/test/smoke_test/upgrade/upgrade_test.go
+++ b/test/smoke_test/upgrade/upgrade_test.go
@@ -1,0 +1,116 @@
+package upgrade
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/mitchellh/go-homedir"
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/test/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_upgrade_change_target_version(t *testing.T) {
+	testutils.SmokeTest(t)
+
+	captured := &changeTargetVersionCapture{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/2022-09-01-00/signin":
+			handleSmokeSignin(t, w, r)
+		case "/2022-09-01-00/fleet/service/s-test/productTier/pt-test/upgrade-path/upgrade-test/target-version":
+			captured.method = r.Method
+			captured.auth = r.Header.Get("Authorization")
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&captured.body))
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			require.NoError(t, json.NewEncoder(w).Encode(changeTargetVersionResponse()))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	pointSmokeClientAt(t, server)
+	t.Setenv("OMNISTRATE_API_KEY", "om_test_key")
+
+	cmd.RootCmd.SetArgs([]string{
+		"upgrade", "change-target-version", "upgrade-test",
+		"--service-id", "s-test",
+		"--product-tier-id", "pt-test",
+		"--target-version", "90.0",
+		"--output", "json",
+	})
+	require.NoError(t, cmd.RootCmd.ExecuteContext(context.Background()))
+
+	require.Equal(t, http.MethodPost, captured.method)
+	require.Equal(t, "Bearer fake-jwt-for-testing", captured.auth)
+	require.Equal(t, "90.0", captured.body["targetVersion"])
+}
+
+type changeTargetVersionCapture struct {
+	method string
+	auth   string
+	body   map[string]any
+}
+
+func handleSmokeSignin(t *testing.T, w http.ResponseWriter, r *http.Request) {
+	t.Helper()
+
+	body, err := io.ReadAll(r.Body)
+	require.NoError(t, err)
+
+	var req map[string]string
+	require.NoError(t, json.Unmarshal(body, &req))
+	require.Equal(t, dataaccess.APIKeySigninEmail, req["email"])
+	require.Equal(t, "om_test_key", req["password"])
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, err = io.WriteString(w, `{"jwtToken":"fake-jwt-for-testing"}`)
+	require.NoError(t, err)
+}
+
+func pointSmokeClientAt(t *testing.T, server *httptest.Server) {
+	t.Helper()
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	t.Setenv("OMNISTRATE_HOST", serverURL.Host)
+	t.Setenv("OMNISTRATE_HOST_SCHEME", serverURL.Scheme)
+	t.Setenv("OMNISTRATE_RETRY_MAX", "0")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("OMNISTRATE_DRY_RUN", "true")
+	homedir.Reset()
+	t.Cleanup(homedir.Reset)
+}
+
+func changeTargetVersionResponse() map[string]any {
+	return map[string]any{
+		"completedCount":    0,
+		"createdAt":         "2026-06-30T00:00:00Z",
+		"failedCount":       0,
+		"inProgressCount":   0,
+		"pendingCount":      5,
+		"productTierId":     "pt-test",
+		"releasedAt":        "2026-06-30T00:00:00Z",
+		"serviceId":         "s-test",
+		"skippedCount":      0,
+		"sourceVersion":     "85.0",
+		"sourceVersionName": "85.0",
+		"status":            "SCHEDULED",
+		"targetVersion":     "90.0",
+		"targetVersionName": "90.0",
+		"totalCount":        5,
+		"type":              "ROLLING",
+		"updatedAt":         "2026-06-30T00:00:00Z",
+		"upgradePathId":     "upgrade-test",
+	}
+}


### PR DESCRIPTION
This pull request introduces a new CLI command to change the target version for a scheduled upgrade path, along with the necessary backend logic, tests, and documentation updates. The changes ensure that users can update the target version of an upgrade path before it starts, and that this functionality is tested and documented.

**New CLI Feature: Change Target Version for Upgrade Path**

*Command Implementation and Registration:*
- Added a new command `change-target-version` under `omnistrate-ctl upgrade`, allowing users to change the target version for a scheduled upgrade path via the CLI. The command requires `service-id`, `product-tier-id`, and `target-version` as arguments. (`cmd/upgrade/change_target_version.go`)
- Registered the new command in the upgrade command group and updated tests to verify its presence and flag configuration. (`cmd/upgrade/upgrade.go`, `cmd/upgrade/upgrade_test.go`) [[1]](diffhunk://#diff-e311c9f86705773bb6281684ddfbd4d54789fc6531f084f61eabed781357bdd2R52) [[2]](diffhunk://#diff-0a5b1389a23e0b0c1f60db9c6f7a2795cc96e9e91632d2b6b907ef3c90d86fbeL14-R14) [[3]](diffhunk://#diff-0a5b1389a23e0b0c1f60db9c6f7a2795cc96e9e91632d2b6b907ef3c90d86fbeR83-R111)

*Backend Logic:*
- Implemented `ChangeUpgradePathTargetVersion` in the data access layer to call the appropriate API and handle the response for changing the target version. (`internal/dataaccess/upgradepath.go`)
- Added a unit test to verify the API payload and endpoint for changing the target version. (`internal/dataaccess/upgradepath_test.go`)

**Documentation Updates**

- Added a dedicated documentation page for the new command, including usage, examples, and flag descriptions. (`mkdocs/docs/omnistrate-ctl_upgrade_change-target-version.md`)
- Linked the new command in the main upgrade command documentation. (`mkdocs/docs/omnistrate-ctl_upgrade.md`)

**Dependency Update**

- Updated the `omnistrate-sdk-go` dependency to version `v0.0.120` to support the new API. (`go.mod`)