### PR TITLE
Add support for account config tags

### DIFF
--- a/cmd/account/create.go
+++ b/cmd/account/create.go
@@ -141,6 +141,7 @@ type CloudAccountParams struct {
 	PrivateLink         bool
 	AllowCreateNew      bool
 	CloudNativeNetworks []string
+	CustomTags          []openapiclient.CustomTag
 }
 
 // CreateCloudAccount creates a cloud provider account and returns the account config ID and account details
@@ -208,6 +209,10 @@ func CreateCloudAccount(ctx context.Context, token string, params CloudAccountPa
 		request.Description = "Nebius Account " + params.NebiusTenantID
 	} else {
 		return nil, fmt.Errorf("no cloud provider credentials provided")
+	}
+
+	if len(params.CustomTags) > 0 {
+		request.CustomTags = params.CustomTags
 	}
 
 	// Create account

--- a/cmd/account/customer_common.go
+++ b/cmd/account/customer_common.go
@@ -42,6 +42,7 @@ type customerAccountSummary struct {
 	AccountStatus      string `json:"account_status,omitempty"`
 	AccountStatusMsg   string `json:"account_status_message,omitempty"`
 	SubscriptionID     string `json:"subscription_id"`
+	CustomTags         string `json:"custom_tags,omitempty"`
 }
 
 type customerAccountDescribeResult struct {
@@ -227,6 +228,7 @@ func buildCustomerAccountSummary(
 	summary.AccountDescription = account.Description
 	summary.AccountStatus = account.Status
 	summary.AccountStatusMsg = account.StatusMessage
+	summary.CustomTags = formatAccountTags(account.CustomTags)
 
 	formattedAccount, err := formatAccount(account)
 	if err == nil {

--- a/cmd/account/customer_create.go
+++ b/cmd/account/customer_create.go
@@ -226,6 +226,14 @@ func runCustomerCreate(cmd *cobra.Command, args []string) error {
 	if target.SubscriptionID != "" {
 		request.SubscriptionId = &target.SubscriptionID
 	}
+	if len(params.CustomTags) > 0 {
+		// The tags flow through the onboarding instance to the customer's backing account config
+		fleetTags := make([]openapiclientfleet.CustomTag, 0, len(params.CustomTags))
+		for _, tag := range params.CustomTags {
+			fleetTags = append(fleetTags, openapiclientfleet.CustomTag{Key: tag.Key, Value: tag.Value})
+		}
+		request.CustomTags = fleetTags
+	}
 
 	createResult, err := dataaccess.CreateResourceInstance(
 		cmd.Context(),

--- a/cmd/account/customer_update.go
+++ b/cmd/account/customer_update.go
@@ -32,6 +32,7 @@ func init() {
 	customerUpdateCmd.Flags().String("name", "", "Updated backing account name")
 	customerUpdateCmd.Flags().String("description", "", "Updated backing account description")
 	customerUpdateCmd.Flags().String("nebius-bindings-file", "", "Path to a YAML file describing the full replacement Nebius bindings")
+	customerUpdateCmd.Flags().String(tagsFlag, "", "Full replacement set of custom tags for the backing account in key=value format, separated by commas (e.g. env=prod,team=platform)")
 	customerUpdateCmd.Flags().Bool("skip-wait", false, "Skip waiting for the backing account to become READY after replacing Nebius bindings")
 	_ = customerUpdateCmd.MarkFlagFilename("nebius-bindings-file")
 }
@@ -108,6 +109,7 @@ func runCustomerUpdate(cmd *cobra.Command, args []string) error {
 		Name:            params.Name,
 		Description:     params.Description,
 		NebiusBindings:  params.NebiusBindings,
+		CustomTags:      params.CustomTags,
 	})
 	if err != nil {
 		utils.HandleSpinnerError(spinner, sm, err)

--- a/cmd/account/list.go
+++ b/cmd/account/list.go
@@ -153,5 +153,6 @@ func formatAccount(account *openapiclient.DescribeAccountConfigResult) (model.Ac
 		Status:          account.Status,
 		CloudProvider:   cloudProvider,
 		TargetAccountID: targetAccountID,
+		CustomTags:      formatAccountTags(account.CustomTags),
 	}, nil
 }

--- a/cmd/account/provider_flags.go
+++ b/cmd/account/provider_flags.go
@@ -19,6 +19,7 @@ const (
 	privateLinkFlag         = "private-link"
 	allowCreateNewFlag      = "allow-create-new-cloud-native-network"
 	cloudNativeNetworksFlag = "cloud-native-networks"
+	tagsFlag                = "tags"
 )
 
 func addCloudAccountProviderFlags(cmd *cobra.Command) {
@@ -39,6 +40,7 @@ func addBaseCloudAccountProviderFlags(cmd *cobra.Command) {
 	cmd.Flags().String(azureTenantIDFlag, "", "Azure tenant ID")
 	cmd.Flags().String(nebiusTenantIDFlag, "", "Nebius tenant ID")
 	cmd.Flags().String(nebiusBindingsFileFlag, "", "Path to a YAML file describing Nebius bindings")
+	cmd.Flags().String(tagsFlag, "", "Custom tags for the account in key=value format, separated by commas (e.g. env=prod,team=platform)")
 	cmd.Flags().Bool(skipWaitFlag, false, "Skip waiting for account onboarding to become READY")
 
 	cmd.MarkFlagsRequiredTogether(gcpProjectIDFlag, gcpProjectNumberFlag)
@@ -117,6 +119,12 @@ func cloudAccountParamsFromFlags(cmd *cobra.Command, name string) (CloudAccountP
 		}
 		params.NebiusBindings = bindings
 	}
+
+	customTags, _, err := parseAccountTags(cmd)
+	if err != nil {
+		return CloudAccountParams{}, err
+	}
+	params.CustomTags = customTags
 
 	supportsCluster := cmd.Flags().Lookup(clusterNameFlag) != nil
 	if err := validateCloudAccountParamsForFlags(params, supportsCluster); err != nil {

--- a/cmd/account/tags.go
+++ b/cmd/account/tags.go
@@ -1,0 +1,74 @@
+package account
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	openapiclient "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
+	"github.com/spf13/cobra"
+)
+
+// parseAccountTags reads the --tags flag and converts it into the SDK custom tag format.
+func parseAccountTags(cmd *cobra.Command) ([]openapiclient.CustomTag, bool, error) {
+	if !cmd.Flags().Changed(tagsFlag) {
+		return nil, false, nil
+	}
+
+	raw, err := cmd.Flags().GetString(tagsFlag)
+	if err != nil {
+		return nil, false, err
+	}
+
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return nil, false, fmt.Errorf("at least one tag must be provided in key=value format when using --%s", tagsFlag)
+	}
+
+	rawPairs := strings.Split(trimmed, ",")
+	tags := make([]openapiclient.CustomTag, 0, len(rawPairs))
+	seen := make(map[string]struct{}, len(rawPairs))
+	for _, rawPair := range rawPairs {
+		pair := strings.TrimSpace(rawPair)
+		if pair == "" {
+			return nil, false, fmt.Errorf("tag pair cannot be empty")
+		}
+
+		parts := strings.SplitN(pair, "=", 2)
+		if len(parts) != 2 {
+			return nil, false, fmt.Errorf("invalid tag %q. Tags must use key=value format", pair)
+		}
+
+		key := strings.TrimSpace(parts[0])
+		if key == "" {
+			return nil, false, fmt.Errorf("tag key cannot be empty")
+		}
+		if _, exists := seen[key]; exists {
+			return nil, false, fmt.Errorf("duplicate tag key: %s", key)
+		}
+		seen[key] = struct{}{}
+
+		tags = append(tags, openapiclient.CustomTag{Key: key, Value: strings.TrimSpace(parts[1])})
+	}
+
+	sort.Slice(tags, func(i, j int) bool {
+		return tags[i].Key < tags[j].Key
+	})
+
+	return tags, true, nil
+}
+
+// formatAccountTags renders the account's custom tags as a compact key=value list for table output.
+func formatAccountTags(tags []openapiclient.CustomTag) string {
+	if len(tags) == 0 {
+		return ""
+	}
+
+	pairs := make([]string, 0, len(tags))
+	for _, tag := range tags {
+		pairs = append(pairs, tag.Key+"="+tag.Value)
+	}
+	sort.Strings(pairs)
+
+	return strings.Join(pairs, ",")
+}

--- a/cmd/account/tags_test.go
+++ b/cmd/account/tags_test.go
@@ -1,0 +1,103 @@
+package account
+
+import (
+	"testing"
+
+	openapiclient "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTagsTestCommand(t *testing.T) *cobra.Command {
+	t.Helper()
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String(tagsFlag, "", "")
+	return cmd
+}
+
+func TestParseAccountTags(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    *string
+		want     []openapiclient.CustomTag
+		provided bool
+		wantErr  string
+	}{
+		{
+			name:  "not provided",
+			value: nil,
+		},
+		{
+			name:     "single tag",
+			value:    ptr("env=prod"),
+			want:     []openapiclient.CustomTag{{Key: "env", Value: "prod"}},
+			provided: true,
+		},
+		{
+			name:  "multiple tags sorted by key",
+			value: ptr("team=platform, env=prod"),
+			want: []openapiclient.CustomTag{
+				{Key: "env", Value: "prod"},
+				{Key: "team", Value: "platform"},
+			},
+			provided: true,
+		},
+		{
+			name:  "keys with dots and slashes",
+			value: ptr("omnistrate.com/cost-center=cc-1234"),
+			want: []openapiclient.CustomTag{
+				{Key: "omnistrate.com/cost-center", Value: "cc-1234"},
+			},
+			provided: true,
+		},
+		{
+			name:    "rejects empty value",
+			value:   ptr(""),
+			wantErr: "at least one tag must be provided in key=value format when using --tags",
+		},
+		{
+			name:    "rejects missing separator",
+			value:   ptr("envprod"),
+			wantErr: `invalid tag "envprod". Tags must use key=value format`,
+		},
+		{
+			name:    "rejects empty key",
+			value:   ptr("=prod"),
+			wantErr: "tag key cannot be empty",
+		},
+		{
+			name:    "rejects duplicate keys",
+			value:   ptr("env=prod,env=dev"),
+			wantErr: "duplicate tag key: env",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newTagsTestCommand(t)
+			if tt.value != nil {
+				require.NoError(t, cmd.Flags().Set(tagsFlag, *tt.value))
+			}
+
+			tags, provided, err := parseAccountTags(cmd)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.provided, provided)
+			assert.Equal(t, tt.want, tags)
+		})
+	}
+}
+
+func TestFormatAccountTags(t *testing.T) {
+	assert.Empty(t, formatAccountTags(nil))
+	assert.Equal(t, "env=prod,team=platform", formatAccountTags([]openapiclient.CustomTag{
+		{Key: "team", Value: "platform"},
+		{Key: "env", Value: "prod"},
+	}))
+}

--- a/cmd/account/update.go
+++ b/cmd/account/update.go
@@ -36,6 +36,7 @@ func init() {
 	updateCmd.Flags().String("name", "", "Updated account name")
 	updateCmd.Flags().String("description", "", "Updated account description")
 	updateCmd.Flags().String("nebius-bindings-file", "", "Path to a YAML file describing the full replacement Nebius bindings")
+	updateCmd.Flags().String(tagsFlag, "", "Full replacement set of custom tags for the account in key=value format, separated by commas (e.g. env=prod,team=platform)")
 	updateCmd.Flags().Bool("skip-wait", false, "Skip waiting for account to become READY after replacing Nebius bindings")
 	_ = updateCmd.MarkFlagFilename("nebius-bindings-file")
 }
@@ -45,6 +46,7 @@ type UpdateCloudAccountParams struct {
 	Name           *string
 	Description    *string
 	NebiusBindings []openapiclient.NebiusAccountBindingInput
+	CustomTags     []openapiclient.CustomTag
 }
 
 func runUpdate(cmd *cobra.Command, args []string) error {
@@ -117,6 +119,7 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		Name:            params.Name,
 		Description:     params.Description,
 		NebiusBindings:  params.NebiusBindings,
+		CustomTags:      params.CustomTags,
 	})
 	if err != nil {
 		utils.HandleSpinnerError(spinner, sm, err)
@@ -189,6 +192,12 @@ func buildUpdateAccountParams(
 		params.NebiusBindings = bindings
 	}
 
+	customTags, _, err := parseAccountTags(cmd)
+	if err != nil {
+		return UpdateCloudAccountParams{}, err
+	}
+	params.CustomTags = customTags
+
 	if err := validateUpdateAccountParams(params); err != nil {
 		return UpdateCloudAccountParams{}, err
 	}
@@ -209,8 +218,8 @@ func validateUpdateAccountParams(params UpdateCloudAccountParams) error {
 		return errors.New("description cannot be empty")
 	}
 
-	if params.Name == nil && params.Description == nil && len(params.NebiusBindings) == 0 {
-		return errors.New("at least one of --name, --description, or --nebius-bindings-file must be provided")
+	if params.Name == nil && params.Description == nil && len(params.NebiusBindings) == 0 && len(params.CustomTags) == 0 {
+		return errors.New("at least one of --name, --description, --nebius-bindings-file, or --tags must be provided")
 	}
 
 	return nil

--- a/cmd/account/update_test.go
+++ b/cmd/account/update_test.go
@@ -39,11 +39,18 @@ func TestValidateUpdateAccountParams(t *testing.T) {
 			},
 		},
 		{
+			name: "custom tags replacement is allowed",
+			params: UpdateCloudAccountParams{
+				ID:         "ac-123",
+				CustomTags: []openapiclient.CustomTag{{Key: "env", Value: "prod"}},
+			},
+		},
+		{
 			name: "requires mutable fields",
 			params: UpdateCloudAccountParams{
 				ID: "ac-123",
 			},
-			wantErr: "at least one of --name, --description, or --nebius-bindings-file must be provided",
+			wantErr: "at least one of --name, --description, --nebius-bindings-file, or --tags must be provided",
 		},
 		{
 			name: "rejects empty name",

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/muesli/cancelreader v0.2.2
 	github.com/njayp/ophis v1.1.4
-	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.121
+	github.com/omnistrate-oss/omnistrate-sdk-go v0.0.122
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.1

--- a/go.sum
+++ b/go.sum
@@ -204,8 +204,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/njayp/ophis v1.1.4 h1:6aq3UdU6MlGIjpg//IzKc2yIxHYMf6Rg1A5MLovM9gg=
 github.com/njayp/ophis v1.1.4/go.mod h1:F9KEnfeCJzCWo3e0JP2QqSCN04bXptXl1ico5lcLeYg=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.121 h1:Bv2HL8ttNbCGSy4vYv2IS77svT4CsyqD0u24ByBk9L0=
-github.com/omnistrate-oss/omnistrate-sdk-go v0.0.121/go.mod h1:q0FPYLbtm+Aw6GW0xbeaMPHR4WGzoV61iTGFoOhO72M=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.122 h1:dO5sTTHHqQyEt11dnFlI4VM70pZhz1am9zrmM5x7etY=
+github.com/omnistrate-oss/omnistrate-sdk-go v0.0.122/go.mod h1:q0FPYLbtm+Aw6GW0xbeaMPHR4WGzoV61iTGFoOhO72M=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/internal/config/configuration.go
+++ b/internal/config/configuration.go
@@ -239,6 +239,9 @@ func CleanupArgsAndFlags(cmd *cobra.Command, args *[]string) {
 			} else {
 				_ = cmd.Flags().Set(f.Name, f.DefValue)
 			}
+			// pflag's Set marks the flag as Changed; clear it so subsequent
+			// in-process executions see a pristine flag set
+			f.Changed = false
 		})
 
 	// Clean up arguments by resetting the slice to nil or an empty slice

