### PR TITLE
Support workload identities in deployment cell templates

### DIFF
--- a/test/smoke_test/deploymentcell/deploymentcell_test.go
+++ b/test/smoke_test/deploymentcell/deploymentcell_test.go
@@ -1,0 +1,122 @@
+package deploymentcell
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/omnistrate-oss/omnistrate-ctl/cmd"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/model"
+	"github.com/omnistrate-oss/omnistrate-ctl/test/testutils"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func Test_deployment_cell_config_template_workload_identities(t *testing.T) {
+	testutils.SmokeTest(t)
+
+	ctx := context.TODO()
+	require := require.New(t)
+	defer testutils.Cleanup()
+
+	testEmail, testPassword, err := testutils.GetTestAccount()
+	require.NoError(err)
+	cmd.RootCmd.SetArgs([]string{"login", fmt.Sprintf("--email=%s", testEmail), fmt.Sprintf("--password=%s", testPassword)})
+	err = cmd.RootCmd.ExecuteContext(ctx)
+	require.NoError(err)
+
+	tmpDir := t.TempDir()
+	currentTemplatePath := filepath.Join(tmpDir, "current-template.yaml")
+	updatedTemplatePath := filepath.Join(tmpDir, "updated-template.yaml")
+	restoreTemplatePath := filepath.Join(tmpDir, "restore-template.yaml")
+
+	cmd.RootCmd.SetArgs([]string{
+		"deployment-cell", "describe-config-template",
+		"--environment", "GLOBAL",
+		"--cloud", "aws",
+		"--output-file", currentTemplatePath,
+	})
+	err = cmd.RootCmd.ExecuteContext(ctx)
+	require.NoError(err)
+
+	currentTemplate := readDeploymentCellTemplateForSmokeTest(t, currentTemplatePath)
+	restoreTemplate := currentTemplate
+	if restoreTemplate.ManagedIdentities == nil {
+		restoreTemplate.ManagedIdentities = []model.ManagedWorkloadIdentity{}
+	}
+	writeDeploymentCellTemplateForSmokeTest(t, restoreTemplatePath, restoreTemplate)
+	defer func() {
+		cmd.RootCmd.SetArgs([]string{
+			"deployment-cell", "update-config-template",
+			"--environment", "GLOBAL",
+			"--cloud", "aws",
+			"--file", restoreTemplatePath,
+		})
+		_ = cmd.RootCmd.ExecuteContext(ctx)
+	}()
+
+	description := "Smoke test workload identity"
+	currentTemplate.ManagedIdentities = []model.ManagedWorkloadIdentity{
+		{
+			Identifier:  "ctl-smoke",
+			Description: &description,
+			Bindings: []model.ManagedWorkloadIdentityBinding{
+				{
+					ServiceAccount: model.ManagedWorkloadIdentityServiceAccount{
+						Namespace: "queue-system",
+						Name:      "queue-writer",
+					},
+				},
+			},
+			Permissions: &model.ManagedWorkloadIdentityPermissions{
+				Policies: map[string]string{
+					"aws": `{"Statement":[{"Action":["sqs:SendMessage"],"Effect":"Allow","Resource":"*"}]}`,
+				},
+			},
+		},
+	}
+	writeDeploymentCellTemplateForSmokeTest(t, updatedTemplatePath, currentTemplate)
+
+	cmd.RootCmd.SetArgs([]string{
+		"deployment-cell", "update-config-template",
+		"--environment", "GLOBAL",
+		"--cloud", "aws",
+		"--file", updatedTemplatePath,
+	})
+	err = cmd.RootCmd.ExecuteContext(ctx)
+	require.NoError(err)
+
+	cmd.RootCmd.SetArgs([]string{
+		"deployment-cell", "describe-config-template",
+		"--environment", "GLOBAL",
+		"--cloud", "aws",
+		"--output-file", currentTemplatePath,
+	})
+	err = cmd.RootCmd.ExecuteContext(ctx)
+	require.NoError(err)
+
+	updatedTemplate := readDeploymentCellTemplateForSmokeTest(t, currentTemplatePath)
+	require.Len(updatedTemplate.ManagedIdentities, 1)
+	require.Equal("ctl-smoke", updatedTemplate.ManagedIdentities[0].Identifier)
+}
+
+func readDeploymentCellTemplateForSmokeTest(t *testing.T, path string) model.DeploymentCellTemplate {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var template model.DeploymentCellTemplate
+	require.NoError(t, yaml.Unmarshal(data, &template))
+	return template
+}
+
+func writeDeploymentCellTemplateForSmokeTest(t *testing.T, path string, template model.DeploymentCellTemplate) {
+	t.Helper()
+
+	data, err := yaml.Marshal(template)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0600))
+}


### PR DESCRIPTION
## Summary
- add optional workloadIdentities support to deployment cell config templates
- map workload identities through DeploymentCellConfiguration AdditionalProperties until the SDK exposes the typed field
- preserve lifecycle semantics: omitted workloadIdentities is not sent, explicit [] is sent to clear existing identities
- include workload identities in describe/generate/update help, generated docs, and table output
- add CRUD/conversion unit coverage plus a smoke test that defines and reads back a workload identity

## Verification
- go test ./cmd/deploymentcell ./internal/dataaccess ./internal/model ./test/smoke_test/deploymentcell -count=1
- git diff --check
- make build

Note: the smoke package compiles under normal test execution; live smoke execution still requires the standard smoke-test credentials/environment.