### PR TITLE
Fix AWS BYOA customer network defaults

### DIFF
--- a/cmd/account/create_test.go
+++ b/cmd/account/create_test.go
@@ -230,19 +230,25 @@ func TestPrivateLinkFlagParsing(t *testing.T) {
 	cmd := &cobra.Command{}
 	addCloudAccountProviderFlags(cmd)
 	cmd.Flags().Bool(privateLinkFlag, false, "")
-	cmd.Flags().Bool(allowCreateNewFlag, false, "")
+	cmd.Flags().Bool(allowCreateNewFlag, true, "")
 
-	// Default is false
 	require.NoError(t, cmd.Flags().Set(awsAccountIDFlag, "123456789012"))
 	params, err := cloudAccountParamsFromFlags(cmd, "test-account")
 	require.NoError(t, err)
 	assert.False(t, params.PrivateLink)
+	assert.True(t, params.AllowCreateNew)
 
-	// Set to true
 	require.NoError(t, cmd.Flags().Set(privateLinkFlag, "true"))
+	require.NoError(t, cmd.Flags().Set(allowCreateNewFlag, "true"))
 	params, err = cloudAccountParamsFromFlags(cmd, "test-account")
 	require.NoError(t, err)
 	assert.True(t, params.PrivateLink)
+	assert.True(t, params.AllowCreateNew)
+
+	require.NoError(t, cmd.Flags().Set(allowCreateNewFlag, "false"))
+	params, err = cloudAccountParamsFromFlags(cmd, "test-account")
+	require.NoError(t, err)
+	assert.False(t, params.AllowCreateNew)
 }
 
 func TestPrivateLinkFlagRegistered(t *testing.T) {

--- a/cmd/account/customer_create.go
+++ b/cmd/account/customer_create.go
@@ -122,7 +122,7 @@ func init() {
 
 	addCustomerAccountProviderFlags(customerCreateCmd)
 	customerCreateCmd.Flags().Bool(privateLinkFlag, false, "Enable AWS PrivateLink connectivity for services deployed in this account")
-	customerCreateCmd.Flags().Bool(allowCreateNewFlag, false, "Allow the platform to create new cloud-native networks in this account on demand")
+	customerCreateCmd.Flags().Bool(allowCreateNewFlag, true, "Allow Omnistrate to create cloud-native networks in this account")
 	customerCreateCmd.Flags().StringSlice(cloudNativeNetworksFlag, nil, "Cloud-native networks to sync and import after account creation (format: region:network-id, e.g. us-east-1:vpc-abc123)")
 
 	customerCreateCmd.Flags().String("service", "", "Service name or ID")
@@ -699,7 +699,8 @@ func buildCustomerAccountRequestParamsWithDerivedValues(
 		return nil
 	}
 
-	switch requestedCloudProvider(params) {
+	cloudProvider := requestedCloudProvider(params)
+	switch cloudProvider {
 	case "aws":
 		if err := setParam(customerAccountIacToolName, "CloudFormation"); err != nil {
 			return nil, err
@@ -772,13 +773,14 @@ func buildCustomerAccountRequestParamsWithDerivedValues(
 		return nil
 	}
 
-	if params.PrivateLink {
-		if err := setOptionalParam(customerAccountPrivateLinkName, true); err != nil {
+	if cloudProvider == "aws" {
+		if err := setOptionalParam(customerAccountPrivateLinkName, params.PrivateLink); err != nil {
 			return nil, err
 		}
 	}
-	if params.AllowCreateNew {
-		if err := setOptionalParam(customerAccountAllowCreateNewName, true); err != nil {
+
+	if cloudProvider != "byoc-onprem" {
+		if err := setOptionalParam(customerAccountAllowCreateNewName, params.AllowCreateNew); err != nil {
 			return nil, err
 		}
 	}

--- a/cmd/account/customer_create_test.go
+++ b/cmd/account/customer_create_test.go
@@ -96,6 +96,7 @@ func TestBuildCustomerAccountRequestParamsWithDerivedValues_Nebius(t *testing.T)
 	params := CloudAccountParams{
 		Name:           "customer-nebius",
 		NebiusTenantID: "tenant-1",
+		AllowCreateNew: true,
 		NebiusBindings: []openapiclient.NebiusAccountBindingInput{
 			{
 				ProjectID:        "project-1",
@@ -109,12 +110,14 @@ func TestBuildCustomerAccountRequestParamsWithDerivedValues_Nebius(t *testing.T)
 	inputParameters := []openapiclient.DescribeInputParameterResult{
 		{Name: customerAccountNebiusTenantIDName, Key: "nebius_tenant_id"},
 		{Name: customerAccountNebiusBindingsName, Key: "nebius_bindings"},
+		{Name: customerAccountAllowCreateNewName, Key: "allow_new_cloud_native_network_creation"},
 	}
 
 	requestParams, err := buildCustomerAccountRequestParamsWithDerivedValues(params, inputParameters, "")
 	require.NoError(t, err)
-	require.Len(t, requestParams, 2)
+	require.Len(t, requestParams, 3)
 	assert.Equal(t, "tenant-1", requestParams["nebius_tenant_id"])
+	assert.Equal(t, true, requestParams["allow_new_cloud_native_network_creation"])
 
 	bindings, ok := requestParams["nebius_bindings"].([]map[string]any)
 	require.True(t, ok)
@@ -134,14 +137,17 @@ func TestBuildCustomerAccountRequestParamsWithDerivedValues_Nebius(t *testing.T)
 
 func TestBuildCustomerAccountRequestParamsWithDerivedValues_AWS(t *testing.T) {
 	params := CloudAccountParams{
-		Name:         "customer-aws",
-		AwsAccountID: "123456789012",
+		Name:           "customer-aws",
+		AwsAccountID:   "123456789012",
+		AllowCreateNew: true,
 	}
 
 	inputParameters := []openapiclient.DescribeInputParameterResult{
 		{Name: customerAccountIacToolName, Key: "account_configuration_method"},
 		{Name: customerAccountAWSAccountIDName, Key: "aws_account_id"},
 		{Name: customerAccountAWSBootstrapRoleName, Key: "aws_bootstrap_role_arn"},
+		{Name: customerAccountPrivateLinkName, Key: "private_link"},
+		{Name: customerAccountAllowCreateNewName, Key: "allow_new_cloud_native_network_creation"},
 	}
 
 	requestParams, err := buildCustomerAccountRequestParamsWithDerivedValues(params, inputParameters, "")
@@ -149,6 +155,8 @@ func TestBuildCustomerAccountRequestParamsWithDerivedValues_AWS(t *testing.T) {
 	assert.Equal(t, "CloudFormation", requestParams["account_configuration_method"])
 	assert.Equal(t, "123456789012", requestParams["aws_account_id"])
 	assert.Equal(t, "arn:aws:iam::123456789012:role/omnistrate-bootstrap-role", requestParams["aws_bootstrap_role_arn"])
+	assert.Equal(t, false, requestParams["private_link"])
+	assert.Equal(t, true, requestParams["allow_new_cloud_native_network_creation"])
 }
 
 func TestCustomerAccountInputParameters(t *testing.T) {
@@ -272,10 +280,11 @@ func TestBuildCustomerAccountRequestParamsWithDerivedValues_PrivateLinkMissingEr
 	assert.Contains(t, err.Error(), customerAccountPrivateLinkName)
 }
 
-func TestBuildCustomerAccountRequestParamsWithDerivedValues_FlagsOmittedDoesNotSetParams(t *testing.T) {
+func TestBuildCustomerAccountRequestParamsWithDerivedValues_AWSDefaultMatchesUINonPrivate(t *testing.T) {
 	params := CloudAccountParams{
-		Name:         "customer-aws",
-		AwsAccountID: "123456789012",
+		Name:           "customer-aws",
+		AwsAccountID:   "123456789012",
+		AllowCreateNew: true,
 	}
 
 	inputParameters := []openapiclient.DescribeInputParameterResult{
@@ -288,10 +297,51 @@ func TestBuildCustomerAccountRequestParamsWithDerivedValues_FlagsOmittedDoesNotS
 
 	requestParams, err := buildCustomerAccountRequestParamsWithDerivedValues(params, inputParameters, "")
 	require.NoError(t, err)
-	_, hasPrivateLink := requestParams["private_link"]
-	_, hasAllowCreate := requestParams["allow_new_cloud_native_network_creation"]
-	assert.False(t, hasPrivateLink)
-	assert.False(t, hasAllowCreate)
+	assert.Equal(t, false, requestParams["private_link"])
+	assert.Equal(t, true, requestParams["allow_new_cloud_native_network_creation"])
+}
+
+func TestBuildCustomerAccountRequestParamsWithDerivedValues_AWSAllowCreationExplicitFalse(t *testing.T) {
+	params := CloudAccountParams{
+		Name:           "customer-aws",
+		AwsAccountID:   "123456789012",
+		AllowCreateNew: false,
+	}
+
+	inputParameters := []openapiclient.DescribeInputParameterResult{
+		{Name: customerAccountIacToolName, Key: "account_configuration_method"},
+		{Name: customerAccountAWSAccountIDName, Key: "aws_account_id"},
+		{Name: customerAccountAWSBootstrapRoleName, Key: "aws_bootstrap_role_arn"},
+		{Name: customerAccountPrivateLinkName, Key: "private_link"},
+		{Name: customerAccountAllowCreateNewName, Key: "allow_new_cloud_native_network_creation"},
+	}
+
+	requestParams, err := buildCustomerAccountRequestParamsWithDerivedValues(params, inputParameters, "")
+	require.NoError(t, err)
+	assert.Equal(t, false, requestParams["private_link"])
+	assert.Equal(t, false, requestParams["allow_new_cloud_native_network_creation"])
+}
+
+func TestBuildCustomerAccountRequestParamsWithDerivedValues_AWSPrivateLinkDefaultsAllowCreation(t *testing.T) {
+	params := CloudAccountParams{
+		Name:           "customer-aws",
+		AwsAccountID:   "123456789012",
+		PrivateLink:    true,
+		AllowCreateNew: true,
+	}
+
+	inputParameters := []openapiclient.DescribeInputParameterResult{
+		{Name: customerAccountIacToolName, Key: "account_configuration_method"},
+		{Name: customerAccountAWSAccountIDName, Key: "aws_account_id"},
+		{Name: customerAccountAWSBootstrapRoleName, Key: "aws_bootstrap_role_arn"},
+		{Name: customerAccountPrivateLinkName, Key: "private_link"},
+		{Name: customerAccountAllowCreateNewName, Key: "allow_new_cloud_native_network_creation"},
+	}
+
+	requestParams, err := buildCustomerAccountRequestParamsWithDerivedValues(params, inputParameters, "")
+	require.NoError(t, err)
+	assert.Equal(t, true, requestParams["private_link"])
+	assert.Equal(t, true, requestParams["allow_new_cloud_native_network_creation"])
 }
 
 func TestResolveCustomerAccountSubscription_NonProductionUsesProvidedSubscription(t *testing.T) {

--- a/mkdocs/docs/omnistrate-ctl_account_customer_create.md
+++ b/mkdocs/docs/omnistrate-ctl_account_customer_create.md
@@ -42,7 +42,7 @@ omnistrate-ctl account customer create --service=[service] --environment=[enviro
 ### Options
 
 ```
-      --allow-create-new-cloud-native-network   Allow the platform to create new cloud-native networks in this account on demand
+      --allow-create-new-cloud-native-network   Allow Omnistrate to create cloud-native networks in this account (default true)
       --aws-account-id string                   AWS account ID
       --azure-subscription-id string            Azure subscription ID
       --azure-tenant-id string                  Azure tenant ID


### PR DESCRIPTION
## Summary
- default `account customer create` to allow Omnistrate-created cloud-native networks by making `--allow-create-new-cloud-native-network` default to true
- always send `allow_new_cloud_native_network_creation` for customer cloud-provider onboarding, while still honoring `--allow-create-new-cloud-native-network=false`
- keep `private_link` handling AWS-only and send `private_link=false` for normal AWS onboarding

## Testing
- go test ./cmd/account
- make gen-doc
- make build
- make unit-test