### PR TITLE
Add CTL support for managed workload identities

### DIFF
--- a/cmd/deploymentcell/generate_template.go
+++ b/cmd/deploymentcell/generate_template.go
@@ -172,6 +172,10 @@ func convertToDeploymentCellConfiguration(cellConfig interface{}) (model.Deploym
 	if err != nil {
 		return result, fmt.Errorf("failed to convert amenities list: %w", err)
 	}
+	managedIdentities, err := dataaccess.ConvertToInternalManagedWorkloadIdentityList(cellConfig)
+	if err != nil {
+		return result, fmt.Errorf("failed to convert managed workload identities list: %w", err)
+	}
 
 	var managedAmenities []model.Amenity
 	var customAmenities []model.Amenity
@@ -191,6 +195,7 @@ func convertToDeploymentCellConfiguration(cellConfig interface{}) (model.Deploym
 		}
 	}
 
+	result.ManagedIdentities = managedIdentities
 	result.ManagedAmenities = managedAmenities
 	result.CustomAmenities = customAmenities
 	return result, nil

--- a/cmd/deploymentcell/generate_template_test.go
+++ b/cmd/deploymentcell/generate_template_test.go
@@ -60,6 +60,46 @@ func TestDeploymentCellTemplateForCloudProviderPreservesDisable(t *testing.T) {
 	require.Equal(t, disable, *template.ManagedAmenities[0].Disable)
 }
 
