### PR TITLE
fix: support escaped commas in custom tags

### DIFF
--- a/cmd/account/customer_update.go
+++ b/cmd/account/customer_update.go
@@ -32,7 +32,7 @@ func init() {
 	customerUpdateCmd.Flags().String("name", "", "Updated backing account name")
 	customerUpdateCmd.Flags().String("description", "", "Updated backing account description")
 	customerUpdateCmd.Flags().String("nebius-bindings-file", "", "Path to a YAML file describing the full replacement Nebius bindings")
-	customerUpdateCmd.Flags().String(tagsFlag, "", "Full replacement set of custom tags for the backing account in key=value format, separated by commas (e.g. env=prod,team=platform)")
+	customerUpdateCmd.Flags().String(tagsFlag, "", `Full replacement set of custom tags for the backing account in key=value format, separated by commas (e.g. env=prod,team=platform). Escape commas inside values with \,`)
 	customerUpdateCmd.Flags().Bool("skip-wait", false, "Skip waiting for the backing account to become READY after replacing Nebius bindings")
 	_ = customerUpdateCmd.MarkFlagFilename("nebius-bindings-file")
 }

--- a/cmd/account/provider_flags.go
+++ b/cmd/account/provider_flags.go
@@ -40,7 +40,7 @@ func addBaseCloudAccountProviderFlags(cmd *cobra.Command) {
 	cmd.Flags().String(azureTenantIDFlag, "", "Azure tenant ID")
 	cmd.Flags().String(nebiusTenantIDFlag, "", "Nebius tenant ID")
 	cmd.Flags().String(nebiusBindingsFileFlag, "", "Path to a YAML file describing Nebius bindings")
-	cmd.Flags().String(tagsFlag, "", "Custom tags for the account in key=value format, separated by commas (e.g. env=prod,team=platform)")
+	cmd.Flags().String(tagsFlag, "", `Custom tags for the account in key=value format, separated by commas (e.g. env=prod,team=platform). Escape commas inside values with \,`)
 	cmd.Flags().Bool(skipWaitFlag, false, "Skip waiting for account onboarding to become READY")
 
 	cmd.MarkFlagsRequiredTogether(gcpProjectIDFlag, gcpProjectNumberFlag)

--- a/cmd/account/tags.go
+++ b/cmd/account/tags.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
 	openapiclient "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
 	"github.com/spf13/cobra"
 )
@@ -25,7 +26,7 @@ func parseAccountTags(cmd *cobra.Command) ([]openapiclient.CustomTag, bool, erro
 		return nil, false, fmt.Errorf("at least one tag must be provided in key=value format when using --%s", tagsFlag)
 	}
 
