### PR TITLE
Adjust amenities count

### DIFF
--- a/cmd/deploymentcell/update_template.go
+++ b/cmd/deploymentcell/update_template.go
@@ -354,11 +354,15 @@ func updateDeploymentCellFromFile(ctx context.Context, token string, deploymentC
 	}
 
 	// Show what we're doing
-	if len(pendingChanges) == 0 {
+	totalAmenities := len(templateConfig.ManagedAmenities) + len(templateConfig.CustomAmenities) + len(templateConfig.ManagedIdentities)
+	if totalAmenities == 0 {
 		fmt.Printf("Removing all amenities from deployment cell\n")
 	} else {
-		fmt.Printf("Updating with %d amenities (%d managed, %d custom)\n",
-			len(pendingChanges), len(templateConfig.ManagedAmenities), len(templateConfig.CustomAmenities))
+		fmt.Print(formatDeploymentCellUpdateSummary(
+			len(templateConfig.ManagedAmenities),
+			len(templateConfig.CustomAmenities),
+			len(templateConfig.ManagedIdentities),
+		))
 	}
 
 	err = dataaccess.UpdateHostCluster(ctx, token, deploymentCellID, pendingChanges, nil)
@@ -382,6 +386,28 @@ func updateDeploymentCellFromFile(ctx context.Context, token string, deploymentC
 	fmt.Printf("ID: %s\n", hc.GetId())
 
 	return nil
+}
+
+func formatDeploymentCellUpdateSummary(managedAmenitiesCount int, customAmenitiesCount int, managedIdentitiesCount int) string {
+	managedIdentityLabel := "managed identities"
+	if managedIdentitiesCount == 1 {
+		managedIdentityLabel = "managed identity"
+	}
+
+	totalAmenitiesCount := managedAmenitiesCount + customAmenitiesCount + managedIdentitiesCount
+	amenityLabel := "amenities"
+	if totalAmenitiesCount == 1 {
+		amenityLabel = "amenity"
+	}
+	return fmt.Sprintf(
+		"Updating with %d %s (%d managed, %d custom, %d %s)\n",
+		totalAmenitiesCount,
+		amenityLabel,
+		managedAmenitiesCount,
+		customAmenitiesCount,
+		managedIdentitiesCount,
+		managedIdentityLabel,
+	)
 }
 
 // processManifestAmenitiesInTemplate processes manifest amenities in a deployment cell template,

--- a/cmd/deploymentcell/update_template_test.go
+++ b/cmd/deploymentcell/update_template_test.go
@@ -1,0 +1,58 @@
+package deploymentcell
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatDeploymentCellUpdateSummaryCountsManagedIdentitiesAsAmenities(t *testing.T) {
+	tests := []struct {
+		name                   string
+		managedAmenitiesCount  int
+		customAmenitiesCount   int
+		managedIdentitiesCount int
+		expected               string
+	}{
+		{
+			name:                   "singular managed identity",
+			managedAmenitiesCount:  12,
+			customAmenitiesCount:   1,
+			managedIdentitiesCount: 1,
+			expected:               "Updating with 14 amenities (12 managed, 1 custom, 1 managed identity)\n",
+		},
+		{
+			name:                   "singular total amenity",
+			managedAmenitiesCount:  0,
+			customAmenitiesCount:   0,
+			managedIdentitiesCount: 1,
+			expected:               "Updating with 1 amenity (0 managed, 0 custom, 1 managed identity)\n",
+		},
+		{
+			name:                   "zero managed identities",
+			managedAmenitiesCount:  12,
+			customAmenitiesCount:   1,
+			managedIdentitiesCount: 0,
+			expected:               "Updating with 13 amenities (12 managed, 1 custom, 0 managed identities)\n",
+		},
+		{
+			name:                   "multiple managed identities",
+			managedAmenitiesCount:  12,
+			customAmenitiesCount:   1,
+			managedIdentitiesCount: 2,
+			expected:               "Updating with 15 amenities (12 managed, 1 custom, 2 managed identities)\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			summary := formatDeploymentCellUpdateSummary(
+				tt.managedAmenitiesCount,
+				tt.customAmenitiesCount,
+				tt.managedIdentitiesCount,
+			)
+
+			require.Equal(t, tt.expected, summary)
+		})
+	}
+}


### PR DESCRIPTION
```
Updating deployment cell configuration...
Updating with 14 amenities (12 managed, 1 custom, 1 managed identity)
```