+func TestDeploymentCellTemplateForCloudProviderPreservesManagedIdentities(t *testing.T) {
+	description := "Allows workloads to publish queue messages."
+	configs := map[string]openapiclient.DeploymentCellConfiguration{
+		"aws": {
+			WorkloadIdentities: []openapiclient.ManagedWorkloadIdentity{
+				{
+					Identifier:  "queue-writer",
+					Description: utils.ToPtr(description),
+					Permissions: &openapiclient.ManagedWorkloadIdentityPermissions{
+						Policies: &map[string]string{
+							"aws": `{"Statement":[{"Action":["sqs:SendMessage"],"Effect":"Allow","Resource":"*"}]}`,
+						},
+					},
+					Bindings: []openapiclient.ManagedWorkloadIdentityBinding{
+						{
+							ServiceAccount: openapiclient.ManagedWorkloadIdentityServiceAccount{
+								Namespace: "queue-system",
+								Name:      "queue-writer",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	template, err := deploymentCellTemplateForCloudProvider(&configs, "aws")
+	require.NoError(t, err)
+	require.Len(t, template.ManagedIdentities, 1)
+
+	identity := template.ManagedIdentities[0]
+	require.Equal(t, "queue-writer", identity.Identifier)
+	require.Equal(t, description, *identity.Description)
+	require.NotNil(t, identity.Permissions)
+	require.Contains(t, identity.Permissions.Policies["aws"], "sqs:SendMessage")
+	require.Len(t, identity.Bindings, 1)
+	require.Equal(t, "queue-system", identity.Bindings[0].ServiceAccount.Namespace)
+	require.Equal(t, "queue-writer", identity.Bindings[0].ServiceAccount.Name)
+}
+
 func TestDeploymentCellTemplateForCloudProviderReturnsErrorForMissingNonBYOCConfig(t *testing.T) {
 	configs := map[string]openapiclient.DeploymentCellConfiguration{
 		"aws": {

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/muesli/cancelreader v0.2.2
 	github.com/njayp/ophis v1.1.4
-	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.120
+	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.121
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/njayp/ophis v1.1.4 h1:6aq3UdU6MlGIjpg//IzKc2yIxHYMf6Rg1A5MLovM9gg=
 github.com/njayp/ophis v1.1.4/go.mod h1:F9KEnfeCJzCWo3e0JP2QqSCN04bXptXl1ico5lcLeYg=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.120 h1:vcMcI39llSHLdUzrMjoCatcxh0v6m1DYaxib4DpPvJ0=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.120/go.mod h1:q0FPYLbtm+Aw6GW0xbeaMPHR4WGzoV61iTGFoOhO72M=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.121 h1:Bv2HL8ttNbCGSy4vYv2IS77svT4CsyqD0u24ByBk9L0=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.121/go.mod h1:q0FPYLbtm+Aw6GW0xbeaMPHR4WGzoV61iTGFoOhO72M=
 github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns=
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=

--- a/internal/dataaccess/hostcluster.go
+++ b/internal/dataaccess/hostcluster.go
@@ -267,6 +267,10 @@ func GetOrganizationDeploymentCellTemplate(ctx context.Context, token string, en
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert amenities list: %w", err)
 	}
+	managedIdentities, err := ConvertToInternalManagedWorkloadIdentityList(amenitiesPerCloudProvider)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert managed workload identities list: %w", err)
+	}
 
 	var managedAmenities []model.Amenity
 	var customAmenities []model.Amenity
@@ -287,8 +291,9 @@ func GetOrganizationDeploymentCellTemplate(ctx context.Context, token string, en
 	}
 
 	return &model.DeploymentCellTemplate{
-		ManagedAmenities: managedAmenities,
-		CustomAmenities:  customAmenities,
+		ManagedIdentities: managedIdentities,
+		ManagedAmenities:  managedAmenities,
+		CustomAmenities:   customAmenities,
 	}, nil
 }
 
@@ -299,12 +304,16 @@ func ConvertToInternalAmenitiesList(data interface{}) ([]model.InternalAmenity, 
 		return nil, err
 	}
 
-	var configWrapper struct {
-		Amenities []model.InternalAmenity `json:"Amenities"`
-	}
-	err = json.Unmarshal(jsonBytes, &configWrapper)
-	if err == nil && len(configWrapper.Amenities) > 0 {
-		return configWrapper.Amenities, nil
+	var rawObject map[string]json.RawMessage
+	if err = json.Unmarshal(jsonBytes, &rawObject); err == nil {
+		if rawAmenities, ok := rawObject["Amenities"]; ok {
+			var amenities []model.InternalAmenity
+			if err = json.Unmarshal(rawAmenities, &amenities); err != nil {
+				return nil, err
+			}
+			return amenities, nil
+		}
+		return nil, nil
 	}
 
 	// If that fails, try to unmarshal directly as an array

--- a/internal/dataaccess/serviceproviderorg.go
+++ b/internal/dataaccess/serviceproviderorg.go
@@ -2,6 +2,7 @@ package dataaccess
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/model"
@@ -60,12 +61,167 @@ func convertTemplateToOpenAPIFormat(deploymentConfig model.DeploymentCellTemplat
 		amenitiesAPI = append(amenitiesAPI, apiAmenity)
 	}
 	configPerCloudProvider[cloudProvider] = openapiclient.DeploymentCellConfiguration{
-		Amenities: amenitiesAPI,
+		Amenities:          amenitiesAPI,
+		WorkloadIdentities: ConvertManagedWorkloadIdentitiesToOpenAPI(deploymentConfig.ManagedIdentities),
 	}
 
 	apiModel.DeploymentCellConfigurationPerCloudProvider = utils.ToPtr(configPerCloudProvider)
 
 	return apiModel
+}
+
+func ConvertManagedWorkloadIdentitiesToOpenAPI(identities []model.ManagedWorkloadIdentity) []openapiclient.ManagedWorkloadIdentity {
+	if len(identities) == 0 {
+		return nil
+	}
+
+	result := make([]openapiclient.ManagedWorkloadIdentity, 0, len(identities))
+	for _, identity := range identities {
+		apiIdentity := openapiclient.ManagedWorkloadIdentity{
+			Identifier:  identity.Identifier,
+			Description: identity.Description,
+			Bindings:    convertManagedWorkloadIdentityBindingsToOpenAPI(identity.Bindings),
+		}
+		if identity.Permissions != nil {
+			apiIdentity.Permissions = convertManagedWorkloadIdentityPermissionsToOpenAPI(identity.Permissions)
+		}
+		result = append(result, apiIdentity)
+	}
+
+	return result
+}
+
+func ConvertManagedWorkloadIdentitiesFromOpenAPI(identities []openapiclient.ManagedWorkloadIdentity) []model.ManagedWorkloadIdentity {
+	if len(identities) == 0 {
+		return nil
+	}
+
+	result := make([]model.ManagedWorkloadIdentity, 0, len(identities))
+	for _, identity := range identities {
+		modelIdentity := model.ManagedWorkloadIdentity{
+			Identifier:  identity.Identifier,
+			Description: identity.Description,
+			Bindings:    convertManagedWorkloadIdentityBindingsFromOpenAPI(identity.Bindings),
+		}
+		if identity.Permissions != nil {
+			modelIdentity.Permissions = convertManagedWorkloadIdentityPermissionsFromOpenAPI(identity.Permissions)
+		}
+		result = append(result, modelIdentity)
+	}
+
+	return result
+}
+
+func ConvertToInternalManagedWorkloadIdentityList(data interface{}) ([]model.ManagedWorkloadIdentity, error) {
+	jsonBytes, err := json.Marshal(data)
+	if err != nil {
+		return nil, err
+	}
+
+	var rawObject map[string]json.RawMessage
+	if err = json.Unmarshal(jsonBytes, &rawObject); err == nil {
+		if rawIdentities, ok := rawObject["WorkloadIdentities"]; ok {
+			var identities []openapiclient.ManagedWorkloadIdentity
+			if err = json.Unmarshal(rawIdentities, &identities); err != nil {
+				return nil, err
+			}
+			return ConvertManagedWorkloadIdentitiesFromOpenAPI(identities), nil
+		}
+		return nil, nil
+	}
+
+	var identities []openapiclient.ManagedWorkloadIdentity
+	if err = json.Unmarshal(jsonBytes, &identities); err != nil {
+		return nil, err
+	}
+
+	return ConvertManagedWorkloadIdentitiesFromOpenAPI(identities), nil
+}
+
+func convertManagedWorkloadIdentityBindingsToOpenAPI(bindings []model.ManagedWorkloadIdentityBinding) []openapiclient.ManagedWorkloadIdentityBinding {
+	if len(bindings) == 0 {
+		return nil
+	}
+
+	result := make([]openapiclient.ManagedWorkloadIdentityBinding, 0, len(bindings))
+	for _, binding := range bindings {
+		result = append(result, openapiclient.ManagedWorkloadIdentityBinding{
+			ServiceAccount: openapiclient.ManagedWorkloadIdentityServiceAccount{
+				Namespace: binding.ServiceAccount.Namespace,
+				Name:      binding.ServiceAccount.Name,
+			},
+		})
+	}
+	return result
+}
+
+func convertManagedWorkloadIdentityBindingsFromOpenAPI(bindings []openapiclient.ManagedWorkloadIdentityBinding) []model.ManagedWorkloadIdentityBinding {
+	if len(bindings) == 0 {
+		return nil
+	}
+
+	result := make([]model.ManagedWorkloadIdentityBinding, 0, len(bindings))
+	for _, binding := range bindings {
+		result = append(result, model.ManagedWorkloadIdentityBinding{
+			ServiceAccount: model.ManagedWorkloadIdentityServiceAccount{
+				Namespace: binding.ServiceAccount.Namespace,
+				Name:      binding.ServiceAccount.Name,
+			},
+		})
+	}
+	return result
+}
+
+func convertManagedWorkloadIdentityPermissionsToOpenAPI(permissions *model.ManagedWorkloadIdentityPermissions) *openapiclient.ManagedWorkloadIdentityPermissions {
+	result := &openapiclient.ManagedWorkloadIdentityPermissions{}
+	if permissions.Policies != nil {
+		policies := permissions.Policies
+		result.Policies = &policies
+	}
+	if permissions.Permissions != nil {
+		permissionStatements := permissions.Permissions
+		result.Permissions = &permissionStatements
+	}
+	if permissions.Roles != nil {
+		roles := make(map[string][]openapiclient.ManagedWorkloadIdentityRole, len(permissions.Roles))
+		for provider, providerRoles := range permissions.Roles {
+			apiRoles := make([]openapiclient.ManagedWorkloadIdentityRole, 0, len(providerRoles))
+			for _, role := range providerRoles {
+				apiRoles = append(apiRoles, openapiclient.ManagedWorkloadIdentityRole{
+					Name: role.Name,
+					Type: role.Type,
+				})
+			}
+			roles[provider] = apiRoles
+		}
+		result.Roles = &roles
+	}
+	return result
+}
+
+func convertManagedWorkloadIdentityPermissionsFromOpenAPI(permissions *openapiclient.ManagedWorkloadIdentityPermissions) *model.ManagedWorkloadIdentityPermissions {
+	result := &model.ManagedWorkloadIdentityPermissions{}
+	if permissions.Policies != nil {
+		result.Policies = *permissions.Policies
+	}
+	if permissions.Permissions != nil {
+		result.Permissions = *permissions.Permissions
+	}
+	if permissions.Roles != nil {
+		roles := make(map[string][]model.ManagedWorkloadIdentityRole, len(*permissions.Roles))
+		for provider, providerRoles := range *permissions.Roles {
+			modelRoles := make([]model.ManagedWorkloadIdentityRole, 0, len(providerRoles))
+			for _, role := range providerRoles {
+				modelRoles = append(modelRoles, model.ManagedWorkloadIdentityRole{
+					Name: role.Name,
+					Type: role.Type,
+				})
+			}
+			roles[provider] = modelRoles
+		}
+		result.Roles = roles
+	}
+	return result
 }
 
 func UpdateServiceProviderOrganization(ctx context.Context, token string, deploymentConfig model.DeploymentCellTemplate, envType string, cloudProvider string) (err error) {

--- a/internal/dataaccess/serviceproviderorg_test.go
+++ b/internal/dataaccess/serviceproviderorg_test.go
@@ -58,3 +58,42 @@ func TestConvertTemplateToOpenAPIFormatPreservesDisable(t *testing.T) {
 	require.NotNil(t, configs["aws"].Amenities[1].Disable)
 	require.Equal(t, disable, *configs["aws"].Amenities[1].Disable)
 }
+
+func TestConvertTemplateToOpenAPIFormatPreservesManagedIdentities(t *testing.T) {
+	description := "Allows workloads to publish queue messages."
+	template := model.DeploymentCellTemplate{
+		ManagedIdentities: []model.ManagedWorkloadIdentity{
+			{
+				Identifier:  "queue-writer",
+				Description: utils.ToPtr(description),
+				Permissions: &model.ManagedWorkloadIdentityPermissions{
+					Policies: map[string]string{
+						"aws": `{"Statement":[{"Action":["sqs:SendMessage"],"Effect":"Allow","Resource":"*"}]}`,
+					},
+				},
+				Bindings: []model.ManagedWorkloadIdentityBinding{
+					{
+						ServiceAccount: model.ManagedWorkloadIdentityServiceAccount{
+							Namespace: "queue-system",
+							Name:      "queue-writer",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	converted := convertTemplateToOpenAPIFormat(template, "aws")
+	configs := converted.GetDeploymentCellConfigurationPerCloudProvider()
+	require.Contains(t, configs, "aws")
+	require.Len(t, configs["aws"].WorkloadIdentities, 1)
+
+	identity := configs["aws"].WorkloadIdentities[0]
+	require.Equal(t, "queue-writer", identity.Identifier)
+	require.Equal(t, description, *identity.Description)
+	require.NotNil(t, identity.Permissions)
+	require.Contains(t, (*identity.Permissions.Policies)["aws"], "sqs:SendMessage")
+	require.Len(t, identity.Bindings, 1)
+	require.Equal(t, "queue-system", identity.Bindings[0].ServiceAccount.Namespace)
+	require.Equal(t, "queue-writer", identity.Bindings[0].ServiceAccount.Name)
+}

--- a/internal/model/deploymentcell.go
+++ b/internal/model/deploymentcell.go
@@ -8,8 +8,9 @@ import (
 
 // DeploymentCellTemplate represents a template structure for API responses
 type DeploymentCellTemplate struct {
-	ManagedAmenities []Amenity `json:"managed_amenities,omitempty" yaml:"managedAmenities,omitempty"`
-	CustomAmenities  []Amenity `json:"custom_amenities,omitempty" yaml:"customAmenities,omitempty"`
+	ManagedIdentities []ManagedWorkloadIdentity `json:"managed_identities,omitempty" yaml:"managedIdentities,omitempty"`
+	ManagedAmenities  []Amenity                 `json:"managed_amenities,omitempty" yaml:"managedAmenities,omitempty"`
+	CustomAmenities   []Amenity                 `json:"custom_amenities,omitempty" yaml:"customAmenities,omitempty"`
 }
 
 // DeploymentCell represents a complete view of a host cluster/deployment cell

--- a/internal/model/serviceproviderorg.go
+++ b/internal/model/serviceproviderorg.go
@@ -63,6 +63,34 @@ type Amenity struct {
 	Properties  map[string]interface{} `json:"properties,omitempty" yaml:"properties,omitempty"`
 }
 
+// ManagedWorkloadIdentity represents a managed workload identity in the deployment cell template.
+type ManagedWorkloadIdentity struct {
+	Identifier  string                              `json:"identifier" yaml:"identifier"`
+	Description *string                             `json:"description,omitempty" yaml:"description,omitempty"`
+	Bindings    []ManagedWorkloadIdentityBinding    `json:"bindings,omitempty" yaml:"bindings,omitempty"`
+	Permissions *ManagedWorkloadIdentityPermissions `json:"permissions,omitempty" yaml:"permissions,omitempty"`
+}
+
+type ManagedWorkloadIdentityBinding struct {
+	ServiceAccount ManagedWorkloadIdentityServiceAccount `json:"serviceAccount" yaml:"serviceAccount"`
+}
+
+type ManagedWorkloadIdentityServiceAccount struct {
+	Namespace string `json:"namespace" yaml:"namespace"`
+	Name      string `json:"name" yaml:"name"`
+}
+
+type ManagedWorkloadIdentityPermissions struct {
+	Policies    map[string]string                        `json:"policies,omitempty" yaml:"policies,omitempty"`
+	Roles       map[string][]ManagedWorkloadIdentityRole `json:"roles,omitempty" yaml:"roles,omitempty"`
+	Permissions map[string][]string                      `json:"permissions,omitempty" yaml:"permissions,omitempty"`
+}
+
+type ManagedWorkloadIdentityRole struct {
+	Name string  `json:"name" yaml:"name"`
+	Type *string `json:"type,omitempty" yaml:"type,omitempty"`
+}
+
 type InternalAmenity struct {
 	Name        string                 `json:"name" yaml:"name"`
 	Description *string                `json:"description,omitempty" yaml:"description,omitempty"`

--- a/internal/model/serviceproviderorg_test.go
+++ b/internal/model/serviceproviderorg_test.go
@@ -34,3 +34,34 @@ customAmenities:
 	require.NotNil(t, template.CustomAmenities[0].Disable)
 	require.Equal(t, disable, *template.CustomAmenities[0].Disable)
 }
+
+func TestDeploymentCellTemplateYAMLPreservesManagedIdentities(t *testing.T) {
+	data := []byte(`
+managedIdentities:
+  - identifier: queue-writer
+    description: Allows workloads to publish queue messages.
+    permissions:
+      policies:
+        aws: |
+          {"Statement":[{"Action":["sqs:SendMessage"],"Effect":"Allow","Resource":"*"}]}
+    bindings:
+      - serviceAccount:
+          namespace: queue-system
+          name: queue-writer
+`)
+
+	var template DeploymentCellTemplate
+	err := yaml.Unmarshal(data, &template)
+	require.NoError(t, err)
+
+	require.Len(t, template.ManagedIdentities, 1)
+	identity := template.ManagedIdentities[0]
+	require.Equal(t, "queue-writer", identity.Identifier)
+	require.NotNil(t, identity.Description)
+	require.Equal(t, "Allows workloads to publish queue messages.", *identity.Description)
+	require.NotNil(t, identity.Permissions)
+	require.Contains(t, identity.Permissions.Policies["aws"], "sqs:SendMessage")
+	require.Len(t, identity.Bindings, 1)
+	require.Equal(t, "queue-system", identity.Bindings[0].ServiceAccount.Namespace)
+	require.Equal(t, "queue-writer", identity.Bindings[0].ServiceAccount.Name)
+}


### PR DESCRIPTION
Usage:
```
omctl deployment-cell update-config-template -e GLOBAL --cloud aws --file ~/Documents/Text/Omnistrate/OneOff/DevTemplates/aws-global-template.yaml
```

```
omctl deployment-cell describe-config-template -e GLOBAL --cloud aws
Deployment Cell Configuration Template
Organization: org-EUVvex3bVm
Environment: GLOBAL
Cloud Provider: aws
Total Amenities: 12 (Managed: 12, Custom: 0)

managedIdentities:
    - identifier: queue-writer
      description: Allows workloads to publish queue messages.
      bindings:
        - serviceAccount:
            namespace: queue-system
            name: queue-writer
      permissions:
        policies:
            aws: |
                {
                  "Version": "2012-10-17",
                  "Statement": [
                    {
                      "Effect": "Allow",
                      "Action": [
                        "sqs:SendMessage"
                      ],
                      "Resource": "*"
                    }
                  ]
                }

(rest omitted)
```