### PR TITLE
fix: omit cloud fields for onprem instance create

### DIFF
--- a/cmd/instance/create.go
+++ b/cmd/instance/create.go
@@ -40,7 +40,10 @@ omnistrate-ctl instance create --service=mysql --environment=dev --plan=mysql --
 omnistrate-ctl instance create --service=Nebius --environment=dev --plan='Nebius BYOA Compute Variants' --resource=NebiusRedis --cloud-provider=nebius --region=eu-north1 --customer-account-id instance-cg1tthkj0
 
 # Create a BYOA instance deployment using a customer account onboarding instance with imported network
-omnistrate-ctl instance create --service=MyService --environment=dev --plan='AWS BYOA' --resource=myResource --cloud-provider=aws --region=us-east-2 --customer-account-id instance-cg1tthkj0 --cloud-provider-native-network-id vpc-0123456789abcdef0`
+omnistrate-ctl instance create --service=MyService --environment=dev --plan='AWS BYOA' --resource=myResource --cloud-provider=aws --region=us-east-2 --customer-account-id instance-cg1tthkj0 --cloud-provider-native-network-id vpc-0123456789abcdef0
+
+# Create an air-gapped/on-prem installer-backed instance. Do not pass --cloud-provider or --region with --onprem-platform.
+omnistrate-ctl instance create --service=MyService --environment=dev --plan='Airgap' --resource=myResource --onprem-platform=Generic --param-file /path/to/params.json`
 
 	customerAccountConfigIDParamKey      = "cloud_provider_account_config_id"
 	cloudProviderNativeNetworkIDParamKey = "cloud_provider_native_network_id"
