### PR TITLE
Remove stale format from ctl

### DIFF
--- a/cmd/service/resource.go
+++ b/cmd/service/resource.go
@@ -7,20 +7,10 @@ import (
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 )
 
-const resourceDeleteExample = `# Delete a resource with service name and resource ID
-omnistrate-ctl service resource delete --service-name=[service-name] --resource-id=[resource-ID]
-
-# Delete a resource with service and resource IDs
-omnistrate-ctl service resource delete --service-id=[service-ID] --resource-id=[resource-ID]
-
-# Delete a resource using the service name or ID as a path segment
-omnistrate-ctl service [service-name-or-ID] resource delete --resource-id=[resource-ID]
-
-# Dry run resource deletion
-omnistrate-ctl service [service-name-or-ID] resource delete --resource-id=[resource-ID] --dry-run`
+const resourceDeleteExample = `# Delete a resource with service and resource IDs
+omnistrate-ctl service resource delete --service-id=[service-ID] --resource-id=[resource-ID]`
 
 func newResourceCmd() *cobra.Command {
 	resourceCmd := &cobra.Command{
@@ -42,7 +32,7 @@ func runResource(cmd *cobra.Command, args []string) error {
 
 func newResourceDeleteCmd() *cobra.Command {
 	resourceDeleteCmd := &cobra.Command{
-		Use:          "delete (--service-name [service-name] | --service-id [service-ID]) --resource-id [resource-ID] [flags]",
+		Use:          "delete --service-id [service-ID] --resource-id [resource-ID] [flags]",
 		Short:        "Delete a service resource",
 		Long:         `This command helps you delete a resource from a service.`,
 		Example:      resourceDeleteExample,
@@ -51,10 +41,8 @@ func newResourceDeleteCmd() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	resourceDeleteCmd.Flags().String("service-name", "", "Service name")
 	resourceDeleteCmd.Flags().String("service-id", "", "Service ID")
 	resourceDeleteCmd.Flags().String("resource-id", "", "Resource ID")
-	resourceDeleteCmd.Flags().Bool("dry-run", false, "Validate resource deletion without deleting it")
 
 	return resourceDeleteCmd
 }
@@ -62,11 +50,6 @@ func newResourceDeleteCmd() *cobra.Command {
 func runResourceDelete(cmd *cobra.Command, args []string) error {
 	defer config.CleanupArgsAndFlags(cmd, &args)
 
-	serviceName, err := cmd.Flags().GetString("service-name")
-	if err != nil {
-		utils.PrintError(err)
-		return err
-	}
 	serviceID, err := cmd.Flags().GetString("service-id")
 	if err != nil {
 		utils.PrintError(err)
@@ -77,122 +60,18 @@ func runResourceDelete(cmd *cobra.Command, args []string) error {
 		utils.PrintError(err)
 		return err
 	}
-	dryRun, err := cmd.Flags().GetBool("dry-run")
-	if err != nil {
-		utils.PrintError(err)
-		return err
-	}
 	output, err := cmd.Flags().GetString("output")
 	if err != nil {
 		utils.PrintError(err)
 		return err
 	}
 
-	return runResourceDeleteWithOptions(cmd, serviceName, serviceID, resourceID, dryRun, output)
+	return runResourceDeleteWithOptions(cmd, serviceID, resourceID, output)
 }
 
-func runServiceResourceDeletePath(cmd *cobra.Command, args []string) (bool, error) {
-	normalizedArgs, rewrote := normalizeServiceResourceDeleteArgs(args)
-	if !rewrote {
-		return false, nil
-	}
-
-	if hasHelpFlag(args) {
-		return true, runResourceDeleteHelp(cmd)
-	}
-
-	serviceName, serviceID, resourceID, dryRun, output, err := parseServiceResourceDeletePath(normalizedArgs)
-	if err != nil {
-		utils.PrintError(err)
-		return true, err
-	}
-
-	if output == "" {
-		output, _ = cmd.Flags().GetString("output")
-	}
-
-	return true, runResourceDeleteWithOptions(cmd, serviceName, serviceID, resourceID, dryRun, output)
-}
-
-func hasHelpFlag(args []string) bool {
-	for _, arg := range args {
-		if arg == "--help" || arg == "-h" {
-			return true
-		}
-	}
-	return false
-}
-
-func runResourceDeleteHelp(cmd *cobra.Command) error {
-	resourceDeleteCmd, _, err := cmd.Find([]string{"resource", "delete"})
-	if err != nil {
-		return err
-	}
-	return resourceDeleteCmd.Help()
-}
-
-func normalizeServiceResourceDeleteArgs(args []string) ([]string, bool) {
-	if len(args) < 3 || args[1] != "resource" || args[2] != "delete" {
-		return args, false
-	}
-
-	normalized := make([]string, 0, len(args)+2)
-	normalized = append(normalized, "resource", "delete", "--service-name", args[0])
-	normalized = append(normalized, args[3:]...)
-
-	return normalized, true
-}
-
-func parseServiceResourceDeletePath(args []string) (serviceName string, serviceID string, resourceID string, dryRun bool, output string, err error) {
-	if len(args) < 4 || args[0] != "resource" || args[1] != "delete" || args[2] != "--service-name" {
-		err = errors.New("invalid service resource delete arguments")
-		return
-	}
-
-	serviceName = args[3]
-	flags := pflag.NewFlagSet("service resource delete", pflag.ContinueOnError)
-	flags.String("service-name", serviceName, "Service name")
-	flags.String("service-id", "", "Service ID")
-	flags.String("resource-id", "", "Resource ID")
-	flags.Bool("dry-run", false, "Validate resource deletion without deleting it")
-	flags.StringP("output", "o", "", "Output format (text|table|json)")
-
-	err = flags.Parse(args[4:])
-	if err != nil {
-		return
-	}
-
-	serviceName, err = flags.GetString("service-name")
-	if err != nil {
-		return
-	}
-	serviceID, err = flags.GetString("service-id")
-	if err != nil {
-		return
-	}
-	resourceID, err = flags.GetString("resource-id")
-	if err != nil {
-		return
-	}
-	dryRun, err = flags.GetBool("dry-run")
-	if err != nil {
-		return
-	}
-	output, err = flags.GetString("output")
-	if err != nil {
-		return
-	}
-
-	err = validateResourceDeleteArguments(serviceName, serviceID, resourceID)
-	return
-}
-
-func validateResourceDeleteArguments(serviceName, serviceID, resourceID string) error {
-	if serviceName == "" && serviceID == "" {
-		return errors.New("service name or ID must be provided")
-	}
-	if serviceName != "" && serviceID != "" {
-		return errors.New("only one of service name or ID can be provided")
+func validateResourceDeleteArguments(serviceID, resourceID string) error {
+	if serviceID == "" {
+		return errors.New("service ID must be provided")
 	}
 	if resourceID == "" {
 		return errors.New("resource ID must be provided")
@@ -200,8 +79,8 @@ func validateResourceDeleteArguments(serviceName, serviceID, resourceID string) 
 	return nil
 }
 
-func runResourceDeleteWithOptions(cmd *cobra.Command, serviceName, serviceID, resourceID string, dryRun bool, output string) error {
-	err := validateResourceDeleteArguments(serviceName, serviceID, resourceID)
+func runResourceDeleteWithOptions(cmd *cobra.Command, serviceID, resourceID, output string) error {
+	err := validateResourceDeleteArguments(serviceID, resourceID)
 	if err != nil {
 		utils.PrintError(err)
 		return err
@@ -224,14 +103,14 @@ func runResourceDeleteWithOptions(cmd *cobra.Command, serviceName, serviceID, re
 	}
 
 	// Check if service exists
-	serviceID, err = getService(cmd.Context(), token, serviceName, serviceID)
+	serviceID, err = getService(cmd.Context(), token, "", serviceID)
 	if err != nil {
 		utils.HandleSpinnerError(spinner, sm, err)
 		return err
 	}
 
 	// Delete resource
-	err = dataaccess.DeleteResource(cmd.Context(), token, serviceID, resourceID, dryRun)
+	err = dataaccess.DeleteResource(cmd.Context(), token, serviceID, resourceID, false)
 	if err != nil {
 		utils.HandleSpinnerError(spinner, sm, err)
 		return err

--- a/cmd/service/resource.go
+++ b/cmd/service/resource.go
@@ -103,7 +103,7 @@ func runResourceDeleteWithOptions(cmd *cobra.Command, serviceID, resourceID, out
 	}
 
 	// Check if service exists
-	serviceID, err = getService(cmd.Context(), token, "", serviceID)
+	_, err = dataaccess.DescribeService(cmd.Context(), token, serviceID)
 	if err != nil {
 		utils.HandleSpinnerError(spinner, sm, err)
 		return err

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -10,9 +10,7 @@ var Cmd = &cobra.Command{
 	Short: "Manage Services for your account",
 	Long: `This command helps you manage the services for your account.
 You can delete, describe, and get services.`,
-	RunE:               run,
-	DisableFlagParsing: true,
-	SilenceUsage:       true,
+	Run: run,
 }
 
 func init() {
@@ -23,9 +21,6 @@ func init() {
 	Cmd.AddCommand(serviceplan.NewNestedCommand())
 }
 
-func run(cmd *cobra.Command, args []string) error {
-	if handled, err := runServiceResourceDeletePath(cmd, args); handled || err != nil {
-		return err
-	}
-	return cmd.Help()
+func run(cmd *cobra.Command, args []string) {
+	_ = cmd.Help()
 }

--- a/cmd/service/service.go
+++ b/cmd/service/service.go
@@ -10,7 +10,8 @@ var Cmd = &cobra.Command{
 	Short: "Manage Services for your account",
 	Long: `This command helps you manage the services for your account.
 You can delete, describe, and get services.`,
-	Run: run,
+	RunE:         run,
+	SilenceUsage: true,
 }
 
 func init() {
@@ -21,6 +22,6 @@ func init() {
 	Cmd.AddCommand(serviceplan.NewNestedCommand())
 }
 
-func run(cmd *cobra.Command, args []string) {
-	_ = cmd.Help()
+func run(cmd *cobra.Command, args []string) error {
+	return cmd.Help()
 }

--- a/cmd/service/service_test.go
+++ b/cmd/service/service_test.go
@@ -14,65 +14,28 @@ func TestResourceDeleteNestedCommandRegistered(t *testing.T) {
 	require.Equal(t, "delete", resourceDeleteCmd.Name())
 	require.NotEmpty(t, resourceDeleteCmd.Example)
 	require.True(t, resourceDeleteCmd.SilenceUsage)
+	require.False(t, Cmd.DisableFlagParsing)
+	require.Contains(t, resourceDeleteCmd.Use, "--service-id")
+	require.Contains(t, resourceDeleteCmd.Use, "--resource-id")
 
 	serviceIDFlag := resourceDeleteCmd.Flags().Lookup("service-id")
 	require.NotNil(t, serviceIDFlag)
 	require.Equal(t, "", serviceIDFlag.DefValue)
 
 	serviceNameFlag := resourceDeleteCmd.Flags().Lookup("service-name")
-	require.NotNil(t, serviceNameFlag)
-	require.Equal(t, "", serviceNameFlag.DefValue)
+	require.Nil(t, serviceNameFlag)
 
 	resourceIDFlag := resourceDeleteCmd.Flags().Lookup("resource-id")
 	require.NotNil(t, resourceIDFlag)
 	require.Equal(t, "", resourceIDFlag.DefValue)
 
 	dryRunFlag := resourceDeleteCmd.Flags().Lookup("dry-run")
-	require.NotNil(t, dryRunFlag)
-	require.Equal(t, "false", dryRunFlag.DefValue)
-}
-
-func TestNormalizeServiceResourceDeleteArgs(t *testing.T) {
-	tests := []struct {
-		name        string
-		args        []string
-		wantArgs    []string
-		wantRewrote bool
-	}{
-		{
-			name:        "rewrites positional service name or ID resource delete",
-			args:        []string{"service-selector", "resource", "delete", "--resource-id", "resource-id"},
-			wantArgs:    []string{"resource", "delete", "--service-name", "service-selector", "--resource-id", "resource-id"},
-			wantRewrote: true,
-		},
-		{
-			name:        "preserves canonical resource delete",
-			args:        []string{"resource", "delete", "--service-id", "service-id", "--resource-id", "resource-id"},
-			wantArgs:    []string{"resource", "delete", "--service-id", "service-id", "--resource-id", "resource-id"},
-			wantRewrote: false,
-		},
-		{
-			name:        "preserves existing service delete",
-			args:        []string{"delete", "--id", "service-id"},
-			wantArgs:    []string{"delete", "--id", "service-id"},
-			wantRewrote: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotArgs, gotRewrote := normalizeServiceResourceDeleteArgs(tt.args)
-
-			require.Equal(t, tt.wantArgs, gotArgs)
-			require.Equal(t, tt.wantRewrote, gotRewrote)
-		})
-	}
+	require.Nil(t, dryRunFlag)
 }
 
 func TestValidateResourceDeleteArguments(t *testing.T) {
 	tests := []struct {
 		name        string
-		serviceName string
 		serviceID   string
 		resourceID  string
 		expectedErr string
@@ -83,21 +46,9 @@ func TestValidateResourceDeleteArguments(t *testing.T) {
 			resourceID: "resource-id",
 		},
 		{
-			name:        "valid with service name",
-			serviceName: "service-name",
+			name:        "missing service ID",
 			resourceID:  "resource-id",
-		},
-		{
-			name:        "missing service name or ID",
-			resourceID:  "resource-id",
-			expectedErr: "service name or ID must be provided",
-		},
-		{
-			name:        "both service name and ID",
-			serviceName: "service-name",
-			serviceID:   "service-id",
-			resourceID:  "resource-id",
-			expectedErr: "only one of service name or ID can be provided",
+			expectedErr: "service ID must be provided",
 		},
 		{
 			name:        "missing resource ID",
@@ -108,7 +59,7 @@ func TestValidateResourceDeleteArguments(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateResourceDeleteArguments(tt.serviceName, tt.serviceID, tt.resourceID)
+			err := validateResourceDeleteArguments(tt.serviceID, tt.resourceID)
 			if tt.expectedErr == "" {
 				require.NoError(t, err)
 				return
@@ -116,39 +67,6 @@ func TestValidateResourceDeleteArguments(t *testing.T) {
 			require.EqualError(t, err, tt.expectedErr)
 		})
 	}
-}
-
-func TestParseServiceResourceDeletePath(t *testing.T) {
-	serviceName, serviceID, resourceID, dryRun, output, err := parseServiceResourceDeletePath([]string{
-		"resource",
-		"delete",
-		"--service-name",
-		"service-selector",
-		"--resource-id",
-		"resource-id",
-		"--dry-run",
-		"--output",
-		"json",
-	})
-
-	require.NoError(t, err)
-	require.Equal(t, "service-selector", serviceName)
-	require.Empty(t, serviceID)
-	require.Equal(t, "resource-id", resourceID)
-	require.True(t, dryRun)
-	require.Equal(t, "json", output)
-}
-
-func TestRunServiceResourceDeletePathHelp(t *testing.T) {
-	handled, err := runServiceResourceDeletePath(Cmd, []string{
-		"service-name",
-		"resource",
-		"delete",
-		"--help",
-	})
-
-	require.True(t, handled)
-	require.NoError(t, err)
 }
 
 func TestServicePlanNestedCommandRegistered(t *testing.T) {

--- a/mkdocs/docs/omnistrate-ctl_service_resource_delete.md
+++ b/mkdocs/docs/omnistrate-ctl_service_resource_delete.md
@@ -7,33 +7,22 @@ Delete a service resource
 This command helps you delete a resource from a service.
 
 ```
-omnistrate-ctl service resource delete (--service-name [service-name] | --service-id [service-ID]) --resource-id [resource-ID] [flags]
+omnistrate-ctl service resource delete --service-id [service-ID] --resource-id [resource-ID] [flags]
 ```
 
 ### Examples
 
 ```
-# Delete a resource with service name and resource ID
-omnistrate-ctl service resource delete --service-name=[service-name] --resource-id=[resource-ID]
-
 # Delete a resource with service and resource IDs
 omnistrate-ctl service resource delete --service-id=[service-ID] --resource-id=[resource-ID]
-
-# Delete a resource using the service name or ID as a path segment
-omnistrate-ctl service [service-name-or-ID] resource delete --resource-id=[resource-ID]
-
-# Dry run resource deletion
-omnistrate-ctl service [service-name-or-ID] resource delete --resource-id=[resource-ID] --dry-run
 ```
 
 ### Options
 
 ```
-      --dry-run               Validate resource deletion without deleting it
-  -h, --help                  help for delete
-      --resource-id string    Resource ID
-      --service-id string     Service ID
-      --service-name string   Service name
+  -h, --help                 help for delete
+      --resource-id string   Resource ID
+      --service-id string    Service ID
 ```
 
 ### Options inherited from parent commands

--- a/test/smoke_test/service/resource_test.go
+++ b/test/smoke_test/service/resource_test.go
@@ -72,9 +72,10 @@ func Test_service_resource_delete_removed_resource(t *testing.T) {
 
 	cmd.RootCmd.SetArgs([]string{
 		"service",
-		serviceName,
 		"resource",
 		"delete",
+		"--service-id",
+		serviceID,
 		"--resource-id",
 		removedResourceID,
 		"--output",


### PR DESCRIPTION
This pull request simplifies and standardizes the `service resource delete` command by removing support for deletion via service name, positional arguments, and the `dry-run` flag. The command now requires explicit `--service-id` and `--resource-id` flags, resulting in a clearer and more maintainable interface. Documentation and tests have been updated accordingly.

**Command simplification and API changes:**

* The `service resource delete` command now requires `--service-id` and `--resource-id` flags; support for `--service-name`, positional service selection, and the `dry-run` flag has been removed. [[1]](diffhunk://#diff-2b2f74447a9a49ab9e0a3ed2ffd777ba19800bafe9ff0d376a89ec2f3954f959L10-R13) [[2]](diffhunk://#diff-2b2f74447a9a49ab9e0a3ed2ffd777ba19800bafe9ff0d376a89ec2f3954f959L45-R35) [[3]](diffhunk://#diff-2b2f74447a9a49ab9e0a3ed2ffd777ba19800bafe9ff0d376a89ec2f3954f959L54-L69)
* All code paths, argument normalization, and validation logic related to service name and dry-run have been removed, and the internal handler now only validates the presence of `service-id` and `resource-id`. [[1]](diffhunk://#diff-2b2f74447a9a49ab9e0a3ed2ffd777ba19800bafe9ff0d376a89ec2f3954f959L80-R83) [[2]](diffhunk://#diff-2b2f74447a9a49ab9e0a3ed2ffd777ba19800bafe9ff0d376a89ec2f3954f959L227-R113)

**Documentation updates:**

* The documentation for the `service resource delete` command has been updated to reflect the new required flags and removed options. Examples and option lists now only mention `--service-id` and `--resource-id`.

**Test updates:**

* Tests have been refactored to remove cases related to service name, positional arguments, and dry-run, and now only validate the required flags and updated validation logic. [[1]](diffhunk://#diff-bd56ab16c65f76c29e29326cb386f0e095f487b0de5c664b4220898c67cdb7d8R17-L75) [[2]](diffhunk://#diff-bd56ab16c65f76c29e29326cb386f0e095f487b0de5c664b4220898c67cdb7d8L86-R51) [[3]](diffhunk://#diff-bd56ab16c65f76c29e29326cb386f0e095f487b0de5c664b4220898c67cdb7d8L111-R62) [[4]](diffhunk://#diff-bd56ab16c65f76c29e29326cb386f0e095f487b0de5c664b4220898c67cdb7d8L121-L153)
* Smoke tests have been updated to use the new flag-based invocation for resource deletion.

**Command runner changes:**

* The root `service` command no longer attempts to handle positional resource deletion commands, and always shows help if no subcommand is provided. [[1]](diffhunk://#diff-f7ef5ec0bec3d10e6312cabcd8f0c78339e56e36143199350b52ab75733a8b30L13-R13) [[2]](diffhunk://#diff-f7ef5ec0bec3d10e6312cabcd8f0c78339e56e36143199350b52ab75733a8b30L26-R25)