-	rawPairs := strings.Split(trimmed, ",")
+	rawPairs := utils.SplitEscapedCommaSeparatedList(trimmed)
 	tags := make([]openapiclient.CustomTag, 0, len(rawPairs))
 	seen := make(map[string]struct{}, len(rawPairs))
 	for _, rawPair := range rawPairs {

--- a/cmd/account/tags_test.go
+++ b/cmd/account/tags_test.go
@@ -53,6 +53,15 @@ func TestParseAccountTags(t *testing.T) {
 			provided: true,
 		},
 		{
+			name:  "tag value can contain escaped commas",
+			value: ptr(`allowed_source_ranges=137.83.246.111/32\,1.2.3.4/32,env=prod`),
+			want: []openapiclient.CustomTag{
+				{Key: "allowed_source_ranges", Value: "137.83.246.111/32,1.2.3.4/32"},
+				{Key: "env", Value: "prod"},
+			},
+			provided: true,
+		},
+		{
 			name:    "rejects empty value",
 			value:   ptr(""),
 			wantErr: "at least one tag must be provided in key=value format when using --tags",

--- a/cmd/account/update.go
+++ b/cmd/account/update.go
@@ -36,7 +36,7 @@ func init() {
 	updateCmd.Flags().String("name", "", "Updated account name")
 	updateCmd.Flags().String("description", "", "Updated account description")
 	updateCmd.Flags().String("nebius-bindings-file", "", "Path to a YAML file describing the full replacement Nebius bindings")
-	updateCmd.Flags().String(tagsFlag, "", "Full replacement set of custom tags for the account in key=value format, separated by commas (e.g. env=prod,team=platform)")
+	updateCmd.Flags().String(tagsFlag, "", `Full replacement set of custom tags for the account in key=value format, separated by commas (e.g. env=prod,team=platform). Escape commas inside values with \,`)
 	updateCmd.Flags().Bool("skip-wait", false, "Skip waiting for account to become READY after replacing Nebius bindings")
 	_ = updateCmd.MarkFlagFilename("nebius-bindings-file")
 }

--- a/cmd/instance/common.go
+++ b/cmd/instance/common.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
 	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
 	"github.com/spf13/cobra"
 )
@@ -35,7 +36,7 @@ func parseCustomTags(cmd *cobra.Command) ([]openapiclientfleet.CustomTag, bool, 
 		return []openapiclientfleet.CustomTag{}, true, nil
 	}
 
-	rawPairs := strings.Split(trimmed, ",")
+	rawPairs := utils.SplitEscapedCommaSeparatedList(trimmed)
 	tags := make([]openapiclientfleet.CustomTag, 0, len(rawPairs))
 	for _, rawPair := range rawPairs {
 		pair := strings.TrimSpace(rawPair)

--- a/cmd/instance/common_test.go
+++ b/cmd/instance/common_test.go
@@ -142,6 +142,17 @@ func TestParseCustomTags(t *testing.T) {
 			expectedSet: true,
 			expectError: false,
 		},
+		{
+			name:     "tag value can contain escaped commas",
+			tagsFlag: `allowed_source_ranges=137.83.246.111/32\,1.2.3.4/32,env=prod`,
+			flagSet:  true,
+			expectedTags: []openapiclientfleet.CustomTag{
+				{Key: "allowed_source_ranges", Value: "137.83.246.111/32,1.2.3.4/32"},
+				{Key: "env", Value: "prod"},
+			},
+			expectedSet: true,
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/instance/create.go
+++ b/cmd/instance/create.go
@@ -101,7 +101,7 @@ func init() {
 	createCmd.Flags().String("cloud-provider-native-network-id", "", fmt.Sprintf("Cloud provider native network ID to inject as %s in instance deployment parameters", cloudProviderNativeNetworkIDParamKey))
 	createCmd.Flags().String("network-type", "", "Optional network type for the instance deployment (PUBLIC / INTERNAL)")
 	createCmd.Flags().String("onprem-platform", "", "On-prem platform for installer-backed deployments (for example EKS, GKE, AKS, OpenShift, Generic)")
-	createCmd.Flags().String("tags", "", "Custom tags to add to the instance deployment (format: key=value,key2=value2)")
+	createCmd.Flags().String("tags", "", `Custom tags to add to the instance deployment (format: key=value,key2=value2). Escape commas inside values with \,`)
 	createCmd.Flags().String("breakpoints", "", "Workflow breakpoint resource IDs or resource keys, optionally scoped to events as id-or-key:event or id-or-key:event|event")
 	createCmd.Flags().StringP("subscription-id", "", "", "Subscription ID to use for the instance deployment. If not provided, instance deployment will be created in your own subscription.")
 	createCmd.Flags().String("instance-id", "", "ID of a previously deleted instance to restore")

--- a/cmd/instance/modify.go
+++ b/cmd/instance/modify.go
@@ -39,7 +39,7 @@ func init() {
 	modifyCmd.Flags().String("network-type", "", "Optional network type change for the instance deployment (PUBLIC / INTERNAL)")
 	modifyCmd.Flags().String("param", "", "Parameters for the instance deployment")
 	modifyCmd.Flags().String("param-file", "", "Json file containing parameters for the instance deployment")
-	modifyCmd.Flags().String("tags", "", "Custom tags to set on the instance deployment (format: key=value,key2=value2)")
+	modifyCmd.Flags().String("tags", "", `Custom tags to set on the instance deployment (format: key=value,key2=value2). Escape commas inside values with \,`)
 	modifyCmd.Flags().Bool("wait", false, "Wait for modification to complete and show progress")
 
 	if err := modifyCmd.MarkFlagFilename("param-file"); err != nil {

--- a/internal/utils/string.go
+++ b/internal/utils/string.go
@@ -68,6 +68,43 @@ func ParseCommaSeparatedList(input string) []string {
 	return result
 }
 
+// SplitEscapedCommaSeparatedList splits input on commas unless the comma is
+// escaped as \,. A backslash only escapes comma and backslash; before any other
+// character it is preserved.
+func SplitEscapedCommaSeparatedList(input string) []string {
+	result := make([]string, 0)
+	var current strings.Builder
+	escaping := false
+
+	for _, r := range input {
+		if escaping {
+			if r != ',' && r != '\\' {
+				current.WriteRune('\\')
+			}
+			current.WriteRune(r)
+			escaping = false
+			continue
+		}
+
+		switch r {
+		case '\\':
+			escaping = true
+		case ',':
+			result = append(result, current.String())
+			current.Reset()
+		default:
+			current.WriteRune(r)
+		}
+	}
+
+	if escaping {
+		current.WriteRune('\\')
+	}
+	result = append(result, current.String())
+
+	return result
+}
+
 // ReadFile reads the contents of a file
 func ReadFile(filePath string) ([]byte, error) {
 	data, err := os.ReadFile(filePath)

--- a/internal/utils/string.go
+++ b/internal/utils/string.go
@@ -91,7 +91,7 @@ func SplitEscapedCommaSeparatedList(input string) []string {
 			escaping = true
 		case ',':
 			result = append(result, current.String())
-			current.Reset()
+			current = strings.Builder{}
 		default:
 			current.WriteRune(r)
 		}

--- a/internal/utils/string_test.go
+++ b/internal/utils/string_test.go
@@ -227,3 +227,50 @@ func TestCutString(t *testing.T) {
 		})
 	}
 }
+
+func TestSplitEscapedCommaSeparatedList(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "multiple values",
+			input: "env=prod,team=platform",
+			want:  []string{"env=prod", "team=platform"},
+		},
+		{
+			name:  "escaped comma stays in value",
+			input: `allowed_source_ranges=137.83.246.111/32\,1.2.3.4/32,env=prod`,
+			want:  []string{"allowed_source_ranges=137.83.246.111/32,1.2.3.4/32", "env=prod"},
+		},
+		{
+			name:  "empty segment preserved",
+			input: "env=prod,,team=platform",
+			want:  []string{"env=prod", "", "team=platform"},
+		},
+		{
+			name:  "backslash before non special character is preserved",
+			input: `path=C:\tmp,env=prod`,
+			want:  []string{`path=C:\tmp`, "env=prod"},
+		},
+		{
+			name:  "escaped backslash",
+			input: `path=C:\\tmp,env=prod`,
+			want:  []string{`path=C:\tmp`, "env=prod"},
+		},
+		{
+			name:  "trailing backslash is preserved",
+			input: `path=C:\`,
+			want:  []string{`path=C:\`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, SplitEscapedCommaSeparatedList(tt.input))
+		})
+	}
+}

--- a/internal/utils/string_test.go
+++ b/internal/utils/string_test.go
@@ -242,6 +242,11 @@ func TestSplitEscapedCommaSeparatedList(t *testing.T) {
 			want:  []string{"env=prod", "team=platform"},
 		},
 		{
+			name:  "longer segment before shorter segment",
+			input: "team=platform,env=prod",
+			want:  []string{"team=platform", "env=prod"},
+		},
+		{
 			name:  "escaped comma stays in value",
 			input: `allowed_source_ranges=137.83.246.111/32\,1.2.3.4/32,env=prod`,
 			want:  []string{"allowed_source_ranges=137.83.246.111/32,1.2.3.4/32", "env=prod"},

--- a/mkdocs/docs/omnistrate-ctl_account_create.md
+++ b/mkdocs/docs/omnistrate-ctl_account_create.md
@@ -38,7 +38,7 @@ omnistrate-ctl account create [account-name] --nebius-tenant-id=[tenant-id] --ne
       --nebius-bindings-file string    Path to a YAML file describing Nebius bindings
       --nebius-tenant-id string        Nebius tenant ID
       --skip-wait                      Skip waiting for account onboarding to become READY
-      --tags string                    Custom tags for the account in key=value format, separated by commas (e.g. env=prod,team=platform)
+      --tags string                    Custom tags for the account in key=value format, separated by commas (e.g. env=prod,team=platform). Escape commas inside values with \,
 ```
 
 ### Options inherited from parent commands

--- a/mkdocs/docs/omnistrate-ctl_account_customer_create.md
+++ b/mkdocs/docs/omnistrate-ctl_account_customer_create.md
@@ -62,7 +62,7 @@ omnistrate-ctl account customer create --service=[service] --environment=[enviro
       --service string                          Service name or ID
       --skip-wait                               Skip waiting for account onboarding to become READY
       --subscription-id string                  Subscription ID to use for the onboarding instance
-      --tags string                             Custom tags for the account in key=value format, separated by commas (e.g. env=prod,team=platform)
+      --tags string                             Custom tags for the account in key=value format, separated by commas (e.g. env=prod,team=platform). Escape commas inside values with \,
 ```
 
 ### Options inherited from parent commands

--- a/mkdocs/docs/omnistrate-ctl_account_customer_update.md
+++ b/mkdocs/docs/omnistrate-ctl_account_customer_update.md
@@ -28,7 +28,7 @@ omnistrate-ctl account customer update instance-abcd1234 --nebius-bindings-file=
       --name string                   Updated backing account name
       --nebius-bindings-file string   Path to a YAML file describing the full replacement Nebius bindings
       --skip-wait                     Skip waiting for the backing account to become READY after replacing Nebius bindings
-      --tags string                   Full replacement set of custom tags for the backing account in key=value format, separated by commas (e.g. env=prod,team=platform)
+      --tags string                   Full replacement set of custom tags for the backing account in key=value format, separated by commas (e.g. env=prod,team=platform). Escape commas inside values with \,
 ```
 
 ### Options inherited from parent commands

--- a/mkdocs/docs/omnistrate-ctl_account_update.md
+++ b/mkdocs/docs/omnistrate-ctl_account_update.md
@@ -28,7 +28,7 @@ omnistrate-ctl account update [account-name or account-id] --nebius-bindings-fil
       --name string                   Updated account name
       --nebius-bindings-file string   Path to a YAML file describing the full replacement Nebius bindings
       --skip-wait                     Skip waiting for account to become READY after replacing Nebius bindings
-      --tags string                   Full replacement set of custom tags for the account in key=value format, separated by commas (e.g. env=prod,team=platform)
+      --tags string                   Full replacement set of custom tags for the account in key=value format, separated by commas (e.g. env=prod,team=platform). Escape commas inside values with \,
 ```
 
 ### Options inherited from parent commands

--- a/mkdocs/docs/omnistrate-ctl_instance_create.md
+++ b/mkdocs/docs/omnistrate-ctl_instance_create.md
@@ -63,7 +63,7 @@ omnistrate-ctl instance create --service=MyService --environment=dev --plan='Air
       --resource string                           Resource name
       --service string                            Service name
       --subscription-id string                    Subscription ID to use for the instance deployment. If not provided, instance deployment will be created in your own subscription.
-      --tags string                               Custom tags to add to the instance deployment (format: key=value,key2=value2)
+      --tags string                               Custom tags to add to the instance deployment (format: key=value,key2=value2). Escape commas inside values with \,
       --version string                            Service plan version (latest|preferred|1.0 etc.). With 'preferred', no version is sent and the platform picks the preferred version automatically. (default "preferred")
       --wait                                      Wait for deployment to complete and show progress
 ```

--- a/mkdocs/docs/omnistrate-ctl_instance_modify.md
+++ b/mkdocs/docs/omnistrate-ctl_instance_modify.md
@@ -33,7 +33,7 @@ omnistrate-ctl instance modify instance-abcd1234 --param-file /path/to/param.jso
       --network-type string   Optional network type change for the instance deployment (PUBLIC / INTERNAL)
       --param string          Parameters for the instance deployment
       --param-file string     Json file containing parameters for the instance deployment
-      --tags string           Custom tags to set on the instance deployment (format: key=value,key2=value2)
+      --tags string           Custom tags to set on the instance deployment (format: key=value,key2=value2). Escape commas inside values with \,
       --wait                  Wait for modification to complete and show progress
 ```
 


### PR DESCRIPTION
## Summary
- Support escaped commas (`\,`) in `--tags` parsing for account and instance commands
- Preserve existing comma-separated `key=value,key2=value2` behavior
- Update help text and add parser tests

## Usage
```bash
omnistrate-ctl account update <account-id> --tags "allowed_source_ranges=137.83.246.111/32\,1.2.3.4/32,public=true"
```

## Tests
- `go test ./internal/utils`
- `go test ./cmd/account`
- `go test ./cmd/instance`
- `git diff --check`