### PR TITLE
List clusters after sync and import

### DIFF
--- a/cmd/account/cloudnativenetwork/cloudnativenetwork_test.go
+++ b/cmd/account/cloudnativenetwork/cloudnativenetwork_test.go
@@ -1,8 +1,11 @@
 package cloudnativenetwork
 
 import (
+	"io"
+	"os"
 	"testing"
 
+	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -137,6 +140,94 @@ func TestSyncTargetsFromFlagsRejectsMalformedNetwork(t *testing.T) {
 	_, err := syncTargetsFromFlags(nil, nil, []string{"vpc-abc123"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "expected region:network-id")
+}
+
+func TestFormatHostClusters(t *testing.T) {
+	reason := "cluster is already managed"
+	hostClusters := []openapiclientfleet.FleetAccountConfigCloudNativeNetworkHostClusterResult{
+		{Name: "eligible-cluster", EligibleToImport: true},
+		{Name: "ineligible-cluster", EligibleToImport: false, IneligibilityReason: &reason},
+	}
+
+	assert.Equal(t,
+		"eligible-cluster - eligible for import\nineligible-cluster - not eligible for import - cluster is already managed",
+		formatHostClusters(hostClusters),
+	)
+}
+
+func TestFormatHostClustersUsesPlaceholderForMissingReason(t *testing.T) {
+	hostClusters := []openapiclientfleet.FleetAccountConfigCloudNativeNetworkHostClusterResult{
+		{Name: "ineligible-cluster", EligibleToImport: false},
+	}
+
+	assert.Equal(t, "ineligible-cluster - not eligible for import", formatHostClusters(hostClusters))
+}
+
+func TestPrintCloudNativeNetworkTableIncludesHostClustersOnePerLine(t *testing.T) {
+	reason := "unsupported cluster version"
+	result := &openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult{
+		CloudNativeNetworks: []openapiclientfleet.FleetAccountConfigCloudNativeNetworkResult{
+			{
+				CloudNativeNetworkId: "vpc-123",
+				Region:               "us-east-1",
+				Status:               "AVAILABLE",
+				HostClusters: []openapiclientfleet.FleetAccountConfigCloudNativeNetworkHostClusterResult{
+					{Name: "eligible-cluster", EligibleToImport: true},
+					{Name: "ineligible-cluster", EligibleToImport: false, IneligibilityReason: &reason},
+				},
+			},
+		},
+	}
+
+	var printErr error
+	output := captureStdout(t, func() {
+		printErr = printCloudNativeNetworkTable(result)
+	})
+
+	require.NoError(t, printErr)
+	assert.Contains(t, output, "HOST CLUSTERS")
+	assert.Contains(t, output, "eligible-cluster - eligible for import\n")
+	assert.Contains(t, output, "ineligible-cluster - not eligible for import - unsupported cluster version")
+}
+
+func TestPrintCloudNativeNetworkTableOmitsHostClustersWithoutClusters(t *testing.T) {
+	result := &openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult{
+		CloudNativeNetworks: []openapiclientfleet.FleetAccountConfigCloudNativeNetworkResult{
+			{
+				CloudNativeNetworkId: "vpc-123",
+				Region:               "us-east-1",
+				Status:               "AVAILABLE",
+			},
+		},
+	}
+
+	var printErr error
+	output := captureStdout(t, func() {
+		printErr = printCloudNativeNetworkTable(result)
+	})
+
+	require.NoError(t, printErr)
+	assert.NotContains(t, output, "HOST CLUSTERS")
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	readPipe, writePipe, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = writePipe
+	defer func() {
+		os.Stdout = oldStdout
+		_ = readPipe.Close()
+	}()
+
+	fn()
+	require.NoError(t, writePipe.Close())
+
+	output, err := io.ReadAll(readPipe)
+	require.NoError(t, err)
+	return string(output)
 }
 
 func TestDeploymentCellCommandStructure(t *testing.T) {

--- a/cmd/account/cloudnativenetwork/output.go
+++ b/cmd/account/cloudnativenetwork/output.go
@@ -3,6 +3,7 @@ package cloudnativenetwork
 import (
 	"fmt"
 	"os"
+	"strings"
 	"text/tabwriter"
 
 	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
@@ -10,6 +11,8 @@ import (
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
 )
+
+const cloudNativeNetworkTableColumnCount = 9
 
 func printCloudNativeNetworkOutput(output string, result *openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult) error {
 	switch output {
@@ -31,24 +34,56 @@ func printCloudNativeNetworkTable(result *openapiclientfleet.FleetListAccountCon
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "NETWORK ID\tREGION\tNAME\tCIDR\tSTATUS\tIMPORTED\tIN USE\tPRIVATE SUBNETS\tPUBLIC SUBNETS")
-	fmt.Fprintln(w, "------\t------\t----\t----\t------\t--------\t------\t---------------\t--------------")
+	includeHostClusters := hasHostClusters(result)
+	header := "NETWORK ID\tREGION\tNAME\tCIDR\tSTATUS\tIMPORTED\tIN USE\tPRIVATE SUBNETS\tPUBLIC SUBNETS"
+	separator := "------\t------\t----\t----\t------\t--------\t------\t---------------\t--------------"
+	if includeHostClusters {
+		header += "\tHOST CLUSTERS"
+		separator += "\t-------------"
+	}
+	fmt.Fprintln(w, header)
+	fmt.Fprintln(w, separator)
 
 	for _, network := range result.CloudNativeNetworks {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%t\t%t\t%d\t%d\n",
-			network.CloudNativeNetworkId,
-			network.Region,
-			derefString(network.Name),
-			derefString(network.Cidr),
-			network.Status,
-			derefBool(network.Imported),
-			derefBool(network.InUse),
-			len(network.PrivateSubnets),
-			len(network.PublicSubnets),
-		)
+		row := []string{network.CloudNativeNetworkId, network.Region, derefString(network.Name), derefString(network.Cidr), network.Status,
+			fmt.Sprintf("%t", derefBool(network.Imported)), fmt.Sprintf("%t", derefBool(network.InUse)), fmt.Sprintf("%d", len(network.PrivateSubnets)), fmt.Sprintf("%d", len(network.PublicSubnets))}
+		if includeHostClusters {
+			row = append(row, formatHostClustersForTable(network.HostClusters))
+		}
+		fmt.Fprintln(w, strings.Join(row, "\t"))
 	}
 
 	return w.Flush()
+}
+
+func hasHostClusters(result *openapiclientfleet.FleetListAccountConfigCloudNativeNetworksResult) bool {
+	for _, network := range result.CloudNativeNetworks {
+		if len(network.HostClusters) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func formatHostClusters(hostClusters []openapiclientfleet.FleetAccountConfigCloudNativeNetworkHostClusterResult) string {
+	lines := make([]string, 0, len(hostClusters))
+	for _, hostCluster := range hostClusters {
+		if hostCluster.EligibleToImport {
+			lines = append(lines, fmt.Sprintf("%s - eligible for import", hostCluster.Name))
+			continue
+		}
+
+		line := fmt.Sprintf("%s - not eligible for import", hostCluster.Name)
+		if hostCluster.IneligibilityReason != nil {
+			line += " - " + *hostCluster.IneligibilityReason
+		}
+		lines = append(lines, line)
+	}
+	return strings.Join(lines, "\n")
+}
+
+func formatHostClustersForTable(hostClusters []openapiclientfleet.FleetAccountConfigCloudNativeNetworkHostClusterResult) string {
+	return strings.ReplaceAll(formatHostClusters(hostClusters), "\n", "\n"+strings.Repeat("\t", cloudNativeNetworkTableColumnCount))
 }
 
 func printDeploymentCellImportOutput(output string, result *dataaccess.CloudNativeNetworkDeploymentCellImportResult) error {


### PR DESCRIPTION
```
❯ omctl-source-prod account cloud-native-network sync $ACCOUNT_CONFIG_ID --region=$IMPORT_REGION --network-id=$IMPORT_NETWORK --include-host-clusters
NETWORK ID             REGION     NAME                         CIDR           STATUS  IMPORTED  IN USE  PRIVATE SUBNETS  PUBLIC SUBNETS  HOST CLUSTERS
------                 ------     ----                         ----           ------  --------  ------  ---------------  --------------  -------------
vpc-02a3395cba4112abb  us-west-2  omnistrate-vpc-hc-sgksduxf9  172.16.0.0/16  READY   true      true    3                3
vpc-037b5c891331fb2d8  us-east-1  omnistrate-vpc-hc-i9ymicm11  10.8.0.0/16    READY   true      false   4                6
vpc-0f8dd6a00b9fbc76e  us-west-2  omnistrate-vpc               10.8.0.0/16    READY   true      false   8                2               omnistrate-blue - eligible for import
vpc-0fbc14fb368d6535d  us-west-2  omnistrate-vpc               10.8.0.0/16    READY   true      true    8                2               omnistrate-blue - eligible for import
```