--- a/internal/config/configuration_test.go
+++ b/internal/config/configuration_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -236,4 +237,23 @@ func TestCleanupArgsAndFlags_EmptyStringArray(t *testing.T) {
 
 	val, _ = cmd.Flags().GetStringArray("tags")
 	assert.Equal(t, []string{}, val)
+}
+
+func TestCleanupArgsAndFlags_ResetsChanged(t *testing.T) {
+	cmd := &cobra.Command{Use: "test", RunE: func(cmd *cobra.Command, args []string) error { return nil }}
+	cmd.Flags().String("tags", "", "tags")
+	cmd.Flags().StringArray("platforms", []string{}, "platforms")
+
+	// Simulate first execution setting a flag
+	_ = cmd.Flags().Set("tags", "env=prod")
+	assert.True(t, cmd.Flags().Changed("tags"))
+
+	args := []string{}
+	CleanupArgsAndFlags(cmd, &args)
+
+	// Subsequent in-process executions must see a pristine flag set: flags that
+	// were never passed must not read as Changed just because cleanup reset them
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		assert.False(t, f.Changed, "flag %s should not be marked Changed after cleanup", f.Name)
+	})
 }

--- a/internal/dataaccess/account.go
+++ b/internal/dataaccess/account.go
@@ -87,6 +87,7 @@ type UpdateAccountParams struct {
 	Name            *string
 	Description     *string
 	NebiusBindings  []openapiclient.NebiusAccountBindingInput
+	CustomTags      []openapiclient.CustomTag
 }
 
 func UpdateAccount(ctx context.Context, token string, params UpdateAccountParams) (string, error) {
@@ -98,6 +99,9 @@ func UpdateAccount(ctx context.Context, token string, params UpdateAccountParams
 	}
 	if len(params.NebiusBindings) > 0 {
 		request.NebiusBindings = params.NebiusBindings
+	}
+	if len(params.CustomTags) > 0 {
+		request.CustomTags = params.CustomTags
 	}
 
 	apiClient := getV1Client()

--- a/internal/model/account.go
+++ b/internal/model/account.go
@@ -6,4 +6,5 @@ type Account struct {
 	Status          string `json:"status"`
 	CloudProvider   string `json:"cloud_provider"`
 	TargetAccountID string `json:"target_account_id"`
+	CustomTags      string `json:"custom_tags,omitempty"`
 }

--- a/mkdocs/docs/omnistrate-ctl_account_create.md
+++ b/mkdocs/docs/omnistrate-ctl_account_create.md
@@ -38,6 +38,7 @@ omnistrate-ctl account create [account-name] --nebius-tenant-id=[tenant-id] --ne
       --nebius-bindings-file string    Path to a YAML file describing Nebius bindings
       --nebius-tenant-id string        Nebius tenant ID
       --skip-wait                      Skip waiting for account onboarding to become READY
+      --tags string                    Custom tags for the account in key=value format, separated by commas (e.g. env=prod,team=platform)
 ```
 
 ### Options inherited from parent commands

--- a/mkdocs/docs/omnistrate-ctl_account_customer_create.md
+++ b/mkdocs/docs/omnistrate-ctl_account_customer_create.md
@@ -62,6 +62,7 @@ omnistrate-ctl account customer create --service=[service] --environment=[enviro
       --service string                          Service name or ID
       --skip-wait                               Skip waiting for account onboarding to become READY
       --subscription-id string                  Subscription ID to use for the onboarding instance
+      --tags string                             Custom tags for the account in key=value format, separated by commas (e.g. env=prod,team=platform)
 ```
 
 ### Options inherited from parent commands

--- a/mkdocs/docs/omnistrate-ctl_account_customer_update.md
+++ b/mkdocs/docs/omnistrate-ctl_account_customer_update.md
@@ -28,6 +28,7 @@ omnistrate-ctl account customer update instance-abcd1234 --nebius-bindings-file=
       --name string                   Updated backing account name
       --nebius-bindings-file string   Path to a YAML file describing the full replacement Nebius bindings
       --skip-wait                     Skip waiting for the backing account to become READY after replacing Nebius bindings
+      --tags string                   Full replacement set of custom tags for the backing account in key=value format, separated by commas (e.g. env=prod,team=platform)
 ```
 
 ### Options inherited from parent commands

--- a/mkdocs/docs/omnistrate-ctl_account_list.md
+++ b/mkdocs/docs/omnistrate-ctl_account_list.md
@@ -21,7 +21,7 @@ omnistrate-ctl account list
 ### Options
 
 ```
-  -f, --filter stringArray   Filter to apply to the list of accounts. E.g.: key1:value1,key2:value2, which filters accounts where key1 equals value1 and key2 equals value2. Allow use of multiple filters to form the logical OR operation. Supported keys: id,name,status,cloud_provider,target_account_id. Check the examples for more details.
+  -f, --filter stringArray   Filter to apply to the list of accounts. E.g.: key1:value1,key2:value2, which filters accounts where key1 equals value1 and key2 equals value2. Allow use of multiple filters to form the logical OR operation. Supported keys: id,name,status,cloud_provider,target_account_id,custom_tags. Check the examples for more details.
   -h, --help                 help for list
 ```
 

--- a/mkdocs/docs/omnistrate-ctl_account_update.md
+++ b/mkdocs/docs/omnistrate-ctl_account_update.md
@@ -28,6 +28,7 @@ omnistrate-ctl account update [account-name or account-id] --nebius-bindings-fil
       --name string                   Updated account name
       --nebius-bindings-file string   Path to a YAML file describing the full replacement Nebius bindings
       --skip-wait                     Skip waiting for account to become READY after replacing Nebius bindings
+      --tags string                   Full replacement set of custom tags for the account in key=value format, separated by commas (e.g. env=prod,team=platform)
 ```
 
 ### Options inherited from parent commands

--- a/test/smoke_test/build/compose/build_test.go
+++ b/test/smoke_test/build/compose/build_test.go
@@ -314,7 +314,9 @@ func Test_build_create_no_name(t *testing.T) {
 	cmd.RootCmd.SetArgs([]string{"build", "-f", "../../composefiles/postgresql.yaml", "--description", "My Service Description", "--service-logo-url", "https://freepnglogos.com/uploads/server-png/server-computer-database-network-vector-graphic-pixabay-31.png"})
 	err = cmd.RootCmd.ExecuteContext(ctx)
 	require.Error(err)
-	require.Contains(err.Error(), "name is required")
+	// Matches real fresh-process CLI behavior: cobra's one-required flag group
+	// fires before the command's own name validation
+	require.Contains(err.Error(), "at least one of the flags in the group [name product-name] is required")
 }
 
 func Test_build_create_no_description(t *testing.T) {


### PR DESCRIPTION
## What

Adds custom tag support to the cloud account command sets. Tags are free-form `key=value` pairs stored on the account configuration — the definitive store that deployment cells expose as the `$sys.deploymentCell.accountTags` system parameter (used for conditional amenities, amenity chart values, and per-account service configuration).

New `--tags` flag on:

- `account create` — set tags at onboarding time
- `account update` — replace the tag set on an existing account
- `account customer create` — tags flow through the BYOA onboarding instance to the customer's backing account configuration
- `account customer update` — replace the tag set on the backing account configuration

Tags are shown in `account describe`, `account list`, and `account customer describe` output (JSON field `customTags`, table column `custom_tags`).

## Sample usage

All outputs below are from a live end-to-end verification run against production APIs (SDK v0.0.122), lightly redacted.

### Create an account with tags

```bash
$ omnistrate-ctl account create my-aws-account --aws-account-id=999900112233 \
    --tags "env=e2e-test,team=platform" --skip-wait --output json
{
    "id": "ac-9hY8ZubSDA",
    "name": "my-aws-account",
    "awsAccountID": "999900112233",
    "customTags": [
        { "key": "env", "value": "e2e-test" },
        { "key": "team", "value": "platform" }
    ],
    "status": "VERIFYING",
    "statusMessage": "verifying account access"
}
```

### Update tags (full replacement)

```bash
$ omnistrate-ctl account update ac-9hY8ZubSDA \
    --tags "env=staging,omnistrate.com/cost-center=cc-e2e" --output json
{
    "id": "ac-9hY8ZubSDA",
    "customTags": [
        { "key": "env", "value": "staging" },
        { "key": "omnistrate.com/cost-center", "value": "cc-e2e" }
    ]
}
```

Note `--tags` replaces the whole set: `env` was overwritten, `team` was removed, and keys containing `.` and `/` are supported.

### Customer BYOA onboarding with tags

```bash
$ omnistrate-ctl account customer create --service my-service --environment Dev \
    --plan my-byoa-plan --subscription-id sub-abcd1234 \
    --aws-account-id=999900112233 --tags "env=e2e-test,team=platform" --skip-wait --output json
{
    "instanceId": "instance-0t1owkfo0",
    "resource": "Cloud Provider Account",
    "cloudProvider": "aws",
    "status": "DEPLOYING",
    "subscriptionId": "sub-abcd1234"
}
```

The tags ride the onboarding instance through the provisioning workflow into the backing account configuration:

```bash
$ omnistrate-ctl account customer describe instance-0t1owkfo0 --output json
{
    "summary": {
        "instance_id": "instance-0t1owkfo0",
        "account_config_id": "ac-809ky8c2ie",
        "target_account_id": "999900112233",
        "instance_status": "DEPLOYING",
        "account_status": "VERIFYING",
        "custom_tags": "env=e2e-test,team=platform"
    }
}
```

### Update tags on a customer's backing account

```bash
$ omnistrate-ctl account customer update instance-0t1owkfo0 \
    --tags "env=staging,omnistrate.com/cost-center=cc-e2e"
# describe now shows:
#   custom_tags: env=staging,omnistrate.com/cost-center=cc-e2e
```

## Semantics and validation

- **Full replacement**: `--tags` on the update commands replaces the entire tag set; include every tag you want to keep.
- **One definitive store**: for BYOA onboarding instances, tags always live on the backing account configuration — reads return the account's tags, and an account shared by multiple onboarding instances has a single tag set (last write wins).
- **Format**: comma-separated `key=value` pairs; keys/values are trimmed; keys may contain `.` and `/`.