@@ -73,7 +76,7 @@ var InstanceID string
 var SubscriptionID string
 
 var createCmd = &cobra.Command{
-	Use:          "create --service=[service] --environment=[environment] --plan=[plan] --version=[version] --resource=[resource] --cloud-provider=[aws|gcp|azure|nebius] --region=[region] [--param=param] [--param-file=file-path] [--instance-id=id] [--customer-account-id=account-instance-id] [--cloud-provider-native-network-id=network-id] [--tags key=value,key2=value2] [--breakpoints id-or-key[:event[|event...]],...]",
+	Use:          "create --service=[service] --environment=[environment] --plan=[plan] --version=[version] --resource=[resource] [--cloud-provider=aws|gcp|azure|nebius] [--region=region] [--param=param] [--param-file=file-path] [--instance-id=id] [--customer-account-id=account-instance-id] [--cloud-provider-native-network-id=network-id] [--onprem-platform=platform] [--tags key=value,key2=value2] [--breakpoints id-or-key[:event[|event...]],...]",
 	Short:        "Create an instance deployment",
 	Long:         `This command helps you create an instance deployment for your service.`,
 	Example:      createExample,
@@ -87,12 +90,13 @@ func init() {
 	createCmd.Flags().String("plan", "", "Service plan name")
 	createCmd.Flags().String("version", "preferred", "Service plan version (latest|preferred|1.0 etc.)")
 	createCmd.Flags().String("resource", "", "Resource name")
-	createCmd.Flags().String("cloud-provider", "", "Cloud provider (aws|gcp|azure|nebius)")
-	createCmd.Flags().String("region", "", "Region code (e.g. us-east-2, us-central1)")
+	createCmd.Flags().String("cloud-provider", "", "Cloud provider (aws|gcp|azure|nebius). Required unless --onprem-platform is provided; do not use with --onprem-platform.")
+	createCmd.Flags().String("region", "", "Region code (e.g. us-east-2, us-central1). Required unless --onprem-platform is provided; do not use with --onprem-platform.")
 	createCmd.Flags().String("param", "", "Parameters for the instance deployment")
 	createCmd.Flags().String("param-file", "", "Json file containing parameters for the instance deployment")
 	createCmd.Flags().String("customer-account-id", "", "Customer BYOA account onboarding instance ID to inject as the cloud account. Use 'omnistrate-ctl account customer list' or 'omnistrate-ctl account customer describe <instance-id>' to find it.")
 	createCmd.Flags().String("cloud-provider-native-network-id", "", fmt.Sprintf("Cloud provider native network ID to inject as %s in instance deployment parameters", cloudProviderNativeNetworkIDParamKey))
+	createCmd.Flags().String("onprem-platform", "", "On-prem platform for installer-backed deployments (for example EKS, GKE, AKS, OpenShift, Generic)")
 	createCmd.Flags().String("tags", "", "Custom tags to add to the instance deployment (format: key=value,key2=value2)")
 	createCmd.Flags().String("breakpoints", "", "Workflow breakpoint resource IDs or resource keys, optionally scoped to events as id-or-key:event or id-or-key:event|event")
 	createCmd.Flags().StringP("subscription-id", "", "", "Subscription ID to use for the instance deployment. If not provided, instance deployment will be created in your own subscription.")
@@ -109,12 +113,6 @@ func init() {
 		return
 	}
 	if err := createCmd.MarkFlagRequired("resource"); err != nil {
-		return
-	}
-	if err := createCmd.MarkFlagRequired("cloud-provider"); err != nil {
-		return
-	}
-	if err := createCmd.MarkFlagRequired("region"); err != nil {
 		return
 	}
 	if err := createCmd.MarkFlagFilename("param-file"); err != nil {
@@ -184,6 +182,11 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		utils.PrintError(err)
 		return err
 	}
+	onpremPlatform, err := cmd.Flags().GetString("onprem-platform")
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
 	subscriptionID, err := cmd.Flags().GetString("subscription-id")
 	if err != nil {
 		utils.PrintError(err)
@@ -216,6 +219,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 	}
 	workflowBreakpoints, err := parseWorkflowBreakpoints(breakpointsRaw)
 	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+	if err = validateCreateCloudTarget(cloudProvider, region, onpremPlatform); err != nil {
 		utils.PrintError(err)
 		return err
 	}
@@ -284,7 +291,7 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		utils.HandleSpinnerError(spinner, sm, err)
 		return err
 	}
-	formattedParams, err = applyCustomerAccountIDParam(formattedParams, &offering, customerAccountID)
+	formattedParams, err = applyCustomerAccountIDParam(formattedParams, &offering, customerAccountID, onpremPlatform)
 	if err != nil {
 		utils.HandleSpinnerError(spinner, sm, err)
 		return err
@@ -308,11 +315,12 @@ func runCreate(cmd *cobra.Command, args []string) error {
 
 	request := openapiclientfleet.FleetCreateResourceInstanceRequest2{
 		ProductTierVersion: &version,
-		CloudProvider:      &cloudProvider,
-		Region:             &region,
 		RequestParams:      formattedParams,
 		NetworkType:        nil,
 	}
+	applyCloudProviderToCreateRequest(&request, cloudProvider)
+	applyRegionToCreateRequest(&request, region)
+	applyOnpremPlatformToCreateRequest(&request, onpremPlatform)
 	if tagsProvided {
 		request.CustomTags = customTags
 	}
@@ -737,8 +745,10 @@ func applyCustomerAccountIDParam(
 	params map[string]any,
 	offering *openapiclientfleet.ServiceOffering,
 	customerAccountID string,
+	onpremPlatform string,
 ) (map[string]any, error) {
 	customerAccountID = strings.TrimSpace(customerAccountID)
+	onpremPlatform = strings.TrimSpace(onpremPlatform)
 	if offering == nil {
 		return nil, fmt.Errorf("service offering is required to validate customer account inputs")
 	}
@@ -746,9 +756,10 @@ func applyCustomerAccountIDParam(
 	existingCustomerAccountID := customerAccountParamValue(params)
 	if strings.EqualFold(offering.ServiceModelType, serviceModelTypeBYOA) &&
 		customerAccountID == "" &&
-		existingCustomerAccountID == "" {
+		existingCustomerAccountID == "" &&
+		onpremPlatform == "" {
 		return nil, fmt.Errorf(
-			"selected service plan is BYOA and requires a customer cloud account. Provide --customer-account-id or set %s in --param/--param-file. Use 'omnistrate-ctl account customer list' to find the onboarding instance ID",
+			"selected service plan is BYOA and requires a customer cloud account or on-prem platform. Provide --customer-account-id, set %s in --param/--param-file, or use --onprem-platform for installer-backed on-prem/air-gapped deployments. Use 'omnistrate-ctl account customer list' to find the onboarding instance ID",
 			customerAccountConfigIDParamKey,
 		)
 	}
@@ -791,6 +802,54 @@ func applyCloudProviderNativeNetworkIDParam(
 	}
 	params[cloudProviderNativeNetworkIDParamKey] = cloudProviderNativeNetworkID
 	return params
+}
+
+func validateCreateCloudTarget(cloudProvider, region, onpremPlatform string) error {
+	cloudProvider = strings.TrimSpace(cloudProvider)
+	region = strings.TrimSpace(region)
+	onpremPlatform = strings.TrimSpace(onpremPlatform)
+
+	if onpremPlatform != "" {
+		if cloudProvider != "" {
+			return fmt.Errorf("--cloud-provider is not supported with --onprem-platform; omit --cloud-provider for installer-backed on-prem/air-gapped deployments")
+		}
+		if region != "" {
+			return fmt.Errorf("--region is not supported with --onprem-platform; omit --region for installer-backed on-prem/air-gapped deployments")
+		}
+		return nil
+	}
+
+	if cloudProvider == "" {
+		return fmt.Errorf("--cloud-provider is required unless --onprem-platform is provided")
+	}
+	if region == "" {
+		return fmt.Errorf("--region is required unless --onprem-platform is provided")
+	}
+	return nil
+}
+
+func applyCloudProviderToCreateRequest(request *openapiclientfleet.FleetCreateResourceInstanceRequest2, cloudProvider string) {
+	cloudProvider = strings.TrimSpace(cloudProvider)
+	if request == nil || cloudProvider == "" {
+		return
+	}
+	request.CloudProvider = utils.ToPtr(cloudProvider)
+}
+
+func applyRegionToCreateRequest(request *openapiclientfleet.FleetCreateResourceInstanceRequest2, region string) {
+	region = strings.TrimSpace(region)
+	if request == nil || region == "" {
+		return
+	}
+	request.Region = utils.ToPtr(region)
+}
+
+func applyOnpremPlatformToCreateRequest(request *openapiclientfleet.FleetCreateResourceInstanceRequest2, onpremPlatform string) {
+	onpremPlatform = strings.TrimSpace(onpremPlatform)
+	if request == nil || onpremPlatform == "" {
+		return
+	}
+	request.OnpremPlatform = utils.ToPtr(onpremPlatform)
 }
 
 func customerAccountParamValue(params map[string]any) string {

--- a/cmd/instance/create_test.go
+++ b/cmd/instance/create_test.go
@@ -1,6 +1,7 @@
 package instance
 
 import (
+	"encoding/json"
 	"testing"
 
 	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
@@ -20,6 +21,10 @@ func TestCreateCommandFlags(t *testing.T) {
 	require.NotNil(t, flag)
 	assert.Contains(t, flag.Usage, cloudProviderNativeNetworkIDParamKey)
 
+	flag = createCmd.Flags().Lookup("onprem-platform")
+	require.NotNil(t, flag)
+	assert.Contains(t, flag.Usage, "installer-backed")
+
 	flag = createCmd.Flags().Lookup("breakpoints")
 	require.NotNil(t, flag)
 	assert.Contains(t, flag.Usage, "id-or-key:event")
@@ -36,7 +41,7 @@ func TestCreateCommandFlags_AllExpectedFlags(t *testing.T) {
 	expectedFlags := []string{
 		"service", "environment", "plan", "version", "resource",
 		"cloud-provider", "region", "param", "param-file",
-		"customer-account-id", "cloud-provider-native-network-id", "tags", "breakpoints",
+		"customer-account-id", "cloud-provider-native-network-id", "onprem-platform", "tags", "breakpoints",
 		"subscription-id", "instance-id", "wait",
 	}
 	for _, flagName := range expectedFlags {
@@ -52,7 +57,7 @@ func TestCreateCommandUse_IncludesInstanceID(t *testing.T) {
 func TestApplyCustomerAccountIDParam_NoCustomerAccountID(t *testing.T) {
 	params := map[string]any{"existing": "value"}
 
-	updated, err := applyCustomerAccountIDParam(params, &openapiclientfleet.ServiceOffering{}, "")
+	updated, err := applyCustomerAccountIDParam(params, &openapiclientfleet.ServiceOffering{}, "", "")
 	require.NoError(t, err)
 	assert.Equal(t, params, updated)
 }
@@ -62,10 +67,25 @@ func TestApplyCustomerAccountIDParam_BYOARequiresCustomerAccount(t *testing.T) {
 		nil,
 		&openapiclientfleet.ServiceOffering{ServiceModelType: serviceModelTypeBYOA},
 		"",
+		"",
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "--customer-account-id")
+	assert.Contains(t, err.Error(), "--onprem-platform")
 	assert.Contains(t, err.Error(), "account customer list")
+}
+
+func TestApplyCustomerAccountIDParam_BYOAWithOnpremPlatformDoesNotRequireCustomerAccount(t *testing.T) {
+	updated, err := applyCustomerAccountIDParam(
+		map[string]any{"existing": "value"},
+		&openapiclientfleet.ServiceOffering{ServiceModelType: serviceModelTypeBYOA},
+		"",
+		"Generic",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "value", updated["existing"])
+	assert.NotContains(t, updated, customerAccountConfigIDParamKey)
 }
 
 func TestApplyCustomerAccountIDParam_BYOAAllowsMagicParam(t *testing.T) {
@@ -74,6 +94,7 @@ func TestApplyCustomerAccountIDParam_BYOAAllowsMagicParam(t *testing.T) {
 	updated, err := applyCustomerAccountIDParam(
 		params,
 		&openapiclientfleet.ServiceOffering{ServiceModelType: serviceModelTypeBYOA},
+		"",
 		"",
 	)
 	require.NoError(t, err)
@@ -85,6 +106,7 @@ func TestApplyCustomerAccountIDParam_RequiresBYOAPlan(t *testing.T) {
 		nil,
 		&openapiclientfleet.ServiceOffering{ServiceModelType: "OMNISTRATE_HOSTED"},
 		"instance-abcd1234",
+		"",
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "only supported for BYOA service plans")
@@ -95,6 +117,7 @@ func TestApplyCustomerAccountIDParam_RejectsDuplicateMagicParam(t *testing.T) {
 		map[string]any{customerAccountConfigIDParamKey: "instance-existing"},
 		&openapiclientfleet.ServiceOffering{ServiceModelType: serviceModelTypeBYOA},
 		"instance-abcd1234",
+		"",
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), customerAccountConfigIDParamKey)
@@ -105,6 +128,7 @@ func TestApplyCustomerAccountIDParam_AddsCustomerAccountID(t *testing.T) {
 		map[string]any{"existing": "value"},
 		&openapiclientfleet.ServiceOffering{ServiceModelType: "byoa"},
 		"instance-abcd1234",
+		"",
 	)
 	require.NoError(t, err)
 	assert.Equal(t, "value", updated["existing"])
@@ -145,6 +169,111 @@ func TestApplyCloudProviderNativeNetworkIDParam_AddsNativeNetworkID(t *testing.T
 
 	assert.Equal(t, "value", updated["existing"])
 	assert.Equal(t, "vpc-abcd1234", updated[cloudProviderNativeNetworkIDParamKey])
+}
+
+func TestValidateCreateCloudTargetRequiresCloudProviderWithoutOnpremPlatform(t *testing.T) {
+	err := validateCreateCloudTarget("", "us-east-2", "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--cloud-provider")
+	assert.Contains(t, err.Error(), "--onprem-platform")
+}
+
+func TestValidateCreateCloudTargetRequiresRegionWithoutOnpremPlatform(t *testing.T) {
+	err := validateCreateCloudTarget("aws", "", "")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--region")
+	assert.Contains(t, err.Error(), "--onprem-platform")
+}
+
+func TestValidateCreateCloudTargetAllowsMissingCloudProviderAndRegionWithOnpremPlatform(t *testing.T) {
+	err := validateCreateCloudTarget("", "", "Generic")
+
+	require.NoError(t, err)
+}
+
+func TestValidateCreateCloudTargetRejectsCloudProviderWithOnpremPlatform(t *testing.T) {
+	err := validateCreateCloudTarget("byoc-onprem", "", "Generic")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--cloud-provider")
+	assert.Contains(t, err.Error(), "--onprem-platform")
+}
+
+func TestValidateCreateCloudTargetRejectsRegionWithOnpremPlatform(t *testing.T) {
+	err := validateCreateCloudTarget("", "us-east-2", "Generic")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--region")
+	assert.Contains(t, err.Error(), "--onprem-platform")
+}
+
+func TestApplyCloudProviderToCreateRequest(t *testing.T) {
+	request := openapiclientfleet.FleetCreateResourceInstanceRequest2{}
+
+	applyCloudProviderToCreateRequest(&request, " aws ")
+
+	require.NotNil(t, request.CloudProvider)
+	assert.Equal(t, "aws", *request.CloudProvider)
+}
+
+func TestApplyCloudProviderToCreateRequestIgnoresEmptyValue(t *testing.T) {
+	request := openapiclientfleet.FleetCreateResourceInstanceRequest2{}
+
+	applyCloudProviderToCreateRequest(&request, " ")
+
+	assert.Nil(t, request.CloudProvider)
+}
+
+func TestApplyRegionToCreateRequest(t *testing.T) {
+	request := openapiclientfleet.FleetCreateResourceInstanceRequest2{}
+
+	applyRegionToCreateRequest(&request, " us-east-2 ")
+
+	require.NotNil(t, request.Region)
+	assert.Equal(t, "us-east-2", *request.Region)
+}
+
+func TestApplyRegionToCreateRequestIgnoresEmptyValue(t *testing.T) {
+	request := openapiclientfleet.FleetCreateResourceInstanceRequest2{}
+
+	applyRegionToCreateRequest(&request, " ")
+
+	assert.Nil(t, request.Region)
+}
+
+func TestApplyOnpremPlatformToCreateRequest(t *testing.T) {
+	request := openapiclientfleet.FleetCreateResourceInstanceRequest2{}
+
+	applyOnpremPlatformToCreateRequest(&request, " Generic ")
+
+	require.NotNil(t, request.OnpremPlatform)
+	assert.Equal(t, "Generic", *request.OnpremPlatform)
+}
+
+func TestApplyOnpremPlatformToCreateRequestIgnoresEmptyValue(t *testing.T) {
+	request := openapiclientfleet.FleetCreateResourceInstanceRequest2{}
+
+	applyOnpremPlatformToCreateRequest(&request, " ")
+
+	assert.Nil(t, request.OnpremPlatform)
+}
+
+func TestCreateRequestOmitsCloudProviderAndRegionWhenOnlyOnpremPlatformIsSet(t *testing.T) {
+	request := openapiclientfleet.FleetCreateResourceInstanceRequest2{}
+	applyCloudProviderToCreateRequest(&request, "")
+	applyRegionToCreateRequest(&request, "")
+	applyOnpremPlatformToCreateRequest(&request, "Generic")
+
+	raw, err := json.Marshal(request)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(raw, &payload))
+	assert.Equal(t, "Generic", payload["onprem_platform"])
+	assert.NotContains(t, payload, "cloud_provider")
+	assert.NotContains(t, payload, "region")
 }
 
 func TestResolveServicePlanCandidates_ScopesToRequestedService(t *testing.T) {

--- a/mkdocs/docs/omnistrate-ctl_instance_create.md
+++ b/mkdocs/docs/omnistrate-ctl_instance_create.md
@@ -7,7 +7,7 @@ Create an instance deployment
 This command helps you create an instance deployment for your service.
 
 ```
-omnistrate-ctl instance create --service=[service] --environment=[environment] --plan=[plan] --version=[version] --resource=[resource] --cloud-provider=[aws|gcp|azure|nebius] --region=[region] [--param=param] [--param-file=file-path] [--instance-id=id] [--customer-account-id=account-instance-id] [--cloud-provider-native-network-id=network-id] [--tags key=value,key2=value2] [--breakpoints id-or-key[:event[|event...]],...] [flags]
+omnistrate-ctl instance create --service=[service] --environment=[environment] --plan=[plan] --version=[version] --resource=[resource] [--cloud-provider=aws|gcp|azure|nebius] [--region=region] [--param=param] [--param-file=file-path] [--instance-id=id] [--customer-account-id=account-instance-id] [--cloud-provider-native-network-id=network-id] [--onprem-platform=platform] [--tags key=value,key2=value2] [--breakpoints id-or-key[:event[|event...]],...] [flags]
 ```
 
 ### Examples
@@ -36,22 +36,26 @@ omnistrate-ctl instance create --service=Nebius --environment=dev --plan='Nebius
 
 # Create a BYOA instance deployment using a customer account onboarding instance with imported network
 omnistrate-ctl instance create --service=MyService --environment=dev --plan='AWS BYOA' --resource=myResource --cloud-provider=aws --region=us-east-2 --customer-account-id instance-cg1tthkj0 --cloud-provider-native-network-id vpc-0123456789abcdef0
+
+# Create an air-gapped/on-prem installer-backed instance. Do not pass --cloud-provider or --region with --onprem-platform.
+omnistrate-ctl instance create --service=MyService --environment=dev --plan='Airgap' --resource=myResource --onprem-platform=Generic --param-file /path/to/params.json
 ```
 
 ### Options
 
 ```
       --breakpoints string                        Workflow breakpoint resource IDs or resource keys, optionally scoped to events as id-or-key:event or id-or-key:event|event
-      --cloud-provider string                     Cloud provider (aws|gcp|azure|nebius)
+      --cloud-provider string                     Cloud provider (aws|gcp|azure|nebius). Required unless --onprem-platform is provided; do not use with --onprem-platform.
       --cloud-provider-native-network-id string   Cloud provider native network ID to inject as cloud_provider_native_network_id in instance deployment parameters
       --customer-account-id string                Customer BYOA account onboarding instance ID to inject as the cloud account. Use 'omnistrate-ctl account customer list' or 'omnistrate-ctl account customer describe <instance-id>' to find it.
       --environment string                        Environment name
   -h, --help                                      help for create
       --instance-id string                        ID of a previously deleted instance to restore
+      --onprem-platform string                    On-prem platform for installer-backed deployments (for example EKS, GKE, AKS, OpenShift, Generic)
       --param string                              Parameters for the instance deployment
       --param-file string                         Json file containing parameters for the instance deployment
       --plan string                               Service plan name
-      --region string                             Region code (e.g. us-east-2, us-central1)
+      --region string                             Region code (e.g. us-east-2, us-central1). Required unless --onprem-platform is provided; do not use with --onprem-platform.
       --resource string                           Resource name
       --service string                            Service name
       --subscription-id string                    Subscription ID to use for the instance deployment. If not provided, instance deployment will be created in your own subscription.


### PR DESCRIPTION
This PR updates instance create to support installer-backed air-gapped/on-prem service models by matching the UI request payload behavior.

  For on-prem installer-backed creates, the backend does not accept cloud_provider or region. Previously, the CLI required and always sent --cloud-provider, which caused backend failures like:

  Invalid request: cloud provider is not supported for on-prem service models

  This change makes --onprem-platform the target selector for air-gapped/on-prem creates and ensures cloud-specific fields are not sent.

  Changes included:

  - Adds --onprem-platform support to instance create
  - Rejects --cloud-provider when used together with --onprem-platform
  - Rejects --region when used together with --onprem-platform


  On-prem create command shape:

  omnistrate-ctl instance create \
    --service=MyService \
    --environment=dev \
    --plan='Airgap' \
    --version=1.0 \
    --resource=nginx \
    --onprem-platform=Generic \
    --param-file /path/to/params.json

  Do not pass these with --onprem-platform:

  --cloud-provider
  --region

  Validation:

  GOCACHE=/private/tmp/omnistrate-go-cache go test ./cmd/instance -run 'TestCreateCommand|TestApplyCustomerAccountIDParam|TestApplyCloudProviderNativeNetworkIDParam|TestValidateCreateCloudTarget|
  TestApplyCloudProviderToCreateRequest|TestApplyRegionToCreateRequest|TestApplyOnpremPlatformToCreateRequest|TestCreateRequestOmitsCloudProviderAndRegionWhenOnlyOnpremPlatformIsSet' -v

  GOCACHE=/private/tmp/omnistrate-go-cache make gen-doc
  GOCACHE=/private/tmp/omnistrate-go-cache make build