### PR TITLE
Bump mkdocs docs dependencies

### DIFF
--- a/mkdocs/requirements.txt
+++ b/mkdocs/requirements.txt
@@ -1,10 +1,10 @@
 mkdocs==1.6.1
 mkdocs-glightbox==0.4.0
-mkdocs-material==9.6.18
+mkdocs-material==9.7.0
 mkdocs-redirects==1.2.2
 fontawesome-markdown==0.2.6
 mkdocs-material-extensions==1.3.1
-pymdown-extensions==10.21.3
+pymdown-extensions==11.0.1
 # Pygments 2.20 breaks pymdownx.highlight when a code fence has no title
 # (passes filename=None into HtmlFormatter, which calls .replace on None).
 # See https://github.com/facelessuser/pymdown-extensions/issues/2572


### PR DESCRIPTION
Supersedes #707.

This carries forward the Dependabot bump from `pymdown-extensions==10.21.3` to `11.0.1`. The original one-line update is not installable with the current `mkdocs-material==9.6.18` pin because that version requires `pymdown-extensions~=10.2`, so this also bumps `mkdocs-material` to the smallest compatible tested version, `9.7.0`.

Validation:
- `pip install -r mkdocs/requirements.txt` in a fresh temporary virtualenv
- `cd mkdocs && mkdocs build --strict --site-dir <tmp-site-dir>`
