### PR TITLE
fix: create instance in the requested service environment

### DIFF
--- a/cmd/instance/create.go
+++ b/cmd/instance/create.go
@@ -291,7 +291,24 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		utils.HandleSpinnerError(spinner, sm, err)
 		return err
 	}
-	offering := res.ConsumptionDescribeServiceOfferingResult.Offerings[0]
+	if res == nil || res.ConsumptionDescribeServiceOfferingResult == nil {
+		err = errors.New("no service offerings found for the target service plan")
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+
+	// Select the offering for the requested environment. The response can contain one
+	// offering per environment the product tier is promoted to.
+	selectedOffering, err := selectOfferingForEnvironment(
+		res.ConsumptionDescribeServiceOfferingResult.Offerings,
+		environmentID,
+		productTierID,
+	)
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+	offering := *selectedOffering
 
 	// Format parameters
 	formattedParams, err := common.FormatParams(param, paramFile)
@@ -565,6 +582,44 @@ func resolveResourceFromServiceOffering(offerings *openapiclientv1.DescribeServi
 
 func matchesIDOrName(id, name, arg string) bool {
 	return strings.EqualFold(id, arg) || strings.EqualFold(name, arg)
+}
+
+// selectOfferingForEnvironment picks the offering that belongs to the requested service
+// environment and product tier. The fleet DescribeServiceOffering API only filters by
+// product tier and version, so a product tier promoted to several environments comes back
+// as one offering per environment. Picking the first offering blindly would deploy the
+// instance into whichever environment the platform happened to list first.
+func selectOfferingForEnvironment(
+	offerings []openapiclientfleet.ServiceOffering,
+	environmentID string,
+	productTierID string,
+) (*openapiclientfleet.ServiceOffering, error) {
+	if len(offerings) == 0 {
+		return nil, errors.New("no service offerings found for the target service plan")
+	}
+
+	for i := range offerings {
+		offering := &offerings[i]
+		if !strings.EqualFold(offering.ServiceEnvironmentID, environmentID) {
+			continue
+		}
+		if productTierID != "" && !strings.EqualFold(offering.ProductTierID, productTierID) {
+			continue
+		}
+		return offering, nil
+	}
+
+	available := make([]string, 0, len(offerings))
+	for _, offering := range offerings {
+		available = append(available, fmt.Sprintf("%s (%s)", offering.ServiceEnvironmentName, offering.ServiceEnvironmentID))
+	}
+
+	return nil, fmt.Errorf(
+		"service plan %s is not available in environment %s. The requested version may not be promoted to that environment. Available environments for this version: %s",
+		productTierID,
+		environmentID,
+		strings.Join(available, ", "),
+	)
 }
 
 func formatInstance(instance *openapiclientfleet.ResourceInstanceSearchRecord, truncateNames bool) model.Instance {

--- a/cmd/instance/create_test.go
+++ b/cmd/instance/create_test.go
@@ -406,6 +406,72 @@ func TestResolveResourceFromServiceOffering_DeduplicatesSameResourceAcrossOfferi
 	assert.Equal(t, "r-target-mysql", resourceID)
 }
 
+func TestSelectOfferingForEnvironment_PicksRequestedEnvironmentNotFirstOffering(t *testing.T) {
+	offerings := []openapiclientfleet.ServiceOffering{
+		{
+			ServiceEnvironmentID:     "se-dev",
+			ServiceEnvironmentName:   "Dev",
+			ServiceEnvironmentURLKey: "dev",
+			ProductTierID:            "pt-byoa",
+		},
+		{
+			ServiceEnvironmentID:     "se-prod",
+			ServiceEnvironmentName:   "Production",
+			ServiceEnvironmentURLKey: "prod",
+			ProductTierID:            "pt-byoa",
+		},
+	}
+
+	offering, err := selectOfferingForEnvironment(offerings, "se-prod", "pt-byoa")
+
+	require.NoError(t, err)
+	assert.Equal(t, "prod", offering.ServiceEnvironmentURLKey)
+}
+
+func TestSelectOfferingForEnvironment_MatchesProductTierWithinEnvironment(t *testing.T) {
+	offerings := []openapiclientfleet.ServiceOffering{
+		{
+			ServiceEnvironmentID:     "se-prod",
+			ServiceEnvironmentURLKey: "prod",
+			ProductTierID:            "pt-hosted",
+			ProductTierURLKey:        "hosted",
+		},
+		{
+			ServiceEnvironmentID:     "se-prod",
+			ServiceEnvironmentURLKey: "prod",
+			ProductTierID:            "pt-byoa",
+			ProductTierURLKey:        "byoa",
+		},
+	}
+
+	offering, err := selectOfferingForEnvironment(offerings, "se-prod", "pt-byoa")
+
+	require.NoError(t, err)
+	assert.Equal(t, "byoa", offering.ProductTierURLKey)
+}
+
+func TestSelectOfferingForEnvironment_ErrorsWhenEnvironmentMissing(t *testing.T) {
+	offerings := []openapiclientfleet.ServiceOffering{
+		{
+			ServiceEnvironmentID:     "se-dev",
+			ServiceEnvironmentURLKey: "dev",
+			ProductTierID:            "pt-byoa",
+		},
+	}
+
+	_, err := selectOfferingForEnvironment(offerings, "se-prod", "pt-byoa")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "se-prod")
+}
+
+func TestSelectOfferingForEnvironment_ErrorsOnEmptyOfferings(t *testing.T) {
+	_, err := selectOfferingForEnvironment(nil, "se-prod", "pt-byoa")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no service offerings")
+}
+
 func servicesFixture(services ...openapiclientv1.DescribeServiceResult) *openapiclientv1.ListServiceResult {
 	return &openapiclientv1.ListServiceResult{
 		Ids:      []string{},


### PR DESCRIPTION
## Problem

`instance create` could deploy into the wrong service environment and then report
`instance not found`, unless an explicit `--version` was passed.

Reproducer — an instance requested against a `PROD` environment was created in `dev`:

omctl instance create
  --service "DataRobot STS" --environment $ACCOUNT_ENVIRONMENT
  --plan byoa --resource datarobot-chart
  --cloud-provider $IMPORT_CLOUD_PROVIDER --region $IMPORT_REGION
  --customer-account-id $ACCOUNT_INSTANCE_ID
  --cloud-provider-native-network-id $IMPORT_NETWORK
  --network-type INTERNAL --param-file ./params.json

## Root cause

`runCreate` resolved `--environment` correctly and then discarded the result when
selecting the service offering:

1. `getResource` resolves `--environment` to the correct `environmentID`.
2. `dataaccess.DescribeServiceOffering` is called with only `serviceID`, `productTierID`
   and `version`. The fleet endpoint accepts no environment filter — it supports just
   `visibility`, `productTierId` and `productTierVersion` — so a product tier promoted to
   several environments returns one offering per environment.
3. The code took `Offerings[0]` unconditionally, which was the `dev` offering.
4. That offering's `ServiceEnvironmentURLKey` was passed to `CreateResourceInstance`, so
   the instance was created in `dev`.
5. `DescribeResourceInstance` was then called with the *requested* (prod) `environmentID`,
   which failed with `instance not found`.

Both symptoms came from step 3. Passing `--version` masked the bug because
`productTierVersion` narrowed the offering list so that `Offerings[0]` happened to be the
right environment.

The rest of the codebase already handles this: `findCustomerAccountOffering`
(`cmd/account/customer_create.go`) matches on both `ServiceEnvironmentID` and
`ProductTierID`, and `cmd/deploy/deploy.go` uses `ExternalDescribeServiceOffering`, which
filters by environment client-side. `instance create` was the only caller of the
unfiltered fleet variant.

## Changes

- Add `selectOfferingForEnvironment`, which picks the offering matching the resolved
  environment and product tier instead of taking the first one.
- Guard the nil-result and empty-offerings cases — `Offerings[0]` would panic on an empty
  list.
- When no offering matches, report the likely cause rather than deploying elsewhere:

  service plan pt-xyz is not available in environment se-prod. The requested version may
  not be promoted to that environment. Available environments for this version: Dev (se-dev)

`--version` is no longer needed as a workaround; the default `preferred` now targets the
requested environment.