### PR TITLE
Route build --dry-run to read-only validation

### DIFF
--- a/cmd/build/build.go
+++ b/cmd/build/build.go
@@ -49,6 +49,9 @@ omnistrate-ctl build --file omnistrate-compose.yaml --product-name "My Service" 
 # Build service with compose spec interactively
 omnistrate-ctl build --file omnistrate-compose.yaml --product-name "My Service" --interactive
 
+# Validate a spec without changing anything (read-only; exits nonzero unless the result is VALID)
+omnistrate-ctl build --file omnistrate-compose.yaml --product-name "My Service" --dry-run
+
 # Build service with compose spec with service description and service logo
 omnistrate-ctl build --file omnistrate-compose.yaml --product-name "My Service" --description "My Service Description" --service-logo-url "https://example.com/logo.png"
 
@@ -99,7 +102,7 @@ var BuildCmd = &cobra.Command{
 func init() {
 	BuildCmd.Flags().StringP("file", "f", "", "Path to the docker compose file (defaults to omnistrate-compose.yaml, docker-compose.yaml or spec.yaml in that order).If docker-compose.yaml is found, it is detected but not supported; please convert it to omnistrate-compose.yaml")
 	BuildCmd.Flags().StringP("spec-type", "s", "", "Spec type (will infer from file if not provided). Valid options include: 'DockerCompose', 'ServicePlanSpec'")
-	BuildCmd.Flags().BoolP("dry-run", "d", false, "Simulate building the service without actually creating resources")
+	BuildCmd.Flags().BoolP("dry-run", "d", false, "Validate the specification without changing anything. Sends it to the server's read-only build validation endpoint: nothing is created, updated, released, promoted or uploaded. Local Terraform, Helm, Kustomize and operator content declared by the specification is sent for validation only, bounded at 16 MiB compressed and 64 MiB uncompressed in total across all artifacts. Exits zero only when the result is VALID; INVALID and INCOMPLETE (a check that could not be completed) both exit nonzero")
 	BuildCmd.Flags().StringP("product-name", "", "", "Name of the service. A service can have multiple service plans. The build command will build a new or existing service plan inside the specified service.")
 	BuildCmd.Flags().StringP("description", "", "", "A short description for the whole service. A service can have multiple service plans.")
 	BuildCmd.Flags().StringP("service-logo-url", "", "", "URL to the service logo")
@@ -179,33 +182,72 @@ func init() {
 	BuildCmd.MarkFlagsRequiredTogether("environment", "environment-type")
 }
 
+// buildOptions holds the parsed `build` command flags. It exists purely so the
+// build route can be executed from tests without a cobra command; the fields
+// mirror the flags one-for-one.
+type buildOptions struct {
+	file                          string
+	specType                      string
+	name                          string
+	description                   string
+	serviceLogoURL                string
+	environment                   string
+	environmentType               string
+	release                       bool
+	releaseAsPreferred            bool
+	releaseName                   string
+	releaseDescription            string
+	interactive                   bool
+	imageUrl                      string
+	envVars                       []string
+	imageRegistryAuthUsername     string
+	imageRegistryAuthPassword     string
+	output                        string
+	dryRun                        bool
+	forceCreateServicePlanVersion bool
+}
+
+// tokenProvider resolves the API token used by the build route. Production
+// always passes common.GetTokenWithLogin.
+type tokenProvider func() (string, error)
+
 func runBuild(cmd *cobra.Command, args []string) error {
 	defer config.CleanupArgsAndFlags(cmd, &args)
 
+	opts, err := parseBuildOptions(cmd)
+	if err != nil {
+		return err
+	}
+
+	return runBuildWithOptions(cmd.Context(), opts, common.GetTokenWithLogin)
+}
+
+// parseBuildOptions reads the build flags in their original order.
+func parseBuildOptions(cmd *cobra.Command) (opts buildOptions, err error) {
 	// Retrieve flags
 	file, err := cmd.Flags().GetString("file")
 	if err != nil {
-		return err
+		return opts, err
 	}
 
 	specType, err := cmd.Flags().GetString("spec-type")
 	if err != nil {
-		return err
+		return opts, err
 	}
 
 	name, err := cmd.Flags().GetString("name")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	productName, err := cmd.Flags().GetString("product-name")
 	if err != nil {
-		return err
+		return opts, err
 	}
 
 	if name != "" && productName != "" {
 		err = errors.New("only one of name or product-name can be provided")
 		utils.PrintError(err)
-		return err
+		return opts, err
 	}
 
 	// Use product-name if provided, otherwise use name
@@ -215,31 +257,31 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	}
 	description, err := cmd.Flags().GetString("description")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	serviceLogoURL, err := cmd.Flags().GetString("service-logo-url")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	environment, err := cmd.Flags().GetString("environment")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	environmentType, err := cmd.Flags().GetString("environment-type")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	release, err := cmd.Flags().GetBool("release")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	releaseAsPreferred, err := cmd.Flags().GetBool("release-as-preferred")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	noReleaseAsPreferred, err := cmd.Flags().GetBool("no-release-as-preferred")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	// If --no-release-as-preferred is set, it overrides --release-as-preferred
 	if noReleaseAsPreferred {
@@ -247,44 +289,91 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	}
 	releaseName, err := cmd.Flags().GetString("release-name")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	releaseDescription, err := cmd.Flags().GetString("release-description")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	interactive, err := cmd.Flags().GetBool("interactive")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	imageUrl, err := cmd.Flags().GetString("image")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	envVars, err := cmd.Flags().GetStringArray("env-var")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	imageRegistryAuthUsername, err := cmd.Flags().GetString("image-registry-auth-username")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	imageRegistryAuthPassword, err := cmd.Flags().GetString("image-registry-auth-password")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	output, err := cmd.Flags().GetString("output")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	dryRun, err := cmd.Flags().GetBool("dry-run")
 	if err != nil {
-		return err
+		return opts, err
 	}
 	forceCreateServicePlanVersion, err := cmd.Flags().GetBool("force-create-service-plan-version")
 	if err != nil {
-		return err
+		return opts, err
 	}
+
+	return buildOptions{
+		file:                          file,
+		specType:                      specType,
+		name:                          name,
+		description:                   description,
+		serviceLogoURL:                serviceLogoURL,
+		environment:                   environment,
+		environmentType:               environmentType,
+		release:                       release,
+		releaseAsPreferred:            releaseAsPreferred,
+		releaseName:                   releaseName,
+		releaseDescription:            releaseDescription,
+		interactive:                   interactive,
+		imageUrl:                      imageUrl,
+		envVars:                       envVars,
+		imageRegistryAuthUsername:     imageRegistryAuthUsername,
+		imageRegistryAuthPassword:     imageRegistryAuthPassword,
+		output:                        output,
+		dryRun:                        dryRun,
+		forceCreateServicePlanVersion: forceCreateServicePlanVersion,
+	}, nil
+}
+
+// runBuildWithOptions is the build route proper. Its body is unchanged from the
+// original runBuild; only flag retrieval and token acquisition were lifted out.
+func runBuildWithOptions(ctx context.Context, opts buildOptions, getToken tokenProvider) error {
+	var err error
+	file := opts.file
+	specType := opts.specType
+	name := opts.name
+	description := opts.description
+	serviceLogoURL := opts.serviceLogoURL
+	environment := opts.environment
+	environmentType := opts.environmentType
+	release := opts.release
+	releaseAsPreferred := opts.releaseAsPreferred
+	releaseName := opts.releaseName
+	releaseDescription := opts.releaseDescription
+	interactive := opts.interactive
+	imageUrl := opts.imageUrl
+	envVars := opts.envVars
+	imageRegistryAuthUsername := opts.imageRegistryAuthUsername
+	imageRegistryAuthPassword := opts.imageRegistryAuthPassword
+	output := opts.output
+	dryRun := opts.dryRun
+	forceCreateServicePlanVersion := opts.forceCreateServicePlanVersion
 
 	// Dynamic spec type detection for file-based builds
 	if imageUrl == "" && specType == "" {
@@ -374,7 +463,11 @@ func runBuild(cmd *cobra.Command, args []string) error {
 					errMsg := fmt.Sprintf("Deployment failed: Required file missing — %s\n\n→ Found: %s\n→ Expected: %s\n\nTip: You can convert your docker-compose.yaml into Omnistrate's native format using the omnistrate-fde skill via the Omnistrate MCP Server\nYou may even invoke it through AI agents like Claude, Gemini or others.\n\nLearn more: https://docs.omnistrate.com/getting-started/mcp-server/#using-skills",
 						OmnistrateComposeFileName, DockerComposeFileName, OmnistrateComposeFileName)
 					utils.PrintError(errors.New(errMsg))
-					return err
+					// nilerr: err is the (nil) os.Stat error. Behaviour is
+					// preserved from the original runBuild; utils.PrintError
+					// exits the process before this return is reached. Left
+					// as-is deliberately so this refactor changes no behaviour.
+					return err //nolint:nilerr
 				}
 
 				// Check for spec.yaml
@@ -406,7 +499,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	}
 
 	// Validate user is currently logged in
-	token, err := common.GetTokenWithLogin()
+	token, err := getToken()
 	if err != nil {
 		utils.PrintError(err)
 		return err
@@ -433,7 +526,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			passwordPtr = utils.ToPtr(imageRegistryAuthPassword)
 		}
 
-		checkImageRes, err := dataaccess.CheckIfContainerImageAccessible(cmd.Context(), token, imageRegistry, image, userNamePtr, passwordPtr)
+		checkImageRes, err := dataaccess.CheckIfContainerImageAccessible(ctx, token, imageRegistry, image, userNamePtr, passwordPtr)
 		if err != nil {
 			utils.PrintError(err)
 			return err
@@ -476,7 +569,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			Password:             passwordPtr,
 		}
 
-		generateComposeSpecRes, err := dataaccess.GenerateComposeSpecFromContainerImage(cmd.Context(), token, generateComposeSpecRequest)
+		generateComposeSpecRes, err := dataaccess.GenerateComposeSpecFromContainerImage(ctx, token, generateComposeSpecRequest)
 		if err != nil {
 			utils.PrintError(err)
 			return err
@@ -527,7 +620,9 @@ func runBuild(cmd *cobra.Command, args []string) error {
 
 	var sm1 utils.SpinnerManager
 	var spinner1 *utils.Spinner
-	if output != "json" {
+	// A dry run prints exactly one structured validation result, so it runs no
+	// spinners in any output mode.
+	if output != "json" && !dryRun {
 		sm1 = utils.NewSpinnerManager()
 		spinner1 = sm1.AddSpinner("Rendering spec file")
 		sm1.Start()
@@ -536,13 +631,28 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	var cwd string
 	cwd, err = os.Getwd()
 	if err != nil {
+		if dryRun {
+			return err
+		}
 		utils.HandleSpinnerError(spinner1, sm1, err)
 		return err
 	}
 
 	// Render files
-	fileData, err = RenderFile(fileData, cwd, file, sm1, spinner1)
+	if dryRun {
+		// RenderFile writes "<rootDir>/<basename>.tmp" into the user's input
+		// root and removes it only on success. The read-only route uses an owned
+		// temporary file outside the source tree instead.
+		fileData, err = renderFileForValidation(fileData, cwd, file)
+	} else {
+		fileData, err = RenderFile(fileData, cwd, file, sm1, spinner1)
+	}
 	if err != nil {
+		if dryRun {
+			// utils.PrintError exits the process, which would stop cobra from
+			// ever seeing a nonzero result.
+			return err
+		}
 		utils.HandleSpinnerError(spinner1, sm1, err)
 		return err
 	}
@@ -551,12 +661,34 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		spinner1 = nil
 	}
 
+	// Read-only validation route. This is placed after token acquisition and
+	// preprocessing and before FindOrCreateServiceHierarchy — the first business
+	// write on the legacy path — so no prepare, build, upload, release,
+	// environment-creation or promotion request is reachable from here.
+	if dryRun {
+		return runDryRunValidation(ctx, token, dryRunInput{
+			specType:                      specType,
+			name:                          name,
+			fileData:                      fileData,
+			cwd:                           cwd,
+			output:                        output,
+			description:                   descriptionPtr,
+			serviceLogoURL:                serviceLogoURLPtr,
+			environment:                   environmentPtr,
+			environmentType:               environmentTypePtr,
+			release:                       release,
+			releaseAsPreferred:            releaseAsPreferred,
+			releaseVersionName:            releaseNamePtr,
+			forceCreateServicePlanVersion: forceCreateServicePlanVersion,
+		})
+	}
+
 	var hierarchyResult *ServiceHierarchyResult
 	extendDistribution := false
 	if specType == ServicePlanSpecType {
 		var hierarchyErr error
 		hierarchyResult, hierarchyErr = FindOrCreateServiceHierarchy(
-			cmd.Context(),
+			ctx,
 			token,
 			name,
 			fileData,
@@ -578,7 +710,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		}
 
 		if shouldCheckDistributionExtension(hierarchyResult) {
-			extendsDistribution, distributionErr := serviceHasAdditionalPlans(cmd.Context(), token, hierarchyResult.ServiceID, hierarchyResult.EnvironmentID)
+			extendsDistribution, distributionErr := serviceHasAdditionalPlans(ctx, token, hierarchyResult.ServiceID, hierarchyResult.EnvironmentID)
 			if distributionErr == nil {
 				extendDistribution = extendsDistribution
 			}
@@ -588,7 +720,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	var buildProgress *specBuildProgress
 	if output != "json" {
 		buildProgress = addSpecBuildChecklist(sm1, fileData, specType, specChecklistOptions{extendDistribution: extendDistribution})
-		if streamErr := buildProgress.StreamFeatureChecks(cmd.Context()); streamErr != nil {
+		if streamErr := buildProgress.StreamFeatureChecks(ctx); streamErr != nil {
 			utils.HandleSpinnerError(nil, sm1, streamErr)
 			return streamErr
 		}
@@ -624,7 +756,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 				}
 
 				uploadResult, uploadErr := dataaccess.UploadArtifact(
-					cmd.Context(),
+					ctx,
 					token,
 					base64Content,
 					task.ArtifactPath,
@@ -643,7 +775,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			}
 
 			if len(uploadedArtifactIDs) > 0 {
-				waitErr := waitForArtifactsReady(cmd.Context(), token, uploadedArtifactIDs, nil)
+				waitErr := waitForArtifactsReady(ctx, token, uploadedArtifactIDs, nil)
 				if waitErr != nil {
 					utils.HandleSpinnerError(spinner1, sm1, waitErr)
 					return waitErr
@@ -658,7 +790,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		spinner1 = buildProgress.StartFinalizing()
 	}
 	ServiceID, EnvironmentID, ProductTierID, undefinedResources, isNewVersionCreated, err = BuildService(
-		cmd.Context(),
+		ctx,
 		fileData,
 		token,
 		name,
@@ -687,7 +819,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	utils.HandleSpinnerSuccess(nil, sm1, header)
 
 	// Get product tier name
-	productTier, err := dataaccess.DescribeProductTier(cmd.Context(), token, ServiceID, ProductTierID)
+	productTier, err := dataaccess.DescribeProductTier(ctx, token, ServiceID, ProductTierID)
 	if err != nil {
 		utils.PrintError(err)
 		return err
@@ -704,7 +836,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	}
 
 	if !dryRun && (release || releaseAsPreferred) {
-		versionDetails, err := dataaccess.DescribeLatestVersion(cmd.Context(), token, ServiceID, ProductTierID)
+		versionDetails, err := dataaccess.DescribeLatestVersion(ctx, token, ServiceID, ProductTierID)
 		if err != nil {
 			err = errors.Wrap(err, "failed to get the latest version")
 			return err
@@ -737,9 +869,9 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	utils.PrintURL("Check the service plan result at", fmt.Sprintf("https://%s/product-tier?serviceId=%s&environmentId=%s", config.GetRootDomain(), ServiceID, EnvironmentID))
 
 	// Ask user to verify account if there are any unverified accounts
-	dataaccess.AskVerifyAccountIfAny(cmd.Context())
+	dataaccess.AskVerifyAccountIfAny(ctx)
 
-	serviceEnvironment, err := dataaccess.DescribeServiceEnvironment(cmd.Context(), token, ServiceID, EnvironmentID)
+	serviceEnvironment, err := dataaccess.DescribeServiceEnvironment(ctx, token, ServiceID, EnvironmentID)
 	if err != nil {
 		utils.PrintError(err)
 		return err
@@ -766,7 +898,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			sm2.Start()
 
 			for {
-				serviceEnvironment, err = dataaccess.DescribeServiceEnvironment(cmd.Context(), token, ServiceID, EnvironmentID)
+				serviceEnvironment, err = dataaccess.DescribeServiceEnvironment(ctx, token, ServiceID, EnvironmentID)
 				if err != nil {
 					utils.PrintError(err)
 					return err
@@ -800,7 +932,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 				launching := sm2.AddSpinner("Launching service to production...")
 				sm2.Start()
 
-				prodEnvironment, err := dataaccess.FindEnvironment(cmd.Context(), token, ServiceID, "prod")
+				prodEnvironment, err := dataaccess.FindEnvironment(ctx, token, ServiceID, "prod")
 				if err != nil && !errors.As(err, &dataaccess.ErrEnvironmentNotFound) {
 					utils.PrintError(err)
 					return err
@@ -809,13 +941,13 @@ func runBuild(cmd *cobra.Command, args []string) error {
 				var prodEnvironmentID string
 				if errors.As(err, &dataaccess.ErrEnvironmentNotFound) {
 					// Get default deployment config ID
-					defaultDeploymentConfigID, err := dataaccess.GetDefaultDeploymentConfigID(cmd.Context(), token)
+					defaultDeploymentConfigID, err := dataaccess.GetDefaultDeploymentConfigID(ctx, token)
 					if err != nil {
 						utils.PrintError(err)
 						return err
 					}
 					prodEnvironmentID, err = dataaccess.CreateServiceEnvironment(
-						cmd.Context(),
+						ctx,
 						token,
 						"Production",
 						"Production environment",
@@ -835,7 +967,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 				}
 
 				// Promote the service to production
-				err = dataaccess.PromoteServiceEnvironment(cmd.Context(), token, ServiceID, EnvironmentID, "", "")
+				err = dataaccess.PromoteServiceEnvironment(ctx, token, ServiceID, EnvironmentID, "", "")
 				if err != nil {
 					utils.PrintError(err)
 					return err
@@ -845,7 +977,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 				sm2.Stop()
 
 				// Retrieve the prod SaaS portal URL
-				prodEnvironment, err = dataaccess.DescribeServiceEnvironment(cmd.Context(), token, ServiceID, prodEnvironmentID)
+				prodEnvironment, err = dataaccess.DescribeServiceEnvironment(ctx, token, ServiceID, prodEnvironmentID)
 				if err != nil {
 					utils.PrintError(err)
 					return err
@@ -869,7 +1001,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 						sm3.Start()
 
 						for {
-							serviceEnvironment, err = dataaccess.DescribeServiceEnvironment(cmd.Context(), token, ServiceID, prodEnvironmentID)
+							serviceEnvironment, err = dataaccess.DescribeServiceEnvironment(ctx, token, ServiceID, prodEnvironmentID)
 							if err != nil {
 								utils.PrintError(err)
 								return err

--- a/cmd/build/dry_run.go
+++ b/cmd/build/dry_run.go
@@ -1,0 +1,683 @@
+package build
+
+// The read-only route for `omnistrate-ctl build --dry-run`, per
+// dry-run-implementation-specs/04-local-artifacts-and-ctl.md §"CTL execution
+// algorithm" and §"Output and logging".
+//
+// This route is entered from runBuildWithOptions after the token is acquired
+// and the spec has been preprocessed, and BEFORE FindOrCreateServiceHierarchy —
+// the first business write on the legacy path. From here the only server
+// interaction permitted is POST /2022-09-01-00/service/spec/validate. Prepare,
+// either normal build endpoint, artifact upload, release, environment creation
+// and promotion are all unreachable, and there is no fallback to them for any
+// server response, including 404/405.
+//
+// Errors are returned rather than routed through utils.PrintError, because
+// PrintError calls os.Exit(1) and would kill the process before cobra could
+// turn an INVALID/INCOMPLETE result into a nonzero exit status.
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/compose-spec/compose-go/loader"
+	"github.com/compose-spec/compose-go/types"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
+	openapiclient "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
+)
+
+const validationArtifactEncoding = dataaccess.ValidationArtifactEncoding
+
+// dryRunInput carries everything the validation route needs. It is assembled in
+// runBuildWithOptions from the already-resolved flags and the already-rendered
+// specification bytes; nothing here is re-read or re-rendered between the two
+// requests.
+type dryRunInput struct {
+	specType string
+	name     string
+	fileData []byte
+	cwd      string
+	output   string
+
+	description                   *string
+	serviceLogoURL                *string
+	environment                   *string
+	environmentType               *string
+	release                       bool
+	releaseAsPreferred            bool
+	releaseVersionName            *string
+	forceCreateServicePlanVersion bool
+}
+
+// validationSpecTypeFor maps the CLI spec type onto the wire enum accepted by
+// ValidateServiceSpecRequest2.specType.
+func validationSpecTypeFor(specType string) (string, error) {
+	switch specType {
+	case ServicePlanSpecType:
+		return dataaccess.ValidationSpecTypeServicePlan, nil
+	case DockerComposeSpecType:
+		return dataaccess.ValidationSpecTypeCompose, nil
+	default:
+		return "", fmt.Errorf("read-only validation does not support spec type %q", specType)
+	}
+}
+
+// runDryRunValidation executes the two-request validation flow and prints
+// exactly one result. It returns nil only for a VALID outcome.
+func runDryRunValidation(ctx context.Context, token string, in dryRunInput) error {
+	switch in.output {
+	case "text", "table", "json":
+	default:
+		return fmt.Errorf("unsupported output format: %s", in.output)
+	}
+
+	wireSpecType, err := validationSpecTypeFor(in.specType)
+	if err != nil {
+		return err
+	}
+
+	limits := defaultValidationLimits()
+	if int64(len(in.fileData)) > limits.MaxTotalSpecBytes {
+		return fmt.Errorf("%w: the specification is %d bytes and read-only validation accepts at most %d",
+			errArtifactLimitExceeded, len(in.fileData), limits.MaxTotalSpecBytes)
+	}
+
+	request := openapiclient.ValidateServiceSpecRequest2{
+		Name:                             in.name,
+		SpecType:                         wireSpecType,
+		FileContent:                      base64.StdEncoding.EncodeToString(in.fileData),
+		Description:                      in.description,
+		ServiceLogoURL:                   in.serviceLogoURL,
+		Environment:                      in.environment,
+		EnvironmentType:                  in.environmentType,
+		Release:                          utils.ToPtr(in.release),
+		ReleaseAsPreferred:               utils.ToPtr(in.releaseAsPreferred),
+		ReleaseVersionName:               in.releaseVersionName,
+		ForceCreateNewServicePlanVersion: utils.ToPtr(in.forceCreateServicePlanVersion),
+	}
+
+	// Compose configs and secrets travel in the envelope, exactly as the normal
+	// build sends them. They are rejected by the server for service-plan specs.
+	if in.specType == DockerComposeSpecType {
+		composeFileData, configs, secrets, composeErr := prepareComposeValidationContent(ctx, in.fileData)
+		if composeErr != nil {
+			return composeErr
+		}
+		request.FileContent = base64.StdEncoding.EncodeToString(composeFileData)
+		request.Configs = configs
+		request.Secrets = secrets
+	}
+
+	// Request one: discovery, with no artifacts.
+	first, err := sendValidationRequest(ctx, token, request, limits)
+	if err != nil {
+		return err
+	}
+	limits = limits.withServerLimits(first.Limits)
+
+	result := first
+	var suppliedArtifacts []openapiclient.ValidationArtifactInput
+
+	if shouldSupplyArtifacts(first) {
+		allowed := collectDeclaredArtifactPaths(in.specType, in.fileData, limits.MaxArchiveMemberPathBytes)
+		suppliedArtifacts, err = packageValidationArtifacts(in.cwd, first.RequiredArtifacts, allowed, limits)
+		if err != nil {
+			return err
+		}
+
+		// Request two: the identical envelope plus the requested content. This
+		// is the only retry; there is no loop and no mutation fallback.
+		request.Artifacts = suppliedArtifacts
+		second, secondErr := sendValidationRequest(ctx, token, request, limits)
+		if secondErr != nil {
+			return secondErr
+		}
+
+		if second.InputDigest != first.InputDigest {
+			return fmt.Errorf(
+				"the validation server described a different input for the second request (%s) than for the first (%s); aborting instead of trusting the result",
+				second.InputDigest, first.InputDigest)
+		}
+		result = second
+	}
+
+	printValidationResult(in.output, result)
+
+	if len(suppliedArtifacts) > 0 && len(result.RequiredArtifacts) > 0 {
+		return fmt.Errorf(
+			"the validation server asked for more local content after the final request (%s); read-only validation does not retry again",
+			strings.Join(requiredArtifactPaths(result), ", "))
+	}
+
+	switch result.Status {
+	case dataaccess.ValidationStatusValid:
+		if err := verifyValidatedArtifacts(first, result, suppliedArtifacts); err != nil {
+			return err
+		}
+		return nil
+	case dataaccess.ValidationStatusInvalid:
+		return errors.New("validation failed: the specification is not valid")
+	case dataaccess.ValidationStatusIncomplete:
+		return errors.New("validation incomplete: not every required check could be completed")
+	default:
+		return fmt.Errorf("validation returned an unknown status %q", result.Status)
+	}
+}
+
+// shouldSupplyArtifacts implements step 4: package and retry once only when the
+// server reported concrete requirements and did not already know the spec is
+// invalid.
+func shouldSupplyArtifacts(result *openapiclient.ValidateServiceSpecResult) bool {
+	if result.Status == dataaccess.ValidationStatusInvalid {
+		return false
+	}
+	return len(result.RequiredArtifacts) > 0
+}
+
+// sendValidationRequest performs one request under the effective deadline and
+// translates an unsupported-server response into an upgrade message.
+func sendValidationRequest(
+	ctx context.Context,
+	token string,
+	request openapiclient.ValidateServiceSpecRequest2,
+	limits validationLimits,
+) (*openapiclient.ValidateServiceSpecResult, error) {
+	requestCtx := ctx
+	if limits.RequestDeadlineSeconds > 0 {
+		var cancel context.CancelFunc
+		requestCtx, cancel = context.WithTimeout(ctx, time.Duration(limits.RequestDeadlineSeconds)*time.Second)
+		defer cancel()
+	}
+
+	result, err := dataaccess.ValidateServiceSpec(requestCtx, token, request)
+	if err != nil {
+		var validationErr *dataaccess.ValidateServiceSpecError
+		if errors.As(err, &validationErr) && validationErr.ServerLacksValidationEndpoint() {
+			return nil, fmt.Errorf(
+				"this Omnistrate server does not support read-only build validation; it requires an upgrade before 'build --dry-run' can be used. No build, prepare or upload request was made")
+		}
+		return nil, err
+	}
+	return result, nil
+}
+
+// verifyValidatedArtifacts confirms a VALID result really acknowledges the
+// supplied bytes and every use that required them.
+func verifyValidatedArtifacts(
+	first *openapiclient.ValidateServiceSpecResult,
+	final *openapiclient.ValidateServiceSpecResult,
+	supplied []openapiclient.ValidationArtifactInput,
+) error {
+	if len(supplied) == 0 {
+		return nil
+	}
+
+	validated := make(map[string]openapiclient.ValidatedArtifact, len(final.ValidatedArtifacts))
+	for _, artifact := range final.ValidatedArtifacts {
+		validated[artifact.LogicalPath] = artifact
+	}
+
+	for _, artifact := range supplied {
+		acknowledged, ok := validated[artifact.LogicalPath]
+		if !ok {
+			return fmt.Errorf(
+				"validation reported VALID but never acknowledged the content supplied for %q; treating the result as untrustworthy",
+				artifact.LogicalPath)
+		}
+		if acknowledged.Sha256 != artifact.Sha256 {
+			return fmt.Errorf(
+				"validation acknowledged different content for %q (%s) than was supplied (%s)",
+				artifact.LogicalPath, acknowledged.Sha256, artifact.Sha256)
+		}
+	}
+
+	// Every use that made the content required must appear among the uses whose
+	// validators consumed it.
+	for _, requirement := range first.RequiredArtifacts {
+		canonical, err := canonicalValidationPath(requirement.LogicalPath, 0)
+		if err != nil {
+			continue
+		}
+		acknowledged, ok := validated[canonical]
+		if !ok {
+			continue
+		}
+		acknowledgedUses := make(map[string]struct{}, len(acknowledged.Uses))
+		for _, use := range acknowledged.Uses {
+			acknowledgedUses[artifactUseKey(use)] = struct{}{}
+		}
+		for _, use := range requirement.Uses {
+			if _, ok := acknowledgedUses[artifactUseKey(use)]; !ok {
+				return fmt.Errorf(
+					"validation reported VALID but did not check %q for resource %q (%s)",
+					canonical, use.ResourceKey, use.Kind)
+			}
+		}
+	}
+
+	return nil
+}
+
+func artifactUseKey(use openapiclient.ValidationArtifactUse) string {
+	provider := ""
+	if use.Provider != nil {
+		provider = *use.Provider
+	}
+	onPrem := ""
+	if use.OnPremPlatform != nil {
+		onPrem = *use.OnPremPlatform
+	}
+	return strings.Join([]string{use.ResourceKey, use.Kind, provider, onPrem, use.Path}, "\x00")
+}
+
+func requiredArtifactPaths(result *openapiclient.ValidateServiceSpecResult) []string {
+	out := make([]string, 0, len(result.RequiredArtifacts))
+	for _, requirement := range result.RequiredArtifacts {
+		out = append(out, requirement.LogicalPath)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Preprocessing that never writes into the user's source tree
+// ---------------------------------------------------------------------------
+
+// renderFileForValidation is the read-only counterpart of RenderFile.
+//
+// RenderFile writes "<rootDir>/<basename>.tmp" for `docker compose config` and
+// removes it only on success, so it destroys a pre-existing file of that name
+// and can leave rendered spec content behind in the user's input root. The
+// validation route must not touch the source tree at all, so the temporary file
+// is created in an owned temp directory outside it and removed unconditionally,
+// while --project-directory preserves the original project directory for
+// relative env-file, config and secret resolution.
+func renderFileForValidation(fileData []byte, rootDir string, file string) ([]byte, error) {
+	rendered, err := renderFileReferences(fileData, file, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if !strings.Contains(string(rendered), "env_file:") {
+		return rendered, nil
+	}
+
+	return renderEnvFileForValidation(rendered, rootDir, file)
+}
+
+// renderEnvFileForValidation mirrors renderEnvFileAndInterpolateVariables in
+// build_from_repo.go, including its `$` escaping convention and its numeric-cpus
+// requoting, but keeps every byte it writes outside the user's project.
+//
+// TestDryRunValidationRenderingMatchesRenderFile pins the two implementations to
+// the same output so they cannot drift.
+func renderEnvFileForValidation(fileData []byte, rootDir string, file string) ([]byte, error) {
+	// Replace `$` with `$$` to avoid interpolation. Do not replace for `${...}`
+	// since it's used to specify variable interpolations.
+	escaped := strings.ReplaceAll(string(fileData), "$", "$$")
+	escaped = strings.ReplaceAll(escaped, "$${", "${")
+	escaped = strings.ReplaceAll(escaped, "${{ secrets.GitHubPAT }}", "$${{ secrets.GitHubPAT }}")
+
+	tempDir, err := os.MkdirTemp("", "omnistrate-validate-")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create a temporary directory for validation rendering: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	baseName := "omnistrate-compose.yaml"
+	if strings.TrimSpace(file) != "" {
+		baseName = filepath.Base(file)
+	}
+	tempFile := filepath.Join(tempDir, baseName+".tmp")
+	if err = os.WriteFile(tempFile, []byte(escaped), 0600); err != nil {
+		return nil, fmt.Errorf("failed to write the temporary validation spec: %w", err)
+	}
+
+	projectDirectory := rootDir
+	if strings.TrimSpace(projectDirectory) == "" {
+		projectDirectory = "."
+	}
+
+	// --project-directory keeps relative env_file/config/secret references
+	// resolving against the user's project even though -f points outside it.
+	renderCmd := exec.Command("docker", "compose", "--project-directory", projectDirectory, "-f", tempFile, "config")
+	cmdOut := &bytes.Buffer{}
+	cmdErr := &bytes.Buffer{}
+	renderCmd.Stdout = cmdOut
+	renderCmd.Stderr = cmdErr
+
+	if err = renderCmd.Run(); err != nil {
+		detail := strings.TrimSpace(cmdErr.String())
+		if detail == "" {
+			return nil, fmt.Errorf("failed to render the compose spec for validation: %w", err)
+		}
+		return nil, fmt.Errorf("failed to render the compose spec for validation: %w\n%s", err, detail)
+	}
+
+	// docker compose config escapes `$` by doubling it; undo that.
+	rendered := strings.ReplaceAll(cmdOut.String(), "$$", "$")
+
+	// Quote numeric cpus values in deploy.resources.
+	re := regexp.MustCompile(`(?m)(^\s*cpus:\s*)([0-9.]+)\s*$`)
+	rendered = re.ReplaceAllString(rendered, `$1"$2"`)
+
+	return []byte(rendered), nil
+}
+
+// prepareComposeValidationContent reproduces the compose preprocessing that
+// BuildService performs before sending a real build request: volumes that point
+// at local files become configs, the project is re-marshalled if that changed
+// it, and config/secret files are read from their declared relative paths and
+// base64 encoded.
+//
+// It is a local, read-only operation. TestDryRunComposeEnvelopeMatchesRealBuild
+// asserts byte equality with what the legacy build endpoint receives, so the two
+// cannot drift.
+func prepareComposeValidationContent(ctx context.Context, fileData []byte) (
+	[]byte, *map[string]string, *map[string]string, error) {
+	parsedYaml, err := loader.ParseYAML(fileData)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to parse YAML content: %w", err)
+	}
+
+	project, err := loader.LoadWithContext(ctx, types.ConfigDetails{
+		ConfigFiles: []types.ConfigFile{{Config: parsedYaml}},
+	})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("invalid compose: %w", err)
+	}
+
+	project, modified, err := convertVolumesToConfigs(project)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if modified {
+		marshalled, marshalErr := project.MarshalYAML()
+		if marshalErr != nil {
+			return nil, nil, nil, fmt.Errorf("failed to marshal project to YAML: %w", marshalErr)
+		}
+		fileData = marshalled
+	}
+
+	var configs *map[string]string
+	if project.Configs != nil {
+		configsTemp := make(map[string]string)
+		for configName, config := range project.Configs {
+			content, readErr := os.ReadFile(filepath.Clean(config.File))
+			if readErr != nil {
+				return nil, nil, nil, readErr
+			}
+			configsTemp[configName] = base64.StdEncoding.EncodeToString(content)
+		}
+		configs = &configsTemp
+	}
+
+	var secrets *map[string]string
+	if project.Secrets != nil {
+		secretsTemp := make(map[string]string)
+		for secretName, secret := range project.Secrets {
+			content, readErr := os.ReadFile(filepath.Clean(secret.File))
+			if readErr != nil {
+				return nil, nil, nil, readErr
+			}
+			secretsTemp[secretName] = base64.StdEncoding.EncodeToString(content)
+		}
+		secrets = &secretsTemp
+	}
+
+	return fileData, configs, secrets, nil
+}
+
+// ---------------------------------------------------------------------------
+// Output
+// ---------------------------------------------------------------------------
+
+type dryRunCheck struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+type dryRunDiagnostic struct {
+	Code        string `json:"code"`
+	Severity    string `json:"severity"`
+	Message     string `json:"message"`
+	Path        string `json:"path,omitempty"`
+	ResourceKey string `json:"resourceKey,omitempty"`
+}
+
+type dryRunArtifactUse struct {
+	ResourceKey    string `json:"resourceKey"`
+	Kind           string `json:"kind"`
+	Provider       string `json:"provider,omitempty"`
+	OnPremPlatform string `json:"onPremPlatform,omitempty"`
+	Path           string `json:"path,omitempty"`
+}
+
+type dryRunArtifactRequirement struct {
+	LogicalPath string              `json:"logicalPath"`
+	Uses        []dryRunArtifactUse `json:"uses"`
+}
+
+type dryRunValidatedArtifact struct {
+	LogicalPath         string              `json:"logicalPath"`
+	Sha256              string              `json:"sha256"`
+	CompressedSizeBytes int64               `json:"compressedSizeBytes"`
+	Uses                []dryRunArtifactUse `json:"uses"`
+}
+
+type dryRunExistingTarget struct {
+	ServiceID            string `json:"serviceID,omitempty"`
+	ServiceEnvironmentID string `json:"serviceEnvironmentID,omitempty"`
+	ProductTierID        string `json:"productTierID,omitempty"`
+}
+
+// dryRunValidationOutput is the single structured document printed on stdout. It
+// mirrors the wire result but always allocates the four required arrays, so a
+// consumer never has to distinguish null from [].
+//
+// It deliberately carries no service plan version, release URL or "built"
+// wording: a dry run changes no service configuration and must not look as
+// though it did.
+type dryRunValidationOutput struct {
+	Status             string                      `json:"status"`
+	ValidationVersion  string                      `json:"validationVersion"`
+	InputDigest        string                      `json:"inputDigest"`
+	ObservedAt         string                      `json:"observedAt,omitempty"`
+	ExistingTarget     *dryRunExistingTarget       `json:"existingTarget,omitempty"`
+	Checks             []dryRunCheck               `json:"checks"`
+	Diagnostics        []dryRunDiagnostic          `json:"diagnostics"`
+	RequiredArtifacts  []dryRunArtifactRequirement `json:"requiredArtifacts"`
+	ValidatedArtifacts []dryRunValidatedArtifact   `json:"validatedArtifacts"`
+}
+
+func newDryRunValidationOutput(result *openapiclient.ValidateServiceSpecResult) dryRunValidationOutput {
+	out := dryRunValidationOutput{
+		Status:             result.Status,
+		ValidationVersion:  result.ValidationVersion,
+		InputDigest:        result.InputDigest,
+		Checks:             make([]dryRunCheck, 0, len(result.Checks)),
+		Diagnostics:        make([]dryRunDiagnostic, 0, len(result.Diagnostics)),
+		RequiredArtifacts:  make([]dryRunArtifactRequirement, 0, len(result.RequiredArtifacts)),
+		ValidatedArtifacts: make([]dryRunValidatedArtifact, 0, len(result.ValidatedArtifacts)),
+	}
+	if result.ObservedAt != nil {
+		out.ObservedAt = result.ObservedAt.UTC().Format(time.RFC3339)
+	}
+	if result.ExistingTarget != nil {
+		target := dryRunExistingTarget{}
+		if result.ExistingTarget.ServiceID != nil {
+			target.ServiceID = *result.ExistingTarget.ServiceID
+		}
+		if result.ExistingTarget.ServiceEnvironmentID != nil {
+			target.ServiceEnvironmentID = *result.ExistingTarget.ServiceEnvironmentID
+		}
+		if result.ExistingTarget.ProductTierID != nil {
+			target.ProductTierID = *result.ExistingTarget.ProductTierID
+		}
+		out.ExistingTarget = &target
+	}
+	for _, check := range result.Checks {
+		out.Checks = append(out.Checks, dryRunCheck{Name: check.Name, Status: check.Status})
+	}
+	for _, diagnostic := range result.Diagnostics {
+		entry := dryRunDiagnostic{
+			Code:     diagnostic.Code,
+			Severity: diagnostic.Severity,
+			Message:  diagnostic.Message,
+		}
+		if diagnostic.Path != nil {
+			entry.Path = *diagnostic.Path
+		}
+		if diagnostic.ResourceKey != nil {
+			entry.ResourceKey = *diagnostic.ResourceKey
+		}
+		out.Diagnostics = append(out.Diagnostics, entry)
+	}
+	for _, requirement := range result.RequiredArtifacts {
+		out.RequiredArtifacts = append(out.RequiredArtifacts, dryRunArtifactRequirement{
+			LogicalPath: requirement.LogicalPath,
+			Uses:        convertArtifactUses(requirement.Uses),
+		})
+	}
+	for _, artifact := range result.ValidatedArtifacts {
+		out.ValidatedArtifacts = append(out.ValidatedArtifacts, dryRunValidatedArtifact{
+			LogicalPath:         artifact.LogicalPath,
+			Sha256:              artifact.Sha256,
+			CompressedSizeBytes: artifact.CompressedSizeBytes,
+			Uses:                convertArtifactUses(artifact.Uses),
+		})
+	}
+	return out
+}
+
+func convertArtifactUses(uses []openapiclient.ValidationArtifactUse) []dryRunArtifactUse {
+	out := make([]dryRunArtifactUse, 0, len(uses))
+	for _, use := range uses {
+		entry := dryRunArtifactUse{
+			ResourceKey: use.ResourceKey,
+			Kind:        use.Kind,
+			Path:        use.Path,
+		}
+		if use.Provider != nil {
+			entry.Provider = *use.Provider
+		}
+		if use.OnPremPlatform != nil {
+			entry.OnPremPlatform = *use.OnPremPlatform
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// printValidationResult writes exactly one document. In JSON mode that is a
+// single JSON object with no spinner, prompt or success footer around it.
+func printValidationResult(output string, result *openapiclient.ValidateServiceSpecResult) {
+	payload := newDryRunValidationOutput(result)
+
+	if output == "json" {
+		// PrintTextTableJsonOutput only fails on an unsupported format, which is
+		// rejected before any request is sent.
+		_ = utils.PrintTextTableJsonOutput(output, payload)
+		return
+	}
+
+	printValidationText(payload)
+}
+
+func printValidationText(payload dryRunValidationOutput) {
+	switch payload.Status {
+	case dataaccess.ValidationStatusValid:
+		utils.PrintSuccess("Validation passed; no service configuration changed")
+	case dataaccess.ValidationStatusInvalid:
+		utils.PrintWarning("Validation failed")
+	case dataaccess.ValidationStatusIncomplete:
+		utils.PrintWarning("Validation incomplete")
+	default:
+		utils.PrintWarning("Validation returned an unknown status: " + payload.Status)
+	}
+
+	if len(payload.Checks) > 0 {
+		fmt.Println()
+		fmt.Println("Checks:")
+		for _, check := range payload.Checks {
+			fmt.Printf("  %-22s %s\n", check.Name, check.Status)
+		}
+	}
+
+	if len(payload.Diagnostics) > 0 {
+		fmt.Println()
+		fmt.Println("Diagnostics:")
+		for _, diagnostic := range payload.Diagnostics {
+			location := diagnostic.Path
+			if diagnostic.ResourceKey != "" {
+				if location == "" {
+					location = "resource " + diagnostic.ResourceKey
+				} else {
+					location += " (resource " + diagnostic.ResourceKey + ")"
+				}
+			}
+			if location == "" {
+				fmt.Printf("  [%s] %s: %s\n", diagnostic.Severity, diagnostic.Code, diagnostic.Message)
+				continue
+			}
+			fmt.Printf("  [%s] %s at %s: %s\n", diagnostic.Severity, diagnostic.Code, location, diagnostic.Message)
+		}
+	}
+
+	if len(payload.RequiredArtifacts) > 0 {
+		fmt.Println()
+		fmt.Println("Local content still required:")
+		for _, requirement := range payload.RequiredArtifacts {
+			fmt.Printf("  %s\n", requirement.LogicalPath)
+			for _, use := range requirement.Uses {
+				fmt.Printf("      used by resource %s (%s)%s\n", use.ResourceKey, use.Kind, formatUseTarget(use))
+			}
+		}
+	}
+
+	if len(payload.ValidatedArtifacts) > 0 {
+		fmt.Println()
+		fmt.Println("Local content validated:")
+		for _, artifact := range payload.ValidatedArtifacts {
+			fmt.Printf("  %s (sha256 %s, %d bytes compressed)\n",
+				artifact.LogicalPath, shortDigest(artifact.Sha256), artifact.CompressedSizeBytes)
+		}
+	}
+
+	fmt.Println()
+	switch payload.Status {
+	case dataaccess.ValidationStatusValid:
+		fmt.Println("No service, environment, plan, version or artifact was created, updated, released or promoted.")
+	case dataaccess.ValidationStatusInvalid:
+		fmt.Println("Fix the diagnostics above and run the validation again. Nothing was changed.")
+	case dataaccess.ValidationStatusIncomplete:
+		fmt.Println("Validation could not finish every required check, so the specification is not confirmed valid. Nothing was changed.")
+	}
+}
+
+func formatUseTarget(use dryRunArtifactUse) string {
+	switch {
+	case use.Provider != "":
+		return " on " + use.Provider
+	case use.OnPremPlatform != "":
+		return " on " + use.OnPremPlatform
+	default:
+		return ""
+	}
+}
+
+func shortDigest(digest string) string {
+	if len(digest) <= 12 {
+		return digest
+	}
+	return digest[:12]
+}

--- a/cmd/build/dry_run_target_test.go
+++ b/cmd/build/dry_run_target_test.go
@@ -1,0 +1,432 @@
+package build
+
+// Target contract for `omnistrate-ctl build --dry-run`, per
+// dry-run-implementation-specs/02-regression-tests.md §"CLI request contract
+// tests" and 04-local-artifacts-and-ctl.md §"CTL execution algorithm" /
+// §"Output and logging".
+//
+// These tests were written before the implementation and were held behind a
+// `dryrun_target` build tag while they were red. Spec 04 has landed, so the tag
+// is gone and they run by default:
+//
+//	go test ./cmd/build -run TestDryRunTarget -count=1 -v
+//
+// Three assumptions in the original file did not survive contact with the
+// generated SDK and the local path allowlist; each is called out at its test:
+// the artifact cases needed specifications that actually DECLARE the local path
+// the server asks for, because a path no local source declares is refused before
+// anything is read.
+//
+// The server here accepts ONLY POST /2022-09-01-00/service/spec/validate.
+// Every other request — prepare, either normal build endpoint, artifact upload,
+// environment creation, release or promotion — is recorded as a violation and
+// answered with an error, and the violation is asserted on the main test
+// goroutine (never with require.FailNow inside the handler).
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// startValidationOnlyServer returns a recorder that permits only the new
+// validation POST. respond produces the response for each validation request,
+// indexed by call number (0-based).
+func startValidationOnlyServer(t *testing.T, respond func(call int, rec recordedRequest, w http.ResponseWriter)) *requestRecorder {
+	t.Helper()
+	return startValidationServerAllowing(t, nil, respond)
+}
+
+// targetDryRunOptions writes the artifact-free ServicePlanSpec fixture into a
+// fresh working directory and returns the JSON dry-run options for it.
+func targetDryRunOptions(t *testing.T) buildOptions {
+	t.Helper()
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "spec.yaml", minimalServicePlanSpec)
+	t.Chdir(dir)
+	return jsonDryRunOptions(specPath, ServicePlanSpecType)
+}
+
+// ---------------------------------------------------------------------------
+// Request shape
+// ---------------------------------------------------------------------------
+
+// TestDryRunTargetNoArtifactIssuesOneValidationRequest — 02: "no artifact (one
+// validation request)".
+func TestDryRunTargetNoArtifactIssuesOneValidationRequest(t *testing.T) {
+	rr := startValidationOnlyServer(t, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		writeJSON(w, validationResult(statusValid, nil))
+	})
+
+	opts := targetDryRunOptions(t)
+	require.NoError(t, runBuildWithOptions(context.Background(), opts, staticToken()))
+	rr.assertNoViolations(t)
+
+	require.Equal(t, []string{"POST " + pathValidateSpec}, rr.sequence())
+
+	body := rr.find(pathValidateSpec)[0].decodeBody(t)
+	require.Equal(t, "service-plan", body["specType"])
+	require.Equal(t, testServiceName, body["name"])
+	require.Equal(t, base64.StdEncoding.EncodeToString([]byte(minimalServicePlanSpec)), body["fileContent"])
+	require.NotContains(t, body, "dryrun", "the validation endpoint has no public dryrun flag")
+}
+
+// TestDryRunTargetArtifactsIssueAtMostTwoValidationRequests — 02: "artifacts (at
+// most two)". First response asks for content, second validates it.
+//
+// RECONCILED: the original used minimalServicePlanSpec, which declares no local
+// artifact source at all, so its only allowlisted path is the documented
+// Terraform default root ".". A server asking for "terraform/network" against
+// that spec is now refused. The fixture therefore declares the path explicitly.
+func TestDryRunTargetArtifactsIssueAtMostTwoValidationRequests(t *testing.T) {
+	requirement := []map[string]any{{
+		"logicalPath": "terraform/network",
+		"uses": []map[string]any{{
+			"resourceKey": "network",
+			"kind":        "terraform",
+			"provider":    "aws",
+			"path":        "/services/0/terraformConfigurations/configurationPerCloudProvider/aws",
+		}},
+	}}
+
+	rr := startValidationOnlyServer(t, func(call int, rec recordedRequest, w http.ResponseWriter) {
+		if call == 0 {
+			writeJSON(w, validationResult(statusIncomplete, requirement))
+			return
+		}
+		writeJSON(w, validationResultAcknowledging(statusValid, rec, requirement))
+	})
+
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "spec.yaml", servicePlanSpecWithLocalTerraform)
+	writeFixture(t, dir, "terraform/network/main.tf", "output \"id\" { value = \"x\" }\n")
+	t.Chdir(dir)
+
+	opts := jsonDryRunOptions(specPath, ServicePlanSpecType)
+	require.NoError(t, runBuildWithOptions(context.Background(), opts, staticToken()))
+	rr.assertNoViolations(t)
+
+	require.Equal(t, 2, rr.countPath(pathValidateSpec), "at most two validation requests")
+
+	firstBody := rr.find(pathValidateSpec)[0].decodeBody(t)
+	require.NotContains(t, firstBody, "artifacts", "the discovery request carries no artifacts")
+
+	second := rr.find(pathValidateSpec)[1].decodeBody(t)
+	artifacts, ok := second["artifacts"].([]any)
+	require.True(t, ok, "second request must carry artifacts: %v", second)
+	require.Len(t, artifacts, 1)
+
+	artifact := artifacts[0].(map[string]any)
+	require.Equal(t, "terraform/network", artifact["logicalPath"])
+	require.Equal(t, "tar+gzip+base64", artifact["encoding"])
+	require.NotEmpty(t, artifact["archiveContent"])
+	require.Len(t, artifact["sha256"], 64)
+	require.NotZero(t, artifact["compressedSizeBytes"])
+
+	// The digest and size describe the exact decoded compressed bytes, and the
+	// archive really contains the declared directory's contents, named relative
+	// to that directory's own root.
+	require.Equal(t, []string{"main.tf"}, tarEntryNames(t, decodeArchive(t, artifact)))
+
+	// RECONCILED: the original compared body["inputDigest"] across the two
+	// REQUESTS. inputDigest is a response field, so that comparison was
+	// vacuously true (nil == nil). The envelope equality that actually matters
+	// is asserted directly here, and the response-digest check the client
+	// performs has its own test,
+	// TestDryRunValidationRejectsAChangedInputDigest.
+	delete(firstBody, "artifacts")
+	delete(second, "artifacts")
+	require.Equal(t, firstBody, second,
+		"both requests must carry the same input envelope apart from the artifacts")
+}
+
+// ---------------------------------------------------------------------------
+// Output and exit status
+// ---------------------------------------------------------------------------
+
+// TestDryRunTargetJSONOutputIsExactlyOneDocument — 02: "JSON/non-TTY ... stdout
+// is one JSON document in JSON mode"; 04 §"Output and logging".
+func TestDryRunTargetJSONOutputIsExactlyOneDocument(t *testing.T) {
+	rr := startValidationOnlyServer(t, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		writeJSON(w, validationResult(statusValid, nil))
+	})
+
+	opts := targetDryRunOptions(t)
+
+	var runErr error
+	stdout := captureStdout(t, func() {
+		runErr = runBuildWithOptions(context.Background(), opts, staticToken())
+	})
+	require.NoError(t, runErr, "VALID must exit zero")
+	rr.assertNoViolations(t)
+
+	requireSingleJSONDocument(t, stdout)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	require.Equal(t, statusValid, result["status"])
+	require.NotContains(t, stdout, "service built")
+	require.NotContains(t, stdout, "product-tier?serviceId=", "no release URL in dry-run output")
+}
+
+// TestDryRunTargetInvalidReturnsNonZero — 02: "INVALID".
+func TestDryRunTargetInvalidReturnsNonZero(t *testing.T) {
+	rr := startValidationOnlyServer(t, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		writeJSON(w, validationResult(statusInvalid, nil))
+	})
+
+	opts := targetDryRunOptions(t)
+
+	var runErr error
+	stdout := captureStdout(t, func() {
+		runErr = runBuildWithOptions(context.Background(), opts, staticToken())
+	})
+	require.Error(t, runErr, "INVALID must return a nonzero error")
+	rr.assertNoViolations(t)
+
+	requireSingleJSONDocument(t, stdout)
+	require.Equal(t, 1, rr.countPath(pathValidateSpec))
+}
+
+// TestDryRunTargetIncompleteReturnsNonZero — 02: "INCOMPLETE". An INCOMPLETE
+// result with no requiredArtifacts must not trigger a second request.
+func TestDryRunTargetIncompleteReturnsNonZero(t *testing.T) {
+	rr := startValidationOnlyServer(t, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		writeJSON(w, validationResult(statusIncomplete, nil))
+	})
+
+	opts := targetDryRunOptions(t)
+
+	var runErr error
+	stdout := captureStdout(t, func() {
+		runErr = runBuildWithOptions(context.Background(), opts, staticToken())
+	})
+	require.Error(t, runErr, "INCOMPLETE must return a nonzero error")
+	rr.assertNoViolations(t)
+
+	requireSingleJSONDocument(t, stdout)
+	require.Equal(t, 1, rr.countPath(pathValidateSpec))
+}
+
+// ---------------------------------------------------------------------------
+// Flags and interaction
+// ---------------------------------------------------------------------------
+
+// TestDryRunTargetInteractiveDoesNotPromptForPromotion — 02: "--interactive with
+// input y (no promotion prompt or mutation)"; 04 step 9.
+func TestDryRunTargetInteractiveDoesNotPromptForPromotion(t *testing.T) {
+	rr := startValidationOnlyServer(t, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		writeJSON(w, validationResult(statusValid, nil))
+	})
+
+	stdinR, stdinW, err := os.Pipe()
+	require.NoError(t, err)
+	origStdin := os.Stdin
+	os.Stdin = stdinR
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		_ = stdinW.Close()
+		_ = stdinR.Close()
+	})
+	_, err = stdinW.WriteString("y\n")
+	require.NoError(t, err)
+
+	opts := targetDryRunOptions(t)
+	opts.output = "table"
+	opts.interactive = true
+
+	require.NoError(t, runBuildWithOptions(context.Background(), opts, staticToken()))
+	rr.assertNoViolations(t)
+
+	require.Equal(t, []string{"POST " + pathValidateSpec}, rr.sequence(),
+		"a dry run must not create an environment or promote even when the user answers y")
+}
+
+// TestDryRunTargetReleaseFlagsAreCandidateIntentOnly — 02: "release-description/
+// name flags"; 04 step 9 ("carried as candidate intent").
+func TestDryRunTargetReleaseFlagsAreCandidateIntentOnly(t *testing.T) {
+	rr := startValidationOnlyServer(t, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		writeJSON(w, validationResult(statusValid, nil))
+	})
+
+	opts := targetDryRunOptions(t)
+	opts.release = true
+	opts.releaseAsPreferred = true
+	opts.releaseDescription = "v1.0.0-alpha"
+	opts.releaseName = "legacy-name"
+	opts.forceCreateServicePlanVersion = true
+
+	require.NoError(t, runBuildWithOptions(context.Background(), opts, staticToken()))
+	rr.assertNoViolations(t)
+
+	require.Equal(t, []string{"POST " + pathValidateSpec}, rr.sequence(),
+		"release flags must not produce a release, version or promotion request")
+
+	body := rr.find(pathValidateSpec)[0].decodeBody(t)
+	require.Equal(t, true, body["release"])
+	require.Equal(t, true, body["releaseAsPreferred"])
+	require.Equal(t, "v1.0.0-alpha", body["releaseVersionName"])
+	require.Equal(t, true, body["forceCreateNewServicePlanVersion"])
+}
+
+// ---------------------------------------------------------------------------
+// Server-side failure modes
+// ---------------------------------------------------------------------------
+
+// TestDryRunTargetUnsupportedServerNeverFallsBackToLegacy — 02: "unsupported
+// server 404/405 ... never fall back to legacy build"; 04 §"Output and logging".
+func TestDryRunTargetUnsupportedServerNeverFallsBackToLegacy(t *testing.T) {
+	for _, status := range []int{http.StatusNotFound, http.StatusMethodNotAllowed} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			rr := startValidationOnlyServer(t, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+				writeAPIError(w, status, "not_supported", "unknown route")
+			})
+
+			opts := targetDryRunOptions(t)
+			err := runBuildWithOptions(context.Background(), opts, staticToken())
+			require.Error(t, err)
+			require.Contains(t, strings.ToLower(err.Error()), "upgrade",
+				"the error must tell the user the server needs an upgrade")
+
+			rr.assertNoViolations(t)
+			require.Equal(t, []string{"POST " + pathValidateSpec}, rr.sequence(),
+				"no legacy prepare/build/upload fallback is permitted")
+		})
+	}
+}
+
+// TestDryRunTargetUnauthorizedIsReportedFaithfully — 02: "401/403".
+func TestDryRunTargetUnauthorizedIsReportedFaithfully(t *testing.T) {
+	for _, status := range []int{http.StatusUnauthorized, http.StatusForbidden} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			rr := startValidationOnlyServer(t, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+				writeAPIError(w, status, "unauthorized", "not allowed")
+			})
+
+			opts := targetDryRunOptions(t)
+			err := runBuildWithOptions(context.Background(), opts, staticToken())
+			require.Error(t, err)
+			require.NotContains(t, strings.ToLower(err.Error()), "upgrade",
+				"auth errors must retain their real meaning")
+
+			rr.assertNoViolations(t)
+			require.Equal(t, 1, rr.countPath(pathValidateSpec))
+		})
+	}
+}
+
+// TestDryRunTargetTransportTimeoutFailsWithoutFallback — 02: "transport
+// timeout". Retries are disabled, so the request count is exact.
+func TestDryRunTargetTransportTimeoutFailsWithoutFallback(t *testing.T) {
+	t.Setenv("OMNISTRATE_CLIENT_TIMEOUT_IN_SECONDS", "1")
+	rr := startValidationOnlyServer(t, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		time.Sleep(3 * time.Second)
+		writeJSON(w, validationResult(statusValid, nil))
+	})
+	// startRecordingServer sets a 30s timeout; re-apply the short one.
+	t.Setenv("OMNISTRATE_CLIENT_TIMEOUT_IN_SECONDS", "1")
+
+	opts := targetDryRunOptions(t)
+	err := runBuildWithOptions(context.Background(), opts, staticToken())
+	require.Error(t, err)
+
+	rr.assertNoViolations(t)
+	require.Equal(t, 1, rr.countPath(pathValidateSpec), "no retry, no legacy fallback")
+}
+
+// ---------------------------------------------------------------------------
+// Local artifact failures
+// ---------------------------------------------------------------------------
+
+// TestDryRunTargetUnreadableLocalArtifactAborts — 02: "unreadable local
+// artifact"; 04 step 7 ("abort with a clear error; do not silently substitute").
+//
+// RECONCILED: the fixture now declares the local path, so the failure is
+// genuinely the unreadable directory rather than the allowlist refusing an
+// undeclared path.
+func TestDryRunTargetUnreadableLocalArtifactAborts(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: mode 0000 does not make a directory unreadable")
+	}
+
+	requirement := []map[string]any{{
+		"logicalPath": "terraform/network",
+		// RECONCILED: ValidationArtifactUse.path is a required field in the
+		// generated SDK, so a use without it fails to decode.
+		"uses": []map[string]any{{
+			"resourceKey": "network",
+			"kind":        "terraform",
+			"path":        "/services/0/terraformConfigurations/configurationPerCloudProvider/aws",
+		}},
+	}}
+
+	rr := startValidationOnlyServer(t, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		writeJSON(w, validationResult(statusIncomplete, requirement))
+	})
+
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "spec.yaml", servicePlanSpecWithLocalTerraform)
+	artifactDir := filepath.Join(dir, "terraform", "network")
+	require.NoError(t, os.MkdirAll(artifactDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(artifactDir, "main.tf"), []byte("x"), 0o600))
+	require.NoError(t, os.Chmod(artifactDir, 0o000))
+	t.Cleanup(func() { _ = os.Chmod(artifactDir, 0o755) })
+	t.Chdir(dir)
+
+	err := runBuildWithOptions(context.Background(),
+		jsonDryRunOptions(specPath, ServicePlanSpecType), staticToken())
+	require.Error(t, err, "an unreadable artifact must abort the dry run")
+
+	rr.assertNoViolations(t)
+	require.Equal(t, 1, rr.countPath(pathValidateSpec),
+		"the second request must not be sent with substituted content")
+}
+
+// TestDryRunTargetMalformedArchiveIsRejected — 02: "malformed archive". A
+// pre-existing .tar.gz that is not a valid gzip stream must fail explicitly and
+// must not be followed by any mutating request.
+//
+// RECONCILED twice: the fixture now declares the archive as its local Helm
+// source, and the client detects the corrupt gzip stream itself, so the second
+// request is never sent at all. The original expected the server to reject it.
+func TestDryRunTargetMalformedArchiveIsRejected(t *testing.T) {
+	requirement := []map[string]any{{
+		"logicalPath": "artifacts/bundle.tar.gz",
+		"uses": []map[string]any{{
+			"resourceKey": "chart",
+			"kind":        "helm",
+			"path":        "/services/0/helmChartConfiguration",
+		}},
+	}}
+
+	rr := startValidationOnlyServer(t, func(call int, _ recordedRequest, w http.ResponseWriter) {
+		if call == 0 {
+			writeJSON(w, validationResult(statusIncomplete, requirement))
+			return
+		}
+		writeAPIError(w, http.StatusBadRequest, "invalid_archive", "archive is not a valid gzip stream")
+	})
+
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "spec.yaml", servicePlanSpecWithLocalArchive)
+	writeFixture(t, dir, "artifacts/bundle.tar.gz", "this is not gzip content at all")
+	t.Chdir(dir)
+
+	err := runBuildWithOptions(context.Background(),
+		jsonDryRunOptions(specPath, ServicePlanSpecType), staticToken())
+	require.Error(t, err, "a malformed archive must fail the dry run")
+	require.Contains(t, err.Error(), "not a valid gzip archive")
+
+	rr.assertNoViolations(t)
+	require.LessOrEqual(t, rr.countPath(pathValidateSpec), 2)
+	require.Equal(t, 1, rr.countPath(pathValidateSpec),
+		"a corrupt archive is detected locally, so the second request is never sent")
+}

--- a/cmd/build/dry_run_test.go
+++ b/cmd/build/dry_run_test.go
@@ -1,0 +1,2068 @@
+package build
+
+// Regression evidence for specification 02 — "Regression tests for the read-only
+// contract" (dry-run-implementation-specs/02-regression-tests.md).
+//
+// HISTORY. This file was originally written against the unfixed tree and every
+// test asserted what `build --dry-run` did TODAY, including its defects. Spec 04
+// has now landed, so the tests that pinned a defect would otherwise pin a
+// behaviour that no longer exists. Each of those has been converted to assert
+// the NEW contract; the comment on each one records the defect it used to
+// reproduce, so the historical evidence is not lost. The tests that pinned
+// behaviour which is still correct (RenderFile's temp-file handling, the
+// "exactly one JSON document" property) are unchanged in substance.
+//
+// The target contract lives in dry_run_target_test.go, which no longer carries a
+// build tag: those cases now run by default.
+//
+// Rules honoured here:
+//   - zero real network calls: every request goes to a local httptest.Server;
+//   - no require.FailNow inside an HTTP handler goroutine: handlers record a
+//     violation string and answer with an error, and the main test goroutine
+//     asserts on the recording;
+//   - retries are disabled through OMNISTRATE_RETRY_MAX so request counts are
+//     deterministic;
+//   - HOME is redirected at a temp dir so no test can read or write the
+//     developer's real ~/.omnistrate credentials.
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mitchellh/go-homedir"
+	openapiclient "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	// fakeToken is never a real credential; it only has to survive the
+	// Authorization header round trip.
+	fakeToken = "dry-run-test-token" //nolint:gosec // G101: fixed fake token used only by the local test server
+
+	testServiceID     = "s-dryrun"
+	testEnvironmentID = "se-dryrun"
+	testProductTierID = "pt-dryrun"
+	testServiceName   = "Dry Run Regression Service"
+)
+
+// Wire paths exercised by the build route. Kept as constants so the target
+// contract tests can forbid them by name.
+const (
+	pathPrepareServicePlanSpec = "/2022-09-01-00/service/serviceplanspec/prepare"
+	pathBuildServicePlanSpec   = "/2022-09-01-00/service/serviceplanspec"
+	pathBuildComposeSpec       = "/2022-09-01-00/service/composespec"
+	pathDeploymentArtifact     = "/2022-09-01-00/deployment-artifact"
+	pathComposeGenImage        = "/2022-09-01-00/compose-gen/image"
+
+	// pathValidateSpec is the read-only validation endpoint specified in
+	// 03-backend-validation.md. It does not exist yet.
+	pathValidateSpec = "/2022-09-01-00/service/spec/validate"
+)
+
+// recordedRequest is one HTTP request observed by the test server.
+type recordedRequest struct {
+	Method   string
+	Path     string
+	RawQuery string
+	Auth     string
+	Body     []byte
+}
+
+func (r recordedRequest) String() string {
+	if r.RawQuery == "" {
+		return r.Method + " " + r.Path
+	}
+	return r.Method + " " + r.Path + "?" + r.RawQuery
+}
+
+// decodeBody decodes a recorded JSON request body. It returns nil for requests
+// without a body.
+func (r recordedRequest) decodeBody(t *testing.T) map[string]any {
+	t.Helper()
+	if len(bytes.TrimSpace(r.Body)) == 0 {
+		return nil
+	}
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(r.Body, &out), "request %s body is not a JSON object: %s", r, string(r.Body))
+	return out
+}
+
+// routeFunc answers a recorded request. It returns false when it does not know
+// the route, in which case the recorder reports an unrouted request.
+type routeFunc func(rec recordedRequest, w http.ResponseWriter) bool
+
+// requestRecorder is the local test server. It records every request and never
+// calls t.Fatal/require.FailNow from the handler goroutine; contract breaches
+// are appended to violations and asserted by the main goroutine instead.
+type requestRecorder struct {
+	server *httptest.Server
+
+	mu         sync.Mutex
+	requests   []recordedRequest
+	violations []string
+
+	// route answers known endpoints.
+	route routeFunc
+	// forbid classifies a request as a contract violation. An empty string
+	// means the request is allowed.
+	forbid func(rec recordedRequest) string
+}
+
+func (rr *requestRecorder) handler(w http.ResponseWriter, req *http.Request) {
+	body, readErr := io.ReadAll(req.Body)
+	rec := recordedRequest{
+		Method:   req.Method,
+		Path:     req.URL.Path,
+		RawQuery: req.URL.RawQuery,
+		Auth:     req.Header.Get("Authorization"),
+		Body:     body,
+	}
+
+	rr.mu.Lock()
+	rr.requests = append(rr.requests, rec)
+	if readErr != nil {
+		rr.violations = append(rr.violations, fmt.Sprintf("failed to read body of %s: %v", rec, readErr))
+	}
+	forbid := rr.forbid
+	route := rr.route
+	rr.mu.Unlock()
+
+	if forbid != nil {
+		if reason := forbid(rec); reason != "" {
+			rr.recordViolation(reason)
+			writeAPIError(w, http.StatusInternalServerError, "forbidden_by_test", reason)
+			return
+		}
+	}
+
+	if route != nil && route(rec, w) {
+		return
+	}
+
+	rr.recordViolation(fmt.Sprintf("unrouted request %s", rec))
+	writeAPIError(w, http.StatusNotFound, "not_routed_by_test", "no test route for "+rec.String())
+}
+
+func (rr *requestRecorder) recordViolation(reason string) {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+	rr.violations = append(rr.violations, reason)
+}
+
+// recorded returns the observed requests in order.
+func (rr *requestRecorder) recorded() []recordedRequest {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+	out := make([]recordedRequest, len(rr.requests))
+	copy(out, rr.requests)
+	return out
+}
+
+// sequence renders the recorded requests as "METHOD /path" strings. This is the
+// primary evidence produced by these tests.
+func (rr *requestRecorder) sequence() []string {
+	recs := rr.recorded()
+	out := make([]string, 0, len(recs))
+	for _, rec := range recs {
+		out = append(out, rec.Method+" "+rec.Path)
+	}
+	return out
+}
+
+// find returns the recorded requests for a path, in order.
+func (rr *requestRecorder) find(path string) []recordedRequest {
+	var out []recordedRequest
+	for _, rec := range rr.recorded() {
+		if rec.Path == path {
+			out = append(out, rec)
+		}
+	}
+	return out
+}
+
+func (rr *requestRecorder) countPath(path string) int {
+	n := 0
+	for _, rec := range rr.recorded() {
+		if rec.Path == path {
+			n++
+		}
+	}
+	return n
+}
+
+// assertNoViolations runs on the main test goroutine.
+func (rr *requestRecorder) assertNoViolations(t *testing.T) {
+	t.Helper()
+	rr.mu.Lock()
+	violations := append([]string(nil), rr.violations...)
+	rr.mu.Unlock()
+	require.Emptyf(t, violations, "test server recorded contract violations: %s\nrequest sequence: %s",
+		strings.Join(violations, "; "), strings.Join(rr.sequence(), " | "))
+}
+
+func (rr *requestRecorder) setRoute(route routeFunc) {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+	rr.route = route
+}
+
+func (rr *requestRecorder) setForbid(forbid func(rec recordedRequest) string) {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+	rr.forbid = forbid
+}
+
+// startRecordingServer starts the local server and points the CTL SDK clients at
+// it. Retries are disabled so that request counts are exact, and HOME is moved
+// to a temp directory so that config.GetToken() cannot pick up (or disturb) the
+// developer's real credentials.
+func startRecordingServer(t *testing.T) *requestRecorder {
+	t.Helper()
+
+	rr := &requestRecorder{}
+	rr.server = httptest.NewServer(http.HandlerFunc(rr.handler))
+	t.Cleanup(rr.server.Close)
+
+	serverURL, err := url.Parse(rr.server.URL)
+	require.NoError(t, err)
+
+	t.Setenv("OMNISTRATE_HOST", serverURL.Host)
+	t.Setenv("OMNISTRATE_HOST_SCHEME", serverURL.Scheme)
+	// Deterministic request counts: no retries, no backoff sleeps.
+	t.Setenv("OMNISTRATE_RETRY_MAX", "0")
+	t.Setenv("OMNISTRATE_RETRY_WAIT_MIN_IN_SECONDS", "0")
+	t.Setenv("OMNISTRATE_RETRY_WAIT_MAX_IN_SECONDS", "0")
+	t.Setenv("OMNISTRATE_CLIENT_TIMEOUT_IN_SECONDS", "30")
+
+	// utils.PrintError calls os.Exit(1) unless config.IsDryRun() is true. That
+	// env flag is the process-global OMNISTRATE_DRY_RUN setting, which is
+	// distinct from the customer's --dry-run flag and, in this codebase, is read
+	// by nothing except PrintError. Setting it here only stops the test binary
+	// from being killed mid-assertion; it does not change the build route.
+	t.Setenv("OMNISTRATE_DRY_RUN", "true")
+
+	// go-homedir caches the resolved home directory; disable the cache so the
+	// redirected HOME below is honoured for every lookup in the process.
+	homedir.DisableCache = true
+	fakeHome := t.TempDir()
+	t.Setenv("HOME", fakeHome)
+	t.Setenv("USERPROFILE", fakeHome)
+
+	return rr
+}
+
+// disablePrintErrorExit stops utils.PrintError from killing the test binary.
+// See the note in startRecordingServer.
+func disablePrintErrorExit(t *testing.T) {
+	t.Helper()
+	t.Setenv("OMNISTRATE_DRY_RUN", "true")
+}
+
+// writeAPIError emits the SDK's Error shape so handleV1Error surfaces the
+// message rather than a decoding failure.
+func writeAPIError(w http.ResponseWriter, status int, name, message string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"id":        "test-error",
+		"name":      name,
+		"message":   message,
+		"fault":     false,
+		"temporary": false,
+		"timeout":   false,
+	})
+}
+
+// writeJSON answers 200 with a JSON body.
+func writeJSON(w http.ResponseWriter, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_ = json.NewEncoder(w).Encode(payload)
+}
+
+// ---------------------------------------------------------------------------
+// Canned validation responses
+// ---------------------------------------------------------------------------
+
+// validationStatus values from 03-backend-validation.md.
+const (
+	statusValid      = "VALID"
+	statusInvalid    = "INVALID"
+	statusIncomplete = "INCOMPLETE"
+)
+
+// validationResult builds a 03-shaped result payload.
+func validationResult(status string, requiredArtifacts []map[string]any) map[string]any {
+	if requiredArtifacts == nil {
+		requiredArtifacts = []map[string]any{}
+	}
+	diagnostics := []map[string]any{}
+	if status == statusInvalid {
+		diagnostics = append(diagnostics, map[string]any{
+			"code":     "SPEC_SEMANTICS_INVALID",
+			"severity": "error",
+			"path":     "/services/0",
+			"message":  "resource has no deployment configuration",
+		})
+	}
+	if status == statusIncomplete && len(requiredArtifacts) == 0 {
+		diagnostics = append(diagnostics, map[string]any{
+			"code":     "DEPENDENCY_UNAVAILABLE",
+			"severity": "incomplete",
+			"path":     "/services/0",
+			"message":  "a required dependency could not be read",
+		})
+	}
+	if status == statusIncomplete && len(requiredArtifacts) > 0 {
+		diagnostics = append(diagnostics, map[string]any{
+			"code":     "ARTIFACT_CONTENT_REQUIRED",
+			"severity": "incomplete",
+			"path":     "/services/0",
+			"message":  "Local artifact content is required for validation.",
+		})
+	}
+	return map[string]any{
+		"status":            status,
+		"validationVersion": "1",
+		"inputDigest":       "0000000000000000000000000000000000000000000000000000000000000000",
+		"checks": []map[string]any{
+			{"name": "syntax", "status": "PASSED"},
+			{"name": "artifact-content", "status": "PASSED"},
+		},
+		"diagnostics":        diagnostics,
+		"requiredArtifacts":  requiredArtifacts,
+		"validatedArtifacts": []map[string]any{},
+	}
+}
+
+// validationResultAcknowledging answers the second request with a result that
+// acknowledges every supplied artifact, echoing its digest and size and listing
+// the uses that made it required — the shape 04 step 8 tells the client to
+// check.
+//
+// It runs on the HTTP handler goroutine, so it never touches *testing.T: a
+// malformed request simply produces an unacknowledged result, which the client
+// then rejects on the main goroutine.
+func validationResultAcknowledging(status string, rec recordedRequest, requirements []map[string]any) map[string]any {
+	result := validationResult(status, nil)
+
+	usesByPath := map[string]any{}
+	for _, requirement := range requirements {
+		if logicalPath, ok := requirement["logicalPath"].(string); ok {
+			usesByPath[logicalPath] = requirement["uses"]
+		}
+	}
+
+	var request struct {
+		Artifacts []struct {
+			LogicalPath         string `json:"logicalPath"`
+			Sha256              string `json:"sha256"`
+			CompressedSizeBytes int64  `json:"compressedSizeBytes"`
+		} `json:"artifacts"`
+	}
+	if err := json.Unmarshal(rec.Body, &request); err != nil {
+		return result
+	}
+
+	validated := make([]map[string]any, 0, len(request.Artifacts))
+	for _, artifact := range request.Artifacts {
+		uses := usesByPath[artifact.LogicalPath]
+		if uses == nil {
+			uses = []map[string]any{}
+		}
+		validated = append(validated, map[string]any{
+			"logicalPath":         artifact.LogicalPath,
+			"sha256":              artifact.Sha256,
+			"compressedSizeBytes": artifact.CompressedSizeBytes,
+			"uses":                uses,
+		})
+	}
+	result["validatedArtifacts"] = validated
+	return result
+}
+
+// firstArtifact returns the single artifact object from a validation request
+// body.
+func firstArtifact(t *testing.T, body map[string]any) map[string]any {
+	t.Helper()
+	artifacts, ok := body["artifacts"].([]any)
+	require.True(t, ok, "request body carries no artifacts: %v", body)
+	require.Len(t, artifacts, 1)
+	artifact, ok := artifacts[0].(map[string]any)
+	require.True(t, ok)
+	return artifact
+}
+
+// decodeArchive base64-decodes an artifact's archiveContent and checks the
+// declared digest and size against the decoded bytes, exactly as the server
+// would.
+func decodeArchive(t *testing.T, artifact map[string]any) []byte {
+	t.Helper()
+	encoded, ok := artifact["archiveContent"].(string)
+	require.True(t, ok, "artifact has no archiveContent: %v", artifact)
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+
+	sum := sha256.Sum256(raw)
+	require.Equal(t, hex.EncodeToString(sum[:]), artifact["sha256"],
+		"sha256 must hash the decoded compressed bytes")
+	require.Equal(t, float64(len(raw)), artifact["compressedSizeBytes"],
+		"compressedSizeBytes must count the decoded compressed bytes")
+	require.Equal(t, "tar+gzip+base64", artifact["encoding"])
+	return raw
+}
+
+// tarEntryNames lists the member names of a gzip-compressed tar archive.
+func tarEntryNames(t *testing.T, archive []byte) []string {
+	t.Helper()
+	gzReader, err := gzip.NewReader(bytes.NewReader(archive))
+	require.NoError(t, err)
+	defer gzReader.Close()
+
+	var names []string
+	tarReader := tar.NewReader(gzReader)
+	for {
+		header, readErr := tarReader.Next()
+		if readErr == io.EOF {
+			break
+		}
+		require.NoError(t, readErr)
+		names = append(names, header.Name)
+	}
+	return names
+}
+
+// ---------------------------------------------------------------------------
+// Canned legacy responses
+// ---------------------------------------------------------------------------
+
+func prepareResult(tasks []map[string]string) map[string]any {
+	if tasks == nil {
+		tasks = []map[string]string{}
+	}
+	return map[string]any{
+		"serviceID":               testServiceID,
+		"serviceEnvironmentID":    testEnvironmentID,
+		"productTierID":           testProductTierID,
+		"isNewProductTierCreated": false,
+		"artifactUploadingTasks":  tasks,
+	}
+}
+
+func buildResult() map[string]any {
+	return map[string]any{
+		"serviceID":                      testServiceID,
+		"serviceEnvironmentID":           testEnvironmentID,
+		"productTierID":                  testProductTierID,
+		"isNewServicePlanVersionCreated": false,
+		"undefinedResources":             map[string]string{},
+	}
+}
+
+func productTierResult() map[string]any {
+	return map[string]any{
+		"id":                       testProductTierID,
+		"key":                      "dry-run-plan",
+		"name":                     "Dry Run Plan",
+		"description":              "plan description",
+		"planDescription":          "plan description",
+		"documentation":            "docs",
+		"enableDeletionProtection": false,
+		"isDisabled":               false,
+		"pricing":                  map[string]any{},
+		"serviceId":                testServiceID,
+		"serviceModelId":           "sm-dryrun",
+		"support":                  "support",
+		"tierType":                 "OMNISTRATE_HOSTED",
+	}
+}
+
+func environmentResult(id, envType string, saasPortalReady bool) map[string]any {
+	out := map[string]any{
+		"id":                 id,
+		"key":                strings.ToLower(envType),
+		"name":               envType,
+		"description":        envType + " environment",
+		"deploymentConfigId": "dc-default",
+		"serviceId":          testServiceID,
+		"type":               envType,
+		"visibility":         "PUBLIC",
+	}
+	if saasPortalReady {
+		out["saasPortalUrl"] = "saas.example.invalid"
+		out["saasPortalStatus"] = "RUNNING"
+	}
+	return out
+}
+
+// legacyRoutes answers every endpoint the current build route can reach.
+// Handlers must not fail the test directly; they only serve canned data.
+func legacyRoutes(prepareTasks []map[string]string) routeFunc {
+	return func(rec recordedRequest, w http.ResponseWriter) bool {
+		switch {
+		case rec.Method == http.MethodPut && rec.Path == pathPrepareServicePlanSpec:
+			writeJSON(w, prepareResult(prepareTasks))
+		case rec.Method == http.MethodPut && rec.Path == pathBuildServicePlanSpec:
+			writeJSON(w, buildResult())
+		case rec.Method == http.MethodPut && rec.Path == pathBuildComposeSpec:
+			writeJSON(w, buildResult())
+		case rec.Method == http.MethodPost && rec.Path == pathDeploymentArtifact:
+			writeJSON(w, "artifact-1")
+		case rec.Method == http.MethodGet && strings.HasPrefix(rec.Path, pathDeploymentArtifact+"/"):
+			writeJSON(w, map[string]any{"id": "artifact-1", "status": "READY"})
+		case rec.Method == http.MethodGet && rec.Path == "/2022-09-01-00/service/"+testServiceID+"/product-tier/"+testProductTierID:
+			writeJSON(w, productTierResult())
+		case rec.Method == http.MethodGet && rec.Path == "/2022-09-01-00/accountconfig":
+			writeJSON(w, map[string]any{"accountConfigs": []any{}})
+		case rec.Method == http.MethodGet && rec.Path == "/2022-09-01-00/service/"+testServiceID+"/environment":
+			writeJSON(w, map[string]any{"ids": []string{testEnvironmentID}})
+		case rec.Method == http.MethodGet && rec.Path == "/2022-09-01-00/service/"+testServiceID+"/environment/"+testEnvironmentID:
+			writeJSON(w, environmentResult(testEnvironmentID, "DEV", true))
+		case rec.Method == http.MethodGet && strings.HasPrefix(rec.Path, "/2022-09-01-00/service/"+testServiceID+"/environment/"):
+			id := strings.TrimPrefix(rec.Path, "/2022-09-01-00/service/"+testServiceID+"/environment/")
+			writeJSON(w, environmentResult(id, "PROD", true))
+		case rec.Method == http.MethodPost && rec.Path == "/2022-09-01-00/service/"+testServiceID+"/environment":
+			writeJSON(w, "se-prod-created")
+		case rec.Method == http.MethodPost && strings.HasSuffix(rec.Path, "/promote"):
+			writeJSON(w, map[string]any{})
+		case rec.Method == http.MethodGet && rec.Path == "/2022-09-01-00/deployment-config/default":
+			writeJSON(w, map[string]any{
+				"id":                     "dc-default",
+				"name":                   "default",
+				"description":            "default",
+				"infraRollConfiguration": map[string]any{},
+				"rolloutPriorityList":    []any{},
+			})
+		case rec.Method == http.MethodGet && rec.Path == pathComposeGenImage:
+			writeJSON(w, map[string]any{"imageAccessible": true})
+		case rec.Method == http.MethodPost && rec.Path == pathComposeGenImage:
+			writeJSON(w, map[string]any{
+				"fileContent": base64.StdEncoding.EncodeToString([]byte(minimalComposeSpec)),
+			})
+		default:
+			return false
+		}
+		return true
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const minimalComposeSpec = `services:
+  api:
+    image: docker.io/library/nginx:1.27
+`
+
+const minimalServicePlanSpec = `version: "1.0"
+name: Dry Run Plan
+deployment:
+  hostedDeployment:
+    awsAccountId: "000000000000"
+services:
+  - name: network
+    terraformConfigurations:
+      configurationPerCloudProvider:
+        aws:
+          terraformPath: /terraform/network
+`
+
+// servicePlanSpecWithLocalTerraform declares an explicit local Terraform source.
+// The path it names is the only path a validation response is allowed to ask
+// for; see collectDeclaredArtifactPaths.
+const servicePlanSpecWithLocalTerraform = `version: "1.0"
+name: Dry Run Plan
+deployment:
+  hostedDeployment:
+    awsAccountId: "000000000000"
+services:
+  - name: network
+    terraformConfigurations:
+      configurationPerCloudProvider:
+        aws:
+          terraformPath: /terraform/network
+          artifactsLocalPath: ./terraform/network
+`
+
+// servicePlanSpecWithLocalArchive declares a pre-built archive as its local
+// Helm source, exercising the "existing .tgz is not rewrapped" branch.
+const servicePlanSpecWithLocalArchive = `version: "1.0"
+name: Dry Run Plan
+deployment:
+  hostedDeployment:
+    awsAccountId: "000000000000"
+services:
+  - name: chart
+    helmChartConfiguration:
+      chartName: demo
+      chartVersion: "1.0.0"
+      artifactsLocalPath: ./artifacts/bundle.tar.gz
+`
+
+// writeFixture writes content into dir/name, creating parent directories.
+func writeFixture(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	full := filepath.Join(dir, name)
+	require.NoError(t, os.MkdirAll(filepath.Dir(full), 0o755))
+	require.NoError(t, os.WriteFile(full, []byte(content), 0o600))
+	return full
+}
+
+// treeSnapshot maps every regular file under root to its sha256. It is used to
+// prove that preprocessing does not modify or add source files.
+func treeSnapshot(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	require.NoError(t, filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() || !info.Mode().IsRegular() {
+			return nil
+		}
+		data, readErr := os.ReadFile(path) //nolint:gosec // test-owned temp tree
+		if readErr != nil {
+			return readErr
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		sum := sha256.Sum256(data)
+		out[rel] = hex.EncodeToString(sum[:])
+		return nil
+	}))
+	return out
+}
+
+// execShim installs stub executables on PATH so the test can prove that the
+// dry-run route runs no Docker build/push and no Git command. Each invocation is
+// appended to a log file. names maps a binary name to the shell body it runs
+// after logging; an empty body just exits 0.
+func execShim(t *testing.T, names map[string]string) (logPath string) {
+	t.Helper()
+	shimDir := t.TempDir()
+	logPath = filepath.Join(shimDir, "invocations.log")
+	require.NoError(t, os.WriteFile(logPath, nil, 0o600))
+
+	for name, body := range names {
+		// The shim runs with PATH restricted to shimDir, so give the script
+		// itself a usable PATH for the helpers it needs.
+		script := "#!/bin/sh\n" +
+			"PATH=/usr/bin:/bin:/usr/sbin:/sbin\n" +
+			"export PATH\n" +
+			"printf '%s %s\\n' " + name + " \"$*\" >> " + logPath + "\n" +
+			body + "\n"
+		require.NoError(t, os.WriteFile(filepath.Join(shimDir, name), []byte(script), 0o700)) //nolint:gosec // test shim must be executable
+	}
+
+	// PATH contains only the shim directory: any unexpected subprocess fails
+	// loudly instead of silently reaching a real binary.
+	t.Setenv("PATH", shimDir)
+	return logPath
+}
+
+func shimInvocations(t *testing.T, logPath string) []string {
+	t.Helper()
+	data, err := os.ReadFile(logPath) //nolint:gosec // test-owned temp file
+	require.NoError(t, err)
+	var out []string
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) != "" {
+			out = append(out, line)
+		}
+	}
+	return out
+}
+
+// captureStdout redirects os.Stdout for the duration of fn.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	orig := os.Stdout
+	os.Stdout = w
+
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, r)
+		done <- buf.String()
+	}()
+
+	fn()
+
+	os.Stdout = orig
+	require.NoError(t, w.Close())
+	out := <-done
+	require.NoError(t, r.Close())
+	return out
+}
+
+// jsonDryRunOptions returns the options for `build --dry-run -o json`.
+func jsonDryRunOptions(file, specType string) buildOptions {
+	return buildOptions{
+		file:            file,
+		specType:        specType,
+		name:            testServiceName,
+		environment:     "Dev",
+		environmentType: "dev",
+		output:          "json",
+		dryRun:          true,
+	}
+}
+
+func staticToken() tokenProvider {
+	return func() (string, error) { return fakeToken, nil }
+}
+
+// ---------------------------------------------------------------------------
+// Shared validation-endpoint server
+// ---------------------------------------------------------------------------
+
+// startValidationServerAllowing starts a recorder that treats every request as a
+// contract violation except POST /service/spec/validate and whatever extraAllow
+// permits. It is the single implementation behind both this file's converted
+// reproductions and dry_run_target_test.go's startValidationOnlyServer.
+func startValidationServerAllowing(
+	t *testing.T,
+	extraAllow func(rec recordedRequest) bool,
+	respond func(call int, rec recordedRequest, w http.ResponseWriter),
+) *requestRecorder {
+	t.Helper()
+
+	rr := startRecordingServer(t)
+	rr.setForbid(func(rec recordedRequest) string {
+		if rec.Method == http.MethodPost && rec.Path == pathValidateSpec {
+			return ""
+		}
+		if extraAllow != nil && extraAllow(rec) {
+			return ""
+		}
+		return "read-only validation must not issue " + rec.String()
+	})
+
+	base := legacyRoutes(nil)
+	calls := 0
+	rr.setRoute(func(rec recordedRequest, w http.ResponseWriter) bool {
+		if rec.Method == http.MethodPost && rec.Path == pathValidateSpec {
+			n := calls
+			calls++
+			respond(n, rec, w)
+			return true
+		}
+		if extraAllow != nil && extraAllow(rec) {
+			return base(rec, w)
+		}
+		return false
+	})
+	return rr
+}
+
+// allowComposeGenReads permits the two read-only compose-generation calls the
+// --image branch makes before there is any specification to validate.
+//
+// Both are reads: ows-orchestration's ComposeGen.GenerateComposeSpecFromContainerImage
+// checks access, reads container image metadata and marshals an in-memory
+// compose project. It performs no database write, starts no workflow and pushes
+// no image.
+func allowComposeGenReads(rec recordedRequest) bool {
+	return rec.Path == pathComposeGenImage
+}
+
+// ---------------------------------------------------------------------------
+// ServicePlanSpec dry run
+// ---------------------------------------------------------------------------
+
+// TestBuildDryRunServicePlanSpecNeverIssuesPrepare records the request sequence
+// for `build --spec-type ServicePlanSpec --dry-run`.
+//
+// CONVERTED. This test used to be named
+// TestBuildDryRunServicePlanSpecIssuesPrepareBeforeValidation and asserted the
+// defect from the investigation ("Preparation can create real objects before
+// dry-run validation"): FindOrCreateServiceHierarchy issued the mutating
+// PUT .../serviceplanspec/prepare before any validation happened, and that
+// prepare request carried no dry-run field, so the backend could not know the
+// caller only wanted validation. The dry-run branch now returns before
+// FindOrCreateServiceHierarchy, so the test asserts the absence of that request
+// instead of its presence.
+func TestBuildDryRunServicePlanSpecNeverIssuesPrepare(t *testing.T) {
+	rr := startValidationServerAllowing(t, nil, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		writeJSON(w, validationResult(statusValid, nil))
+	})
+
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "spec.yaml", minimalServicePlanSpec)
+	t.Chdir(dir)
+
+	err := runBuildWithOptions(context.Background(),
+		jsonDryRunOptions(specPath, ServicePlanSpecType), staticToken())
+	require.NoError(t, err)
+	rr.assertNoViolations(t)
+
+	require.Equal(t, []string{
+		"POST " + pathValidateSpec,
+	}, rr.sequence(), "recorded request sequence for build --dry-run (ServicePlanSpec)")
+	t.Logf("ServicePlanSpec dry-run request sequence: %s", strings.Join(rr.sequence(), " | "))
+
+	require.Zero(t, rr.countPath(pathPrepareServicePlanSpec), "no prepare request")
+	require.Zero(t, rr.countPath(pathBuildServicePlanSpec), "no build request")
+	require.Zero(t, rr.countPath(pathDeploymentArtifact), "no artifact publication")
+
+	validations := rr.find(pathValidateSpec)
+	require.Len(t, validations, 1)
+	require.Equal(t, "Bearer "+fakeToken, validations[0].Auth)
+
+	body := validations[0].decodeBody(t)
+	require.Equal(t, base64.StdEncoding.EncodeToString([]byte(minimalServicePlanSpec)), body["fileContent"])
+	for key := range body {
+		require.NotContains(t, strings.ToLower(key), "dry",
+			"the validation envelope has no dry-run flag: %v", body)
+	}
+}
+
+// TestBuildDryRunServicePlanSpecValidatesLocalArtifactsWithoutUpload is the
+// converted form of TestBuildDryRunServicePlanSpecSkipsUploadButStillPrepares,
+// which recorded the asymmetry the investigation found: artifact upload was
+// guarded by dryRun, but the prepare call that produced the upload tasks was
+// not, so local artifact content was never validated at all. Local content is
+// now validated through the request-scoped transport, with no upload.
+func TestBuildDryRunServicePlanSpecValidatesLocalArtifactsWithoutUpload(t *testing.T) {
+	requirement := []map[string]any{{
+		"logicalPath": "terraform/network",
+		"uses": []map[string]any{{
+			"resourceKey": "network",
+			"kind":        "terraform",
+			"provider":    "aws",
+			"path":        "/services/0/terraformConfigurations/configurationPerCloudProvider/aws",
+		}},
+	}}
+
+	rr := startValidationServerAllowing(t, nil, func(call int, rec recordedRequest, w http.ResponseWriter) {
+		if call == 0 {
+			writeJSON(w, validationResult(statusIncomplete, requirement))
+			return
+		}
+		writeJSON(w, validationResultAcknowledging(statusValid, rec, requirement))
+	})
+
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "spec.yaml", servicePlanSpecWithLocalTerraform)
+	writeFixture(t, dir, "terraform/network/main.tf", "resource \"null_resource\" \"n\" {}\n")
+	t.Chdir(dir)
+
+	err := runBuildWithOptions(context.Background(),
+		jsonDryRunOptions(specPath, ServicePlanSpecType), staticToken())
+	require.NoError(t, err)
+	rr.assertNoViolations(t)
+
+	require.Equal(t, []string{
+		"POST " + pathValidateSpec,
+		"POST " + pathValidateSpec,
+	}, rr.sequence(), "recorded request sequence for build --dry-run with local artifacts")
+	t.Logf("ServicePlanSpec dry-run with artifacts request sequence: %s", strings.Join(rr.sequence(), " | "))
+
+	require.Zero(t, rr.countPath(pathPrepareServicePlanSpec), "no prepare request")
+	require.Zero(t, rr.countPath(pathDeploymentArtifact), "no artifact upload")
+
+	// The archive really carries the local file.
+	artifact := firstArtifact(t, rr.find(pathValidateSpec)[1].decodeBody(t))
+	names := tarEntryNames(t, decodeArchive(t, artifact))
+	require.Contains(t, names, "main.tf")
+}
+
+// ---------------------------------------------------------------------------
+// Compose dry run
+// ---------------------------------------------------------------------------
+
+// TestBuildDryRunComposeSpecUsesValidationEndpoint is the converted form of
+// TestBuildDryRunComposeSpecUsesNormalBuildEndpoint, which recorded that the
+// Compose dry run went to the normal build endpoint with dryrun=true, i.e. into
+// the mutating import workflow.
+func TestBuildDryRunComposeSpecUsesValidationEndpoint(t *testing.T) {
+	rr := startValidationServerAllowing(t, nil, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		writeJSON(w, validationResult(statusValid, nil))
+	})
+
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "omnistrate-compose.yaml", minimalComposeSpec)
+	t.Chdir(dir)
+
+	err := runBuildWithOptions(context.Background(),
+		jsonDryRunOptions(specPath, DockerComposeSpecType), staticToken())
+	require.NoError(t, err)
+	rr.assertNoViolations(t)
+
+	require.Equal(t, []string{
+		"POST " + pathValidateSpec,
+	}, rr.sequence(), "recorded request sequence for build --dry-run (Compose)")
+	t.Logf("Compose dry-run request sequence: %s", strings.Join(rr.sequence(), " | "))
+
+	require.Zero(t, rr.countPath(pathBuildComposeSpec), "no build request")
+	require.Zero(t, rr.countPath(pathPrepareServicePlanSpec))
+
+	body := rr.find(pathValidateSpec)[0].decodeBody(t)
+	require.Equal(t, "compose", body["specType"])
+}
+
+// ---------------------------------------------------------------------------
+// Interactive mode
+// ---------------------------------------------------------------------------
+
+// TestBuildDryRunInteractiveNeverPromotes drives the full route with
+// --dry-run --interactive and makes "y" available on stdin.
+//
+// CONVERTED. This test used to be named TestBuildDryRunInteractivePromotionHasNoGuard
+// and asserted the defect from the investigation ("Interactive dry-run can
+// proceed to production actions"): the post-build prompts were not guarded by
+// dryRun, so answering "y" created a real production environment and promoted
+// into it. It now asserts that no prompt is reached and no environment or
+// promotion request is issued, per 04 §"CTL execution algorithm" step 9.
+func TestBuildDryRunInteractiveNeverPromotes(t *testing.T) {
+	rr := startValidationServerAllowing(t, nil, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		writeJSON(w, validationResult(statusValid, nil))
+	})
+
+	stdinR, stdinW, err := os.Pipe()
+	require.NoError(t, err)
+	origStdin := os.Stdin
+	os.Stdin = stdinR
+	t.Cleanup(func() {
+		os.Stdin = origStdin
+		_ = stdinW.Close()
+		_ = stdinR.Close()
+	})
+	// Make "y" available up front: if any prompt were still reached it would
+	// consume this and proceed, so the assertions below would fail loudly rather
+	// than deadlock.
+	_, err = stdinW.WriteString("y\ny\ny\n")
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "omnistrate-compose.yaml", minimalComposeSpec)
+	t.Chdir(dir)
+
+	opts := jsonDryRunOptions(specPath, DockerComposeSpecType)
+	opts.output = "table" // --interactive is rejected with json output
+	opts.interactive = true
+
+	runErr := runBuildWithOptions(context.Background(), opts, staticToken())
+	require.NoError(t, runErr)
+	rr.assertNoViolations(t)
+
+	sequence := strings.Join(rr.sequence(), " | ")
+	require.Equal(t, []string{"POST " + pathValidateSpec}, rr.sequence(),
+		"interactive dry run must issue only the validation request; sequence: %s", sequence)
+	require.NotContains(t, sequence, "/environment")
+	require.NotContains(t, sequence, "/promote")
+	t.Logf("interactive dry-run request sequence: %s", sequence)
+}
+
+// ---------------------------------------------------------------------------
+// RenderFile writes <basename>.tmp into the input root; the dry run does not
+// ---------------------------------------------------------------------------
+
+// TestBuildDryRunRenderFileOverwritesSpecTmpSentinel proves the preprocessing
+// defect described in 04 §"CTL execution algorithm" step 2: RenderFile writes
+// "<basename>.tmp" next to the user's spec for `docker compose config`.
+//
+// A sentinel file is placed at that path first. Both sub-cases show it being
+// destroyed, and the failure sub-case additionally shows the temporary file
+// being left behind in the user's source tree.
+//
+// UNCHANGED. RenderFile still behaves this way and is still what the real build
+// uses; the dry-run route no longer calls it. See
+// TestDryRunValidationLeavesTheSpecTmpSentinelAlone for the replacement path.
+func TestBuildDryRunRenderFileOverwritesSpecTmpSentinel(t *testing.T) {
+	const sentinel = "SENTINEL-DO-NOT-TOUCH\n"
+	const envFileSpec = `services:
+  api:
+    image: docker.io/library/nginx:1.27
+    env_file:
+      - ./api.env
+`
+
+	t.Run("DockerConfigSucceedsAndDeletesTheSentinelPath", func(t *testing.T) {
+		disablePrintErrorExit(t)
+		dir := t.TempDir()
+		specPath := writeFixture(t, dir, "omnistrate-compose.yaml", envFileSpec)
+		writeFixture(t, dir, "api.env", "KEY=value\n")
+		tmpPath := filepath.Join(dir, "omnistrate-compose.yaml.tmp")
+		require.NoError(t, os.WriteFile(tmpPath, []byte(sentinel), 0o600))
+
+		// Controlled `docker` that echoes the file it was handed; no real Docker.
+		execShim(t, map[string]string{"docker": `cat "$3"`})
+
+		rendered, err := RenderFile([]byte(envFileSpec), dir, specPath, nil, nil)
+		require.NoError(t, err)
+		require.NotEmpty(t, rendered)
+
+		_, statErr := os.Stat(tmpPath)
+		require.True(t, os.IsNotExist(statErr),
+			"RenderFile deleted the pre-existing %s written by the user", tmpPath)
+	})
+
+	t.Run("DockerConfigFailsAndLeavesTheRenderedTempFileBehind", func(t *testing.T) {
+		disablePrintErrorExit(t)
+		dir := t.TempDir()
+		specPath := writeFixture(t, dir, "omnistrate-compose.yaml", envFileSpec)
+		writeFixture(t, dir, "api.env", "KEY=value\n")
+		tmpPath := filepath.Join(dir, "omnistrate-compose.yaml.tmp")
+		require.NoError(t, os.WriteFile(tmpPath, []byte(sentinel), 0o600))
+
+		execShim(t, map[string]string{"docker": "exit 1"})
+
+		_, err := RenderFile([]byte(envFileSpec), dir, specPath, nil, nil)
+		require.Error(t, err, "docker compose config failure must surface")
+
+		leftover, readErr := os.ReadFile(tmpPath) //nolint:gosec // test-owned temp tree
+		require.NoError(t, readErr, "the temporary file is left in the user's input root on error")
+		require.NotEqual(t, sentinel, string(leftover),
+			"the user's file at %s was overwritten by RenderFile", tmpPath)
+		require.Contains(t, string(leftover), "nginx")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Preprocessing safety checks
+// ---------------------------------------------------------------------------
+
+// TestBuildDryRunPreprocessingPreservesSourceTreeAndPathSemantics asserts the
+// safety properties 02 requires from preprocessing: `$file` references and
+// Compose config/secret files keep their path semantics, no source file is
+// modified, no file is added to the input tree, and no Docker or Git subprocess
+// runs.
+//
+// CONVERTED. The assertions on the envelope moved from the legacy build endpoint
+// to the validation endpoint; the preprocessing properties themselves are
+// unchanged, which is the point — the same bytes a real build would send are
+// what gets validated.
+func TestBuildDryRunPreprocessingPreservesSourceTreeAndPathSemantics(t *testing.T) {
+	rr := startValidationServerAllowing(t, nil, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		writeJSON(w, validationResult(statusValid, nil))
+	})
+
+	const composeWithFileRefs = `services:
+  x-embed-$: {{ $file:./fragments/api.yaml }}
+configs:
+  app_config:
+    file: ./conf/app.conf
+secrets:
+  app_secret:
+    file: ./conf/app.secret
+`
+	const apiFragment = `api:
+  image: docker.io/library/nginx:1.27
+  labels:
+    embedded: from-file-reference
+`
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "omnistrate-compose.yaml", composeWithFileRefs)
+	writeFixture(t, dir, "fragments/api.yaml", apiFragment)
+	writeFixture(t, dir, "conf/app.conf", "config-file-content\n")
+	writeFixture(t, dir, "conf/app.secret", "secret-file-content\n")
+
+	logPath := execShim(t, map[string]string{"docker": "exit 7", "git": "exit 7"})
+	before := treeSnapshot(t, dir)
+	t.Chdir(dir)
+
+	err := runBuildWithOptions(context.Background(),
+		jsonDryRunOptions(specPath, DockerComposeSpecType), staticToken())
+	require.NoError(t, err)
+	rr.assertNoViolations(t)
+
+	// No source file modified, none added, none removed.
+	require.Equal(t, before, treeSnapshot(t, dir), "dry run modified the input tree")
+
+	// No Docker image build/push and no Git command.
+	require.Empty(t, shimInvocations(t, logPath), "dry run invoked a subprocess")
+
+	// No account onboarding or artifact publication.
+	require.Zero(t, rr.countPath(pathDeploymentArtifact))
+	for _, rec := range rr.recorded() {
+		require.False(t, strings.HasPrefix(rec.Path, "/2022-09-01-00/accountconfig") && rec.Method != http.MethodGet,
+			"dry run issued a mutating account request: %s", rec)
+	}
+
+	validations := rr.find(pathValidateSpec)
+	require.Len(t, validations, 1)
+	body := validations[0].decodeBody(t)
+
+	// $file reference was resolved relative to the spec file's directory.
+	sent, decErr := base64.StdEncoding.DecodeString(body["fileContent"].(string))
+	require.NoError(t, decErr)
+	require.Contains(t, string(sent), "embedded: from-file-reference")
+
+	// Compose config/secret files keep path semantics: their bytes are read from
+	// the declared relative paths and base64-encoded.
+	configs, ok := body["configs"].(map[string]any)
+	require.True(t, ok, "configs missing from request body: %v", body)
+	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("config-file-content\n")), configs["app_config"])
+
+	secrets, ok := body["secrets"].(map[string]any)
+	require.True(t, ok, "secrets missing from request body: %v", body)
+	require.Equal(t, base64.StdEncoding.EncodeToString([]byte("secret-file-content\n")), secrets["app_secret"])
+}
+
+// TestBuildDryRunImageGeneratedSpecUsesControlledImageReader covers the
+// image-generated spec branch with a controlled image metadata reader (the local
+// server answers the compose-gen endpoints).
+//
+// CONVERTED. It used to record that this branch reached the normal build
+// endpoint with dryrun=true. The generated spec is now validated instead.
+//
+// The two compose-gen calls remain, and are the only non-validation requests any
+// dry run makes. Both are reads: ows-orchestration's
+// ComposeGen.GenerateComposeSpecFromContainerImage checks access, reads image
+// metadata and marshals an in-memory compose project — no database write, no
+// workflow, no image push — so this branch can produce a candidate without
+// mutation and does not need the "unsupported validation" refusal that 04 §"CTL
+// execution algorithm" reserves for branches that cannot.
+func TestBuildDryRunImageGeneratedSpecUsesControlledImageReader(t *testing.T) {
+	rr := startValidationServerAllowing(t, allowComposeGenReads,
+		func(_ int, _ recordedRequest, w http.ResponseWriter) {
+			writeJSON(w, validationResult(statusValid, nil))
+		})
+
+	dir := t.TempDir()
+	logPath := execShim(t, map[string]string{"docker": "exit 7", "git": "exit 7"})
+	t.Chdir(dir)
+
+	opts := jsonDryRunOptions("", DockerComposeSpecType)
+	opts.imageUrl = "docker.io/library/nginx:1.27"
+
+	err := runBuildWithOptions(context.Background(), opts, staticToken())
+	require.NoError(t, err)
+	rr.assertNoViolations(t)
+
+	require.Equal(t, []string{
+		"GET " + pathComposeGenImage,
+		"POST " + pathComposeGenImage,
+		"POST " + pathValidateSpec,
+	}, rr.sequence(), "recorded request sequence for build --image --dry-run")
+	t.Logf("image-generated dry-run request sequence: %s", strings.Join(rr.sequence(), " | "))
+
+	require.Zero(t, rr.countPath(pathBuildComposeSpec), "no build request")
+	require.Empty(t, shimInvocations(t, logPath), "image dry run invoked a subprocess")
+	require.Empty(t, treeSnapshot(t, dir), "image dry run wrote files into the working directory")
+}
+
+// TestBuildDryRunJSONOutputIsSingleJSONDocument asserts the stdout contract from
+// 04 §"Output and logging": exactly one JSON document, carrying the validation
+// result and none of the build vocabulary.
+//
+// CONVERTED. The "exactly one JSON document" property is the part that was true
+// before and after; the payload assertions are new.
+func TestBuildDryRunJSONOutputIsSingleJSONDocument(t *testing.T) {
+	rr := startValidationServerAllowing(t, nil, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		writeJSON(w, validationResult(statusValid, nil))
+	})
+
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "omnistrate-compose.yaml", minimalComposeSpec)
+	t.Chdir(dir)
+
+	var runErr error
+	stdout := captureStdout(t, func() {
+		runErr = runBuildWithOptions(context.Background(),
+			jsonDryRunOptions(specPath, DockerComposeSpecType), staticToken())
+	})
+	require.NoError(t, runErr)
+	rr.assertNoViolations(t)
+
+	requireSingleJSONDocument(t, stdout)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	require.Equal(t, statusValid, result["status"])
+
+	// Required arrays are always present, never null.
+	for _, key := range []string{"checks", "diagnostics", "requiredArtifacts", "validatedArtifacts"} {
+		require.NotNil(t, result[key], "%s must be an array, not null: %s", key, stdout)
+	}
+
+	// None of the build vocabulary 04 forbids.
+	require.NotContains(t, stdout, "service built")
+	require.NotContains(t, stdout, "Successfully built")
+	require.NotContains(t, stdout, "product-tier?serviceId=")
+	require.NotContains(t, stdout, "\"version\":")
+	require.NotContains(t, stdout, "Next steps")
+	t.Logf("dry-run JSON stdout: %s", strings.TrimSpace(stdout))
+}
+
+// requireSingleJSONDocument asserts stdout holds exactly one JSON value.
+func requireSingleJSONDocument(t *testing.T, stdout string) {
+	t.Helper()
+	dec := json.NewDecoder(strings.NewReader(stdout))
+	var first any
+	require.NoError(t, dec.Decode(&first), "stdout is not valid JSON: %q", stdout)
+
+	var extra any
+	err := dec.Decode(&extra)
+	require.ErrorIs(t, err, io.EOF, "stdout contained more than one JSON document: %q", stdout)
+}
+
+// ---------------------------------------------------------------------------
+// Preprocessing: the read-only route never writes into the source tree
+// ---------------------------------------------------------------------------
+
+const envFileComposeSpec = `services:
+  api:
+    image: docker.io/library/nginx:1.27
+    env_file:
+      - ./api.env
+`
+
+// TestDryRunValidationLeavesTheSpecTmpSentinelAlone is the counterpart of
+// TestBuildDryRunRenderFileOverwritesSpecTmpSentinel: a sentinel is placed at
+// the path RenderFile would clobber, and the dry-run route must leave it
+// untouched in both the success and the failure case, while still resolving the
+// env file against the original project directory.
+func TestDryRunValidationLeavesTheSpecTmpSentinelAlone(t *testing.T) {
+	const sentinel = "SENTINEL-DO-NOT-TOUCH\n"
+
+	t.Run("DockerConfigSucceeds", func(t *testing.T) {
+		rr := startValidationServerAllowing(t, nil, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+			writeJSON(w, validationResult(statusValid, nil))
+		})
+
+		dir := t.TempDir()
+		specPath := writeFixture(t, dir, "omnistrate-compose.yaml", envFileComposeSpec)
+		writeFixture(t, dir, "api.env", "KEY=value\n")
+		tmpPath := filepath.Join(dir, "omnistrate-compose.yaml.tmp")
+		require.NoError(t, os.WriteFile(tmpPath, []byte(sentinel), 0o600))
+
+		// A controlled `docker` that records its arguments and echoes the file
+		// it was handed. "$5" is the -f argument once --project-directory <dir>
+		// precedes it.
+		logPath := execShim(t, map[string]string{"docker": `cat "$5"`})
+		before := treeSnapshot(t, dir)
+		t.Chdir(dir)
+
+		require.NoError(t, runBuildWithOptions(context.Background(),
+			jsonDryRunOptions(specPath, DockerComposeSpecType), staticToken()))
+		rr.assertNoViolations(t)
+
+		require.Equal(t, before, treeSnapshot(t, dir), "the dry run modified the input tree")
+		leftover, readErr := os.ReadFile(tmpPath) //nolint:gosec // test-owned temp tree
+		require.NoError(t, readErr)
+		require.Equal(t, sentinel, string(leftover), "the user's %s was overwritten", tmpPath)
+
+		// The project directory is preserved so relative env_file/config/secret
+		// references still resolve against the user's project.
+		invocations := shimInvocations(t, logPath)
+		require.Len(t, invocations, 1)
+		require.Contains(t, invocations[0], "--project-directory "+dir)
+		require.NotContains(t, invocations[0], dir+"/omnistrate-compose.yaml.tmp",
+			"the temporary file must live outside the source tree")
+	})
+
+	t.Run("DockerConfigFails", func(t *testing.T) {
+		rr := startValidationServerAllowing(t, nil, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+			writeJSON(w, validationResult(statusValid, nil))
+		})
+
+		dir := t.TempDir()
+		specPath := writeFixture(t, dir, "omnistrate-compose.yaml", envFileComposeSpec)
+		writeFixture(t, dir, "api.env", "KEY=value\n")
+		tmpPath := filepath.Join(dir, "omnistrate-compose.yaml.tmp")
+		require.NoError(t, os.WriteFile(tmpPath, []byte(sentinel), 0o600))
+
+		execShim(t, map[string]string{"docker": "echo 'boom' >&2; exit 1"})
+		before := treeSnapshot(t, dir)
+		t.Chdir(dir)
+
+		err := runBuildWithOptions(context.Background(),
+			jsonDryRunOptions(specPath, DockerComposeSpecType), staticToken())
+		require.Error(t, err, "a rendering failure must surface as an error")
+
+		require.Equal(t, before, treeSnapshot(t, dir),
+			"a failed dry run must leave nothing behind in the input tree")
+		leftover, readErr := os.ReadFile(tmpPath) //nolint:gosec // test-owned temp tree
+		require.NoError(t, readErr)
+		require.Equal(t, sentinel, string(leftover))
+		require.Zero(t, rr.countPath(pathValidateSpec), "no request is sent when rendering fails")
+	})
+}
+
+// TestDryRunValidationRenderingMatchesRenderFile pins renderFileForValidation to
+// the same output as RenderFile so the read-only preprocessing cannot drift from
+// what a real build sends.
+func TestDryRunValidationRenderingMatchesRenderFile(t *testing.T) {
+	disablePrintErrorExit(t)
+
+	specDir := t.TempDir()
+	specPath := writeFixture(t, specDir, "omnistrate-compose.yaml", envFileComposeSpec)
+	writeFixture(t, specDir, "api.env", "KEY=value\n")
+
+	// Both renderers get the same controlled `docker`, which echoes the compose
+	// file it was handed. RenderFile puts it at $3; the validation renderer puts
+	// it at $5 because --project-directory precedes -f.
+	execShim(t, map[string]string{"docker": `if [ "$2" = "--project-directory" ]; then cat "$5"; else cat "$3"; fi`})
+
+	viaRenderFile, err := RenderFile([]byte(envFileComposeSpec), specDir, specPath, nil, nil)
+	require.NoError(t, err)
+
+	viaValidation, err := renderFileForValidation([]byte(envFileComposeSpec), specDir, specPath)
+	require.NoError(t, err)
+
+	require.Equal(t, string(viaRenderFile), string(viaValidation),
+		"the read-only renderer must produce the same bytes as RenderFile")
+}
+
+// TestDryRunComposeEnvelopeMatchesRealBuild proves the dry run validates exactly
+// the bytes, configs and secrets a real build would send. prepareComposeValidationContent
+// reproduces BuildService's compose preprocessing; this pins the two together.
+func TestDryRunComposeEnvelopeMatchesRealBuild(t *testing.T) {
+	const composeWithConfigs = `services:
+  api:
+    image: docker.io/library/nginx:1.27
+configs:
+  app_config:
+    file: ./conf/app.conf
+secrets:
+  app_secret:
+    file: ./conf/app.secret
+`
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "omnistrate-compose.yaml", composeWithConfigs)
+	writeFixture(t, dir, "conf/app.conf", "config-file-content\n")
+	writeFixture(t, dir, "conf/app.secret", "secret-file-content\n")
+
+	// Capture what the legacy build endpoint receives.
+	legacy := startRecordingServer(t)
+	legacy.setRoute(legacyRoutes(nil))
+	t.Chdir(dir)
+
+	opts := jsonDryRunOptions(specPath, DockerComposeSpecType)
+	opts.dryRun = false
+	require.NoError(t, runBuildWithOptions(context.Background(), opts, staticToken()))
+	legacy.assertNoViolations(t)
+
+	buildBody := legacy.find(pathBuildComposeSpec)[0].decodeBody(t)
+
+	// Now capture what the validation endpoint receives.
+	validation := startValidationServerAllowing(t, nil, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		writeJSON(w, validationResult(statusValid, nil))
+	})
+	require.NoError(t, runBuildWithOptions(context.Background(),
+		jsonDryRunOptions(specPath, DockerComposeSpecType), staticToken()))
+	validation.assertNoViolations(t)
+
+	validateBody := validation.find(pathValidateSpec)[0].decodeBody(t)
+
+	require.Equal(t, buildBody["fileContent"], validateBody["fileContent"],
+		"the validated bytes must be the bytes a real build would send")
+	require.Equal(t, buildBody["configs"], validateBody["configs"])
+	require.Equal(t, buildBody["secrets"], validateBody["secrets"])
+	require.NotEmpty(t, validateBody["configs"])
+	require.NotEmpty(t, validateBody["secrets"])
+}
+
+// ---------------------------------------------------------------------------
+// The backend is not trusted to choose which local files are read
+// ---------------------------------------------------------------------------
+
+// TestDryRunValidationRefusesUndeclaredServerPaths is the hostile-server case
+// from 04 §"CTL execution algorithm" step 5. Each sub-case has a server that
+// answers the discovery request by demanding local content, and each demand must
+// be refused before anything is opened.
+func TestDryRunValidationRefusesUndeclaredServerPaths(t *testing.T) {
+	cases := []struct {
+		name        string
+		spec        string
+		logicalPath string
+		wantErr     string
+	}{{
+		// The attack 04 names explicitly: an unrelated in-workspace credentials
+		// directory that happens to be inside cwd.
+		name:        "UnrelatedDirectoryInsideTheWorkingDirectory",
+		spec:        servicePlanSpecWithLocalTerraform,
+		logicalPath: "credentials",
+		wantErr:     "does not declare as a local artifact source",
+	}, {
+		name:        "AbsolutePath",
+		spec:        servicePlanSpecWithLocalTerraform,
+		logicalPath: "/etc",
+		wantErr:     "is absolute",
+	}, {
+		name:        "ParentEscape",
+		spec:        servicePlanSpecWithLocalTerraform,
+		logicalPath: "../elsewhere",
+		wantErr:     "escapes the working directory",
+	}, {
+		name:        "EscapeHiddenInsideAnAllowedPrefix",
+		spec:        servicePlanSpecWithLocalTerraform,
+		logicalPath: "terraform/network/../../../elsewhere",
+		wantErr:     "escapes the working directory",
+	}, {
+		name:        "BackslashPath",
+		spec:        servicePlanSpecWithLocalTerraform,
+		logicalPath: `terraform\network`,
+		wantErr:     "contains a backslash",
+	}, {
+		// A compose specification declares no local artifact source at all, so
+		// every requirement against one is refused.
+		name:        "ComposeSpecificationHasNoLocalSources",
+		spec:        "",
+		logicalPath: "terraform/network",
+		wantErr:     "declared: none",
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			requirement := []map[string]any{{
+				"logicalPath": tc.logicalPath,
+				"uses": []map[string]any{{
+					"resourceKey": "network",
+					"kind":        "terraform",
+					"path":        "/services/0",
+				}},
+			}}
+
+			rr := startValidationServerAllowing(t, nil, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+				writeJSON(w, validationResult(statusIncomplete, requirement))
+			})
+
+			dir := t.TempDir()
+			// A credentials directory that a hostile server might try to exfiltrate.
+			writeFixture(t, dir, "credentials/aws.json", "{\"secret\":\"NEVER-SEND-THIS\"}\n")
+			writeFixture(t, dir, "terraform/network/main.tf", "output \"id\" { value = \"x\" }\n")
+
+			var opts buildOptions
+			if tc.spec == "" {
+				specPath := writeFixture(t, dir, "omnistrate-compose.yaml", minimalComposeSpec)
+				t.Chdir(dir)
+				opts = jsonDryRunOptions(specPath, DockerComposeSpecType)
+			} else {
+				specPath := writeFixture(t, dir, "spec.yaml", tc.spec)
+				t.Chdir(dir)
+				opts = jsonDryRunOptions(specPath, ServicePlanSpecType)
+			}
+
+			err := runBuildWithOptions(context.Background(), opts, staticToken())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tc.wantErr)
+
+			rr.assertNoViolations(t)
+			require.Equal(t, 1, rr.countPath(pathValidateSpec),
+				"no second request is sent, so nothing was read or transmitted")
+
+			// Belt and braces: the credential bytes never appear on the wire.
+			for _, rec := range rr.recorded() {
+				require.NotContains(t, string(rec.Body), "NEVER-SEND-THIS")
+			}
+		})
+	}
+}
+
+// TestDryRunValidationRefusesSymlinkEscapes covers the case where the path IS
+// declared but resolves outside the working directory through a symlink.
+func TestDryRunValidationRefusesSymlinkEscapes(t *testing.T) {
+	const specWithLinkedSource = `version: "1.0"
+name: Dry Run Plan
+services:
+  - name: network
+    terraformConfigurations:
+      configurationPerCloudProvider:
+        aws:
+          terraformPath: /terraform
+          artifactsLocalPath: ./linked
+`
+	requirement := []map[string]any{{
+		"logicalPath": "linked",
+		"uses": []map[string]any{{
+			"resourceKey": "network",
+			"kind":        "terraform",
+			"path":        "/services/0",
+		}},
+	}}
+
+	rr := startValidationServerAllowing(t, nil, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		writeJSON(w, validationResult(statusIncomplete, requirement))
+	})
+
+	outside := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(outside, "secret.txt"), []byte("OUTSIDE-SECRET"), 0o600))
+
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "spec.yaml", specWithLinkedSource)
+	require.NoError(t, os.Symlink(outside, filepath.Join(dir, "linked")))
+	t.Chdir(dir)
+
+	err := runBuildWithOptions(context.Background(),
+		jsonDryRunOptions(specPath, ServicePlanSpecType), staticToken())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "escapes base directory")
+
+	rr.assertNoViolations(t)
+	require.Equal(t, 1, rr.countPath(pathValidateSpec))
+	for _, rec := range rr.recorded() {
+		require.NotContains(t, string(rec.Body), "OUTSIDE-SECRET")
+	}
+}
+
+// TestDryRunValidationPreservesTheExplicitRootWithoutBroadening asserts the
+// canonical "." root behaviour from 04 step 5: a specification with no explicit
+// Terraform source defaults to "./", which is canonical "." and means the
+// working directory — never the user's home directory.
+func TestDryRunValidationPreservesTheExplicitRootWithoutBroadening(t *testing.T) {
+	requirement := []map[string]any{{
+		"logicalPath": ".",
+		"uses": []map[string]any{{
+			"resourceKey": "network",
+			"kind":        "terraform",
+			"path":        "/services/0/terraformConfigurations/configurationPerCloudProvider/aws",
+		}},
+	}}
+
+	rr := startValidationServerAllowing(t, nil, func(call int, rec recordedRequest, w http.ResponseWriter) {
+		if call == 0 {
+			writeJSON(w, validationResult(statusIncomplete, requirement))
+			return
+		}
+		writeJSON(w, validationResultAcknowledging(statusValid, rec, requirement))
+	})
+
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "spec.yaml", minimalServicePlanSpec)
+	writeFixture(t, dir, "main.tf", "output \"id\" { value = \"x\" }\n")
+	t.Chdir(dir)
+
+	require.NoError(t, runBuildWithOptions(context.Background(),
+		jsonDryRunOptions(specPath, ServicePlanSpecType), staticToken()))
+	rr.assertNoViolations(t)
+
+	artifact := firstArtifact(t, rr.find(pathValidateSpec)[1].decodeBody(t))
+	require.Equal(t, ".", artifact["logicalPath"], "the default root is canonical \".\"")
+
+	names := tarEntryNames(t, decodeArchive(t, artifact))
+	require.Contains(t, names, "main.tf")
+	require.Contains(t, names, "spec.yaml")
+}
+
+// ---------------------------------------------------------------------------
+// Second-request contract
+// ---------------------------------------------------------------------------
+
+func localTerraformFixture(t *testing.T) buildOptions {
+	t.Helper()
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "spec.yaml", servicePlanSpecWithLocalTerraform)
+	writeFixture(t, dir, "terraform/network/main.tf", "output \"id\" { value = \"x\" }\n")
+	t.Chdir(dir)
+	return jsonDryRunOptions(specPath, ServicePlanSpecType)
+}
+
+func terraformRequirement() []map[string]any {
+	return []map[string]any{{
+		"logicalPath": "terraform/network",
+		"uses": []map[string]any{{
+			"resourceKey": "network",
+			"kind":        "terraform",
+			"provider":    "aws",
+			"path":        "/services/0/terraformConfigurations/configurationPerCloudProvider/aws",
+		}},
+	}}
+}
+
+// TestDryRunValidationRejectsAChangedInputDigest — 04 step 8.
+func TestDryRunValidationRejectsAChangedInputDigest(t *testing.T) {
+	requirement := terraformRequirement()
+	rr := startValidationServerAllowing(t, nil, func(call int, rec recordedRequest, w http.ResponseWriter) {
+		if call == 0 {
+			writeJSON(w, validationResult(statusIncomplete, requirement))
+			return
+		}
+		result := validationResultAcknowledging(statusValid, rec, requirement)
+		result["inputDigest"] = "1111111111111111111111111111111111111111111111111111111111111111"
+		writeJSON(w, result)
+	})
+
+	err := runBuildWithOptions(context.Background(), localTerraformFixture(t), staticToken())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "different input for the second request")
+
+	rr.assertNoViolations(t)
+	require.Equal(t, 2, rr.countPath(pathValidateSpec), "exactly one retry, no loop")
+}
+
+// TestDryRunValidationRejectsAThirdContentRequest — 04 step 8: "INCOMPLETE or
+// another request for content after request two returns nonzero; no unbounded
+// retry loop and no mutation fallback."
+func TestDryRunValidationRejectsAThirdContentRequest(t *testing.T) {
+	requirement := terraformRequirement()
+	rr := startValidationServerAllowing(t, nil, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		// The server keeps asking for the same content, for ever.
+		writeJSON(w, validationResult(statusIncomplete, requirement))
+	})
+
+	var runErr error
+	stdout := captureStdout(t, func() {
+		runErr = runBuildWithOptions(context.Background(), localTerraformFixture(t), staticToken())
+	})
+	require.Error(t, runErr)
+	require.Contains(t, runErr.Error(), "asked for more local content after the final request")
+
+	rr.assertNoViolations(t)
+	require.Equal(t, 2, rr.countPath(pathValidateSpec), "no unbounded retry loop")
+	require.Zero(t, rr.countPath(pathBuildServicePlanSpec), "no mutation fallback")
+	require.Zero(t, rr.countPath(pathPrepareServicePlanSpec))
+	requireSingleJSONDocument(t, stdout)
+}
+
+// TestDryRunValidationRejectsUnacknowledgedArtifacts — 04 step 8: a VALID result
+// must acknowledge the supplied digest and every required use.
+func TestDryRunValidationRejectsUnacknowledgedArtifacts(t *testing.T) {
+	requirement := terraformRequirement()
+
+	t.Run("DigestNotAcknowledged", func(t *testing.T) {
+		rr := startValidationServerAllowing(t, nil, func(call int, _ recordedRequest, w http.ResponseWriter) {
+			if call == 0 {
+				writeJSON(w, validationResult(statusIncomplete, requirement))
+				return
+			}
+			// VALID, but the supplied content is never mentioned.
+			writeJSON(w, validationResult(statusValid, nil))
+		})
+
+		err := runBuildWithOptions(context.Background(), localTerraformFixture(t), staticToken())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "never acknowledged the content supplied")
+		rr.assertNoViolations(t)
+	})
+
+	t.Run("RequiredUseNotChecked", func(t *testing.T) {
+		rr := startValidationServerAllowing(t, nil, func(call int, rec recordedRequest, w http.ResponseWriter) {
+			if call == 0 {
+				writeJSON(w, validationResult(statusIncomplete, requirement))
+				return
+			}
+			// The digest is acknowledged but the use that required it is not.
+			writeJSON(w, validationResultAcknowledging(statusValid, rec, nil))
+		})
+
+		err := runBuildWithOptions(context.Background(), localTerraformFixture(t), staticToken())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "did not check")
+		rr.assertNoViolations(t)
+	})
+}
+
+// TestDryRunValidationIncompleteAfterContentIsNonZero — the second response can
+// still be INCOMPLETE for reasons unrelated to artifacts; that is a nonzero exit
+// with one JSON document, never a fallback to the build endpoint.
+func TestDryRunValidationIncompleteAfterContentIsNonZero(t *testing.T) {
+	requirement := terraformRequirement()
+	rr := startValidationServerAllowing(t, nil, func(call int, rec recordedRequest, w http.ResponseWriter) {
+		if call == 0 {
+			writeJSON(w, validationResult(statusIncomplete, requirement))
+			return
+		}
+		result := validationResultAcknowledging(statusIncomplete, rec, requirement)
+		writeJSON(w, result)
+	})
+
+	var runErr error
+	stdout := captureStdout(t, func() {
+		runErr = runBuildWithOptions(context.Background(), localTerraformFixture(t), staticToken())
+	})
+	require.Error(t, runErr)
+	require.Contains(t, runErr.Error(), "validation incomplete")
+
+	rr.assertNoViolations(t)
+	require.Equal(t, 2, rr.countPath(pathValidateSpec))
+	requireSingleJSONDocument(t, stdout)
+
+	var result map[string]any
+	require.NoError(t, json.Unmarshal([]byte(stdout), &result))
+	require.Equal(t, statusIncomplete, result["status"])
+}
+
+// ---------------------------------------------------------------------------
+// Archive semantics
+// ---------------------------------------------------------------------------
+
+// TestDryRunValidationDoesNotRewrapExistingArchives — 04 step 6.
+func TestDryRunValidationDoesNotRewrapExistingArchives(t *testing.T) {
+	requirement := []map[string]any{{
+		"logicalPath": "artifacts/bundle.tar.gz",
+		"uses": []map[string]any{{
+			"resourceKey": "chart",
+			"kind":        "helm",
+			"path":        "/services/0/helmChartConfiguration",
+		}},
+	}}
+
+	rr := startValidationServerAllowing(t, nil, func(call int, rec recordedRequest, w http.ResponseWriter) {
+		if call == 0 {
+			writeJSON(w, validationResult(statusIncomplete, requirement))
+			return
+		}
+		writeJSON(w, validationResultAcknowledging(statusValid, rec, requirement))
+	})
+
+	// A real, minimal tar.gz written by the same writer the normal build uses.
+	var raw bytes.Buffer
+	gzw := gzip.NewWriter(&raw)
+	tw := tar.NewWriter(gzw)
+	payload := []byte("chart contents\n")
+	require.NoError(t, tw.WriteHeader(&tar.Header{Name: "Chart.yaml", Mode: 0o600, Size: int64(len(payload))}))
+	_, err := tw.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, tw.Close())
+	require.NoError(t, gzw.Close())
+
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "spec.yaml", servicePlanSpecWithLocalArchive)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "artifacts"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "artifacts", "bundle.tar.gz"), raw.Bytes(), 0o600))
+	t.Chdir(dir)
+
+	require.NoError(t, runBuildWithOptions(context.Background(),
+		jsonDryRunOptions(specPath, ServicePlanSpecType), staticToken()))
+	rr.assertNoViolations(t)
+
+	artifact := firstArtifact(t, rr.find(pathValidateSpec)[1].decodeBody(t))
+	require.Equal(t, raw.Bytes(), decodeArchive(t, artifact),
+		"an existing .tar.gz must be transmitted byte-for-byte, not rewrapped")
+}
+
+// TestDryRunValidationRejectsSymlinksInsideAnArtifact — 04 step 6: unsupported
+// members are detected explicitly rather than silently omitted.
+func TestDryRunValidationRejectsSymlinksInsideAnArtifact(t *testing.T) {
+	requirement := terraformRequirement()
+	rr := startValidationServerAllowing(t, nil, func(_ int, _ recordedRequest, w http.ResponseWriter) {
+		writeJSON(w, validationResult(statusIncomplete, requirement))
+	})
+
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "spec.yaml", servicePlanSpecWithLocalTerraform)
+	writeFixture(t, dir, "terraform/network/main.tf", "output \"id\" { value = \"x\" }\n")
+	require.NoError(t, os.Symlink("main.tf", filepath.Join(dir, "terraform", "network", "alias.tf")))
+	t.Chdir(dir)
+
+	err := runBuildWithOptions(context.Background(),
+		jsonDryRunOptions(specPath, ServicePlanSpecType), staticToken())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot transport symlinks")
+	require.Contains(t, err.Error(), "alias.tf")
+
+	rr.assertNoViolations(t)
+	require.Equal(t, 1, rr.countPath(pathValidateSpec),
+		"an archive with an unsupported member is never sent")
+}
+
+// TestBoundedArchiveEnforcesLimitsWhileWriting drives createBoundedTarGz
+// directly with tiny budgets, so the limits are proven to fail during the write
+// rather than after an unbounded allocation.
+func TestBoundedArchiveEnforcesLimitsWhileWriting(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"a.tf", "b.tf", "c.tf"} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), bytes.Repeat([]byte("x"), 4096), 0o600))
+	}
+
+	t.Run("EntryBudget", func(t *testing.T) {
+		budget := &archiveBudget{
+			remainingCompressed: 1 << 20,
+			remainingExtracted:  1 << 20,
+			remainingEntries:    2,
+			maxMemberPathBytes:  1024,
+		}
+		_, err := createBoundedTarGz(dir, "terraform", budget)
+		require.ErrorIs(t, err, errArtifactLimitExceeded)
+		require.Contains(t, err.Error(), "too many archive entries")
+	})
+
+	t.Run("ExtractedByteBudget", func(t *testing.T) {
+		budget := &archiveBudget{
+			remainingCompressed: 1 << 20,
+			remainingExtracted:  1000, // less than one file
+			remainingEntries:    100,
+			maxMemberPathBytes:  1024,
+		}
+		_, err := createBoundedTarGz(dir, "terraform", budget)
+		require.ErrorIs(t, err, errArtifactLimitExceeded)
+		require.Contains(t, err.Error(), "uncompressed artifact size")
+	})
+
+	t.Run("CompressedByteBudget", func(t *testing.T) {
+		budget := &archiveBudget{
+			remainingCompressed: 8, // smaller than a gzip header
+			remainingExtracted:  1 << 20,
+			remainingEntries:    100,
+			maxMemberPathBytes:  1024,
+		}
+		_, err := createBoundedTarGz(dir, "terraform", budget)
+		require.ErrorIs(t, err, errArtifactLimitExceeded)
+		require.Contains(t, err.Error(), "compressed archive size")
+	})
+
+	t.Run("MemberPathBudget", func(t *testing.T) {
+		budget := &archiveBudget{
+			remainingCompressed: 1 << 20,
+			remainingExtracted:  1 << 20,
+			remainingEntries:    100,
+			maxMemberPathBytes:  2,
+		}
+		_, err := createBoundedTarGz(dir, "terraform", budget)
+		require.ErrorIs(t, err, errArtifactLimitExceeded)
+		require.Contains(t, err.Error(), "archive member path")
+	})
+
+	t.Run("WithinBudget", func(t *testing.T) {
+		budget := newArchiveBudget(defaultValidationLimits())
+		archive, err := createBoundedTarGz(dir, "terraform", budget)
+		require.NoError(t, err)
+		require.Equal(t, []string{"a.tf", "b.tf", "c.tf"}, tarEntryNames(t, archive))
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+func TestCanonicalValidationPath(t *testing.T) {
+	cases := []struct {
+		raw     string
+		want    string
+		wantErr string
+	}{
+		{raw: "terraform/network", want: "terraform/network"},
+		{raw: "./terraform/network", want: "terraform/network"},
+		{raw: "  ./terraform/network  ", want: "terraform/network"},
+		{raw: "./", want: "."},
+		{raw: ".", want: "."},
+		{raw: "terraform//network", want: "terraform/network"},
+		{raw: "terraform/./network", want: "terraform/network"},
+		{raw: "", wantErr: "is empty"},
+		{raw: "   ", wantErr: "is empty"},
+		{raw: "/terraform", wantErr: "is absolute"},
+		{raw: "//terraform", wantErr: "is absolute"},
+		{raw: "..", wantErr: "escapes the working directory"},
+		{raw: "../x", wantErr: "escapes the working directory"},
+		{raw: "a/../../b", wantErr: "escapes the working directory"},
+		// A sibling-prefix path is legitimate and must NOT be rejected.
+		{raw: "terraform-other/network", want: "terraform-other/network"},
+		{raw: "a/b\x00c", wantErr: "NUL"},
+		{raw: `a\b`, wantErr: "backslash"},
+	}
+
+	for _, tc := range cases {
+		t.Run(fmt.Sprintf("%q", tc.raw), func(t *testing.T) {
+			got, err := canonicalValidationPath(tc.raw, 1024)
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+
+	t.Run("PathLengthLimit", func(t *testing.T) {
+		_, err := canonicalValidationPath(strings.Repeat("a", 40), 16)
+		require.ErrorIs(t, err, errArtifactLimitExceeded)
+	})
+}
+
+func TestCollectDeclaredArtifactPaths(t *testing.T) {
+	t.Run("DefaultTerraformRootIsCanonicalDot", func(t *testing.T) {
+		allowed := collectDeclaredArtifactPaths(ServicePlanSpecType, []byte(minimalServicePlanSpec), 1024)
+		require.Equal(t, []string{"."}, sortedPaths(allowed))
+	})
+
+	t.Run("ExplicitLocalPaths", func(t *testing.T) {
+		const spec = `services:
+  - name: a
+    terraformConfigurations:
+      configurationPerCloudProvider:
+        aws:
+          artifactsLocalPath: ./tf/aws
+        gcp:
+          artifactRelativePath: tf/gcp
+      configurationPerOnPremPlatform:
+        GenericPlatform:
+          artifactsLocalPath: ./tf/onprem
+  - name: b
+    helmChartConfiguration:
+      artifactsLocalPath: ./charts/demo
+  - name: c
+    kustomizeConfiguration:
+      artifactsLocalPath: ./kustomize
+  - name: d
+    operatorCRDConfiguration:
+      artifactsLocalPath: ./operator
+`
+		allowed := collectDeclaredArtifactPaths(ServicePlanSpecType, []byte(spec), 1024)
+		require.Equal(t, []string{
+			"charts/demo", "kustomize", "operator", "tf/aws", "tf/gcp", "tf/onprem",
+		}, sortedPaths(allowed))
+	})
+
+	t.Run("GitBackedSourcesDeclareNoLocalPath", func(t *testing.T) {
+		const spec = `services:
+  - name: a
+    terraformConfigurations:
+      configurationPerCloudProvider:
+        aws:
+          gitConfiguration:
+            repositoryUrl: https://example.invalid/repo.git
+  - name: b
+    kustomizeConfiguration:
+      gitConfiguration:
+        repositoryUrl: https://example.invalid/repo.git
+      artifactsLocalPath: ./ignored
+`
+		allowed := collectDeclaredArtifactPaths(ServicePlanSpecType, []byte(spec), 1024)
+		require.Empty(t, sortedPaths(allowed))
+	})
+
+	t.Run("ContradictoryExclusiveFieldsDeclareNothing", func(t *testing.T) {
+		const spec = `services:
+  - name: a
+    terraformConfigurations:
+      configurationPerCloudProvider:
+        aws:
+          artifactsLocalPath: ./one
+          artifactRelativePath: two
+`
+		allowed := collectDeclaredArtifactPaths(ServicePlanSpecType, []byte(spec), 1024)
+		require.Empty(t, sortedPaths(allowed))
+	})
+
+	t.Run("ComposeDeclaresNothing", func(t *testing.T) {
+		allowed := collectDeclaredArtifactPaths(DockerComposeSpecType, []byte(minimalComposeSpec), 1024)
+		require.Empty(t, sortedPaths(allowed))
+	})
+
+	t.Run("EscapingDeclarationsAreNotAllowlisted", func(t *testing.T) {
+		const spec = `services:
+  - name: a
+    terraformConfigurations:
+      configurationPerCloudProvider:
+        aws:
+          artifactsLocalPath: ../../etc
+`
+		allowed := collectDeclaredArtifactPaths(ServicePlanSpecType, []byte(spec), 1024)
+		require.Empty(t, sortedPaths(allowed))
+	})
+}
+
+func TestValidationLimitsRespectTheSmallerServerValue(t *testing.T) {
+	limits := defaultValidationLimits().withServerLimits(&openapiclient.ValidationLimits{
+		MaxTotalCompressedArtifactBytes: 1024,
+		MaxArtifacts:                    1024, // larger than the client default
+		MaxArchiveEntries:               0,    // unset, must be ignored
+	})
+	require.Equal(t, int64(1024), limits.MaxTotalCompressedArtifactBytes)
+	require.Equal(t, defaultMaxArtifacts, limits.MaxArtifacts)
+	require.Equal(t, defaultMaxArchiveEntries, limits.MaxArchiveEntries)
+}
+
+// ---------------------------------------------------------------------------
+// Debug logging must not leak the payload
+// ---------------------------------------------------------------------------
+
+// TestDryRunValidationDebugLogsOmitSecretSentinels runs the whole dry-run route
+// with debug logging on and unique sentinels in the specification, in a compose
+// secret and inside the local artifact, then asserts that none of them — nor the
+// token, nor the base64 archive — reaches the captured log, while the request
+// metadata still does. 04 §"Output and logging".
+func TestDryRunValidationDebugLogsOmitSecretSentinels(t *testing.T) {
+	const (
+		specSentinel     = "SENTINEL-SPEC-4f1a9c2b"
+		artifactSentinel = "SENTINEL-ARTIFACT-77c31d0e"
+	)
+
+	spec := fmt.Sprintf(`version: "1.0"
+name: Dry Run Plan
+description: %s
+services:
+  - name: network
+    terraformConfigurations:
+      configurationPerCloudProvider:
+        aws:
+          terraformPath: /terraform/network
+          artifactsLocalPath: ./terraform/network
+`, specSentinel)
+
+	requirement := terraformRequirement()
+	rr := startValidationServerAllowing(t, nil, func(call int, rec recordedRequest, w http.ResponseWriter) {
+		if call == 0 {
+			writeJSON(w, validationResult(statusIncomplete, requirement))
+			return
+		}
+		writeJSON(w, validationResultAcknowledging(statusValid, rec, requirement))
+	})
+
+	dir := t.TempDir()
+	specPath := writeFixture(t, dir, "spec.yaml", spec)
+	writeFixture(t, dir, "terraform/network/main.tf",
+		fmt.Sprintf("variable \"token\" { default = \"%s\" }\n", artifactSentinel))
+	t.Chdir(dir)
+
+	logs := captureDebugLogs(t, func() {
+		require.NoError(t, runBuildWithOptions(context.Background(),
+			jsonDryRunOptions(specPath, ServicePlanSpecType), staticToken()))
+	})
+	rr.assertNoViolations(t)
+
+	require.NotEmpty(t, logs, "debug logging produced no output, so this test would prove nothing")
+	require.Contains(t, logs, pathValidateSpec, "request metadata must still be logged")
+	require.Contains(t, logs, "[REDACTED]", "the Authorization header must be redacted")
+	require.Contains(t, logs, "body omitted")
+
+	forbidden := map[string]string{
+		"the specification sentinel":     specSentinel,
+		"the base64 specification":       base64.StdEncoding.EncodeToString([]byte(spec)),
+		"the artifact sentinel":          artifactSentinel,
+		"the API token":                  fakeToken,
+		"the Authorization header value": "Bearer " + fakeToken,
+	}
+	for what, sentinel := range forbidden {
+		require.NotContains(t, logs, sentinel, "%s appeared in the debug log", what)
+	}
+
+	// The base64 archive itself must not appear either.
+	artifact := firstArtifact(t, rr.find(pathValidateSpec)[1].decodeBody(t))
+	archiveContent, ok := artifact["archiveContent"].(string)
+	require.True(t, ok)
+	require.NotContains(t, logs, archiveContent, "the base64 archive appeared in the debug log")
+}
+
+// captureDebugLogs redirects the global zerolog logger into a buffer and turns
+// on the debug level that gates the request/response dumps.
+func captureDebugLogs(t *testing.T, fn func()) string {
+	t.Helper()
+	t.Setenv("OMNISTRATE_LOG_LEVEL", "debug")
+
+	var buf bytes.Buffer
+	original := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+	t.Cleanup(func() { log.Logger = original })
+
+	fn()
+	return buf.String()
+}

--- a/cmd/build/validation_artifacts.go
+++ b/cmd/build/validation_artifacts.go
@@ -1,0 +1,582 @@
+package build
+
+// Local artifact packaging for `omnistrate-ctl build --dry-run`, per
+// dry-run-implementation-specs/04-local-artifacts-and-ctl.md §"CTL execution
+// algorithm" steps 5-7.
+//
+// Two properties drive every decision in this file:
+//
+//  1. The backend is NOT trusted to choose which local files are read. A
+//     validation response arrives over the network and names filesystem paths.
+//     Before anything is opened, each returned path is checked lexically
+//     (absolute/escaping/NUL/backslash/`..`), reconciled against the local
+//     source declarations in the user's own specification, and finally resolved
+//     with symlink evaluation so a symlink cannot point outside the working
+//     directory. A server that asks for `secrets/` or `../../.aws` gets an
+//     error, not bytes.
+//
+//  2. Limits are enforced WHILE writing, never after allocating an unbounded
+//     string. The tar stream is written through byte-counting writers that fail
+//     the moment a budget is exceeded.
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	openapiclient "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
+	"gopkg.in/yaml.v3"
+)
+
+// Client-side defaults for the bounds in 04 §"Bounds". The backend owns the
+// authoritative constants; when a response advertises `limits`, the smaller of
+// the client and server value wins (see validationLimits.withServerLimits).
+const (
+	defaultMaxRequestBodyBytes              int64 = 24 << 20 // 24 MiB
+	defaultMaxTotalCompressedArtifactBytes  int64 = 16 << 20 // 16 MiB
+	defaultMaxTotalExtractedBytes           int64 = 64 << 20 // 64 MiB
+	defaultMaxTotalSpecBytes                int64 = 1 << 20  // 1 MiB
+	defaultMaxArtifacts                     int64 = 64
+	defaultMaxArchiveEntries                int64 = 4096
+	defaultMaxArchiveMemberPathBytes        int64 = 1024
+	defaultMaxConcurrentContentValidations  int64 = 4
+	defaultValidationRequestDeadlineSeconds int64 = 120
+)
+
+// validationLimits are the effective limits for one dry-run invocation.
+type validationLimits struct {
+	MaxRequestBodyBytes             int64
+	MaxTotalCompressedArtifactBytes int64
+	MaxTotalExtractedBytes          int64
+	MaxTotalSpecBytes               int64
+	MaxArtifacts                    int64
+	MaxArchiveEntries               int64
+	MaxArchiveMemberPathBytes       int64
+	RequestDeadlineSeconds          int64
+}
+
+func defaultValidationLimits() validationLimits {
+	return validationLimits{
+		MaxRequestBodyBytes:             defaultMaxRequestBodyBytes,
+		MaxTotalCompressedArtifactBytes: defaultMaxTotalCompressedArtifactBytes,
+		MaxTotalExtractedBytes:          defaultMaxTotalExtractedBytes,
+		MaxTotalSpecBytes:               defaultMaxTotalSpecBytes,
+		MaxArtifacts:                    defaultMaxArtifacts,
+		MaxArchiveEntries:               defaultMaxArchiveEntries,
+		MaxArchiveMemberPathBytes:       defaultMaxArchiveMemberPathBytes,
+		RequestDeadlineSeconds:          defaultValidationRequestDeadlineSeconds,
+	}
+}
+
+// withServerLimits keeps the smaller of the client and server value for every
+// advertised limit, as 04 §"Bounds" requires. A zero or negative advertised
+// value is ignored rather than treated as "no content allowed".
+func (l validationLimits) withServerLimits(server *openapiclient.ValidationLimits) validationLimits {
+	if server == nil {
+		return l
+	}
+	smaller := func(current, advertised int64) int64 {
+		if advertised > 0 && advertised < current {
+			return advertised
+		}
+		return current
+	}
+	l.MaxRequestBodyBytes = smaller(l.MaxRequestBodyBytes, server.MaxRequestBodyBytes)
+	l.MaxTotalCompressedArtifactBytes = smaller(l.MaxTotalCompressedArtifactBytes, server.MaxTotalCompressedArtifactBytes)
+	l.MaxTotalExtractedBytes = smaller(l.MaxTotalExtractedBytes, server.MaxTotalExtractedBytes)
+	l.MaxTotalSpecBytes = smaller(l.MaxTotalSpecBytes, server.MaxTotalSpecBytes)
+	l.MaxArtifacts = smaller(l.MaxArtifacts, server.MaxArtifacts)
+	l.MaxArchiveEntries = smaller(l.MaxArchiveEntries, server.MaxArchiveEntries)
+	l.MaxArchiveMemberPathBytes = smaller(l.MaxArchiveMemberPathBytes, server.MaxArchiveMemberPathBytes)
+	l.RequestDeadlineSeconds = smaller(l.RequestDeadlineSeconds, server.RequestDeadlineSeconds)
+	return l
+}
+
+// errArtifactLimitExceeded marks any failure caused by one of the transport
+// bounds so the caller can report "this input is too large for read-only
+// validation" instead of an opaque archive error.
+var errArtifactLimitExceeded = errors.New("validation artifact limit exceeded")
+
+// ---------------------------------------------------------------------------
+// Canonical validation paths
+// ---------------------------------------------------------------------------
+
+// canonicalValidationPath applies the validation-specific checks that must run
+// BEFORE the shared normalisation, then normalises.
+//
+// The backend's NormalizeWorkspaceArtifactPath trims whitespace, removes "./",
+// returns "." for the workspace root and strips a leading "/". Stripping a
+// leading "/" would silently turn an absolute path into a relative one, so this
+// stricter client-side check rejects absolute and volume-qualified input
+// outright, along with NUL bytes, backslashes and any ".." component. The
+// canonical forms match the backend exactly: "./terraform/network" becomes
+// "terraform/network" and "./" becomes ".".
+func canonicalValidationPath(raw string, maxBytes int64) (string, error) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", errors.New("artifact path is empty")
+	}
+	if maxBytes > 0 && int64(len(trimmed)) > maxBytes {
+		return "", fmt.Errorf("%w: artifact path is longer than %d bytes", errArtifactLimitExceeded, maxBytes)
+	}
+	if strings.ContainsRune(trimmed, 0) {
+		return "", fmt.Errorf("artifact path %q contains a NUL byte", raw)
+	}
+	if strings.Contains(trimmed, `\`) {
+		return "", fmt.Errorf("artifact path %q contains a backslash", raw)
+	}
+	if strings.HasPrefix(trimmed, "/") || filepath.IsAbs(trimmed) || filepath.VolumeName(trimmed) != "" {
+		return "", fmt.Errorf("artifact path %q is absolute; only paths inside the working directory are allowed", raw)
+	}
+	// Component-aware ".." rejection, before any normalisation can collapse it.
+	for _, component := range strings.Split(trimmed, "/") {
+		if component == ".." {
+			return "", fmt.Errorf("artifact path %q escapes the working directory", raw)
+		}
+	}
+
+	canonical := path.Clean(trimmed)
+	if canonical == "." || canonical == "./" {
+		return ".", nil
+	}
+	if canonical == ".." || strings.HasPrefix(canonical, "../") || strings.HasPrefix(canonical, "/") {
+		return "", fmt.Errorf("artifact path %q escapes the working directory", raw)
+	}
+	return canonical, nil
+}
+
+// ---------------------------------------------------------------------------
+// Local source declaration collector — the allowlist
+// ---------------------------------------------------------------------------
+
+// declaredLocalArtifactPaths is a narrow reader over the typed YAML positions
+// that can declare a local artifact source. It exists ONLY to build the
+// allowlist that constrains which paths a validation response may ask for; the
+// backend remains authoritative for semantic and provider discovery.
+//
+// The field names mirror the backend's own structs
+// (servicebuild/common/module/{terraform,helm,kustomize,operator_crd}.go), so a
+// path the real build would archive is a path this collector accepts.
+type declaredLocalArtifactPaths struct {
+	Services []struct {
+		TerraformConfigurations *struct {
+			ConfigurationPerCloudProvider  map[string]declaredTerraformConfiguration `yaml:"configurationPerCloudProvider"`
+			ConfigurationPerOnPremPlatform map[string]declaredTerraformConfiguration `yaml:"configurationPerOnPremPlatform"`
+		} `yaml:"terraformConfigurations"`
+		HelmChartConfiguration *struct {
+			ArtifactsLocalPath   string `yaml:"artifactsLocalPath"`
+			ArtifactRelativePath string `yaml:"artifactRelativePath"`
+		} `yaml:"helmChartConfiguration"`
+		KustomizeConfiguration *struct {
+			ArtifactsLocalPath string                   `yaml:"artifactsLocalPath"`
+			GitConfiguration   declaredGitConfiguration `yaml:"gitConfiguration"`
+		} `yaml:"kustomizeConfiguration"`
+		OperatorCRDConfiguration *struct {
+			ArtifactsLocalPath string `yaml:"artifactsLocalPath"`
+		} `yaml:"operatorCRDConfiguration"`
+	} `yaml:"services"`
+}
+
+type declaredTerraformConfiguration struct {
+	ArtifactsLocalPath   string                   `yaml:"artifactsLocalPath"`
+	ArtifactRelativePath string                   `yaml:"artifactRelativePath"`
+	GitConfiguration     declaredGitConfiguration `yaml:"gitConfiguration"`
+}
+
+type declaredGitConfiguration struct {
+	RepositoryURL string `yaml:"repositoryUrl"`
+}
+
+// collectDeclaredArtifactPaths returns the canonical local artifact paths the
+// specification itself declares, plus the documented Terraform default root.
+//
+// Compose specifications declare no local artifact sources at all (there is no
+// x-omnistrate extension for one), so the allowlist for a compose dry run is
+// empty and any requirement a server returns for it is refused.
+//
+// This function never fails the dry run: an undecodable or self-contradictory
+// declaration simply contributes nothing to the allowlist, and the backend
+// reports the real problem as INVALID.
+func collectDeclaredArtifactPaths(specType string, fileData []byte, maxPathBytes int64) map[string]struct{} {
+	allowed := make(map[string]struct{})
+	if specType != ServicePlanSpecType {
+		return allowed
+	}
+
+	var spec declaredLocalArtifactPaths
+	if err := yaml.Unmarshal(fileData, &spec); err != nil {
+		return allowed
+	}
+
+	add := func(raw string) {
+		canonical, err := canonicalValidationPath(raw, maxPathBytes)
+		if err != nil {
+			return
+		}
+		allowed[canonical] = struct{}{}
+	}
+
+	// resolveExclusive mirrors module.TerraformConfiguration.ResolveArtifactPath
+	// and module.HelmChartConfiguration.ResolveArtifactPath: both fields map to
+	// the same backend field, so setting both is an error and contributes
+	// nothing.
+	resolveExclusive := func(localPath, relativePath string) (string, bool) {
+		if localPath != "" && relativePath != "" {
+			return "", false
+		}
+		if relativePath != "" {
+			return relativePath, true
+		}
+		return localPath, true
+	}
+
+	addTerraform := func(config declaredTerraformConfiguration) {
+		if config.GitConfiguration.RepositoryURL != "" {
+			// Git-backed Terraform has no local requirement.
+			return
+		}
+		effective, ok := resolveExclusive(config.ArtifactsLocalPath, config.ArtifactRelativePath)
+		if !ok {
+			return
+		}
+		if effective == "" {
+			// Documented default local root when neither Git nor a local path
+			// is set (extractArtifactUploadTasks defaults to "./").
+			effective = "./"
+		}
+		add(effective)
+	}
+
+	for _, service := range spec.Services {
+		if service.TerraformConfigurations != nil {
+			for _, config := range service.TerraformConfigurations.ConfigurationPerCloudProvider {
+				addTerraform(config)
+			}
+			for _, config := range service.TerraformConfigurations.ConfigurationPerOnPremPlatform {
+				addTerraform(config)
+			}
+		}
+		if service.HelmChartConfiguration != nil {
+			if effective, ok := resolveExclusive(
+				service.HelmChartConfiguration.ArtifactsLocalPath,
+				service.HelmChartConfiguration.ArtifactRelativePath,
+			); ok && effective != "" {
+				add(effective)
+			}
+		}
+		if service.KustomizeConfiguration != nil &&
+			service.KustomizeConfiguration.GitConfiguration.RepositoryURL == "" &&
+			service.KustomizeConfiguration.ArtifactsLocalPath != "" {
+			add(service.KustomizeConfiguration.ArtifactsLocalPath)
+		}
+		if service.OperatorCRDConfiguration != nil && service.OperatorCRDConfiguration.ArtifactsLocalPath != "" {
+			add(service.OperatorCRDConfiguration.ArtifactsLocalPath)
+		}
+	}
+
+	return allowed
+}
+
+func sortedPaths(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for p := range set {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Packaging
+// ---------------------------------------------------------------------------
+
+// archiveBudget carries the per-request limits that span all artifacts.
+type archiveBudget struct {
+	remainingCompressed int64
+	remainingExtracted  int64
+	remainingEntries    int64
+	maxMemberPathBytes  int64
+}
+
+func newArchiveBudget(limits validationLimits) *archiveBudget {
+	return &archiveBudget{
+		remainingCompressed: limits.MaxTotalCompressedArtifactBytes,
+		remainingExtracted:  limits.MaxTotalExtractedBytes,
+		remainingEntries:    limits.MaxArchiveEntries,
+		maxMemberPathBytes:  limits.MaxArchiveMemberPathBytes,
+	}
+}
+
+// boundedWriter fails as soon as the budget is exhausted, so an oversized
+// artifact never materialises fully in memory.
+type boundedWriter struct {
+	dst       io.Writer
+	remaining *int64
+	what      string
+	limit     int64
+}
+
+func (w *boundedWriter) Write(p []byte) (int, error) {
+	if int64(len(p)) > *w.remaining {
+		return 0, fmt.Errorf("%w: %s exceeds %d bytes", errArtifactLimitExceeded, w.what, w.limit)
+	}
+	n, err := w.dst.Write(p)
+	*w.remaining -= int64(n)
+	return n, err
+}
+
+// packageValidationArtifacts turns the server's requirements into request-scoped
+// archives. cwd is the archive base, matching ArchiveArtifactPaths(cwd, ...) in
+// the normal build path.
+func packageValidationArtifacts(
+	cwd string,
+	requirements []openapiclient.ArtifactRequirement,
+	allowed map[string]struct{},
+	limits validationLimits,
+) ([]openapiclient.ValidationArtifactInput, error) {
+	if len(requirements) == 0 {
+		return nil, nil
+	}
+
+	resolvedBaseDir, err := resolveArchiveBaseDir(cwd)
+	if err != nil {
+		return nil, err
+	}
+
+	// Deduplicate by canonical path first: the same local bytes are never
+	// packaged twice, however many uses reference them.
+	canonicalPaths := make([]string, 0, len(requirements))
+	seen := make(map[string]struct{}, len(requirements))
+	for _, requirement := range requirements {
+		canonical, pathErr := canonicalValidationPath(requirement.LogicalPath, limits.MaxArchiveMemberPathBytes)
+		if pathErr != nil {
+			return nil, fmt.Errorf("the server requested local content for an unusable path: %w", pathErr)
+		}
+		if _, exists := allowed[canonical]; !exists {
+			return nil, fmt.Errorf(
+				"the server requested local content for %q, which this specification does not declare as a local artifact source (declared: %s); refusing to read it",
+				requirement.LogicalPath, describeAllowedPaths(allowed))
+		}
+		if _, duplicate := seen[canonical]; duplicate {
+			continue
+		}
+		seen[canonical] = struct{}{}
+		canonicalPaths = append(canonicalPaths, canonical)
+	}
+
+	if limits.MaxArtifacts > 0 && int64(len(canonicalPaths)) > limits.MaxArtifacts {
+		return nil, fmt.Errorf("%w: %d artifacts requested, the limit is %d",
+			errArtifactLimitExceeded, len(canonicalPaths), limits.MaxArtifacts)
+	}
+
+	sort.Strings(canonicalPaths)
+	budget := newArchiveBudget(limits)
+
+	artifacts := make([]openapiclient.ValidationArtifactInput, 0, len(canonicalPaths))
+	for _, canonical := range canonicalPaths {
+		compressed, buildErr := buildValidationArchive(resolvedBaseDir, canonical, budget)
+		if buildErr != nil {
+			return nil, buildErr
+		}
+
+		digest := sha256.Sum256(compressed)
+		artifacts = append(artifacts, openapiclient.ValidationArtifactInput{
+			LogicalPath:         canonical,
+			Encoding:            validationArtifactEncoding,
+			ArchiveContent:      base64.StdEncoding.EncodeToString(compressed),
+			Sha256:              hex.EncodeToString(digest[:]),
+			CompressedSizeBytes: int64(len(compressed)),
+		})
+	}
+
+	return artifacts, nil
+}
+
+func describeAllowedPaths(allowed map[string]struct{}) string {
+	if len(allowed) == 0 {
+		return "none"
+	}
+	return strings.Join(sortedPaths(allowed), ", ")
+}
+
+// buildValidationArchive resolves one canonical path under the archive base and
+// returns the exact compressed bytes to send. resolveArtifactPath performs the
+// symlink evaluation and containment check, so a symlinked artifact path that
+// points outside the working directory is rejected here.
+func buildValidationArchive(resolvedBaseDir, canonical string, budget *archiveBudget) ([]byte, error) {
+	resolvedPath, info, err := resolveArtifactPath(resolvedBaseDir, canonical)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read local artifact %q: %w", canonical, err)
+	}
+
+	if !info.IsDir() {
+		// Existing .tgz/.tar.gz inputs are sent as-is, never rewrapped.
+		if !isGzipTarFile(resolvedPath) {
+			return nil, fmt.Errorf("artifact path %q is not a directory or a .tar.gz file", canonical)
+		}
+		return readExistingArchive(resolvedPath, canonical, budget)
+	}
+
+	return createBoundedTarGz(resolvedPath, canonical, budget)
+}
+
+// readExistingArchive reads a pre-existing archive within the compressed budget
+// and verifies it really is a gzip stream, so a malformed file fails locally
+// with a clear message rather than as an opaque server-side rejection.
+func readExistingArchive(resolvedPath, canonical string, budget *archiveBudget) ([]byte, error) {
+	info, err := os.Stat(resolvedPath)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read local artifact %q: %w", canonical, err)
+	}
+	if info.Size() > budget.remainingCompressed {
+		return nil, fmt.Errorf("%w: archive %q is %d bytes and does not fit in the remaining %d byte budget",
+			errArtifactLimitExceeded, canonical, info.Size(), budget.remainingCompressed)
+	}
+
+	content, err := os.ReadFile(resolvedPath) //nolint:gosec // resolvedPath is constrained to the archive base by resolveArtifactPath
+	if err != nil {
+		return nil, fmt.Errorf("cannot read local artifact %q: %w", canonical, err)
+	}
+	if int64(len(content)) != info.Size() {
+		return nil, fmt.Errorf("local artifact %q changed while it was being read; aborting rather than validating stale content", canonical)
+	}
+	budget.remainingCompressed -= int64(len(content))
+
+	gzReader, err := gzip.NewReader(bytes.NewReader(content))
+	if err != nil {
+		return nil, fmt.Errorf("local artifact %q is not a valid gzip archive: %w", canonical, err)
+	}
+	_ = gzReader.Close()
+
+	return content, nil
+}
+
+// createBoundedTarGz reproduces the tar layout of createTarGzBase64 (entry names
+// relative to the artifact directory's own root, no implicit exclusions) while
+// enforcing the entry, member-path, extracted-byte and compressed-byte budgets
+// as the stream is written.
+//
+// Unlike createTarGzBase64 it refuses symlinks and other non-regular members
+// explicitly: the validation extractor rejects them, and silently dropping a
+// file the validators need would let an incomplete archive be reported as
+// validated content.
+func createBoundedTarGz(sourceDir, canonical string, budget *archiveBudget) ([]byte, error) {
+	var buf bytes.Buffer
+	bounded := &boundedWriter{
+		dst:       &buf,
+		remaining: &budget.remainingCompressed,
+		what:      "the total compressed archive size",
+		limit:     budget.remainingCompressed,
+	}
+	gzWriter := gzip.NewWriter(bounded)
+	tarWriter := tar.NewWriter(gzWriter)
+
+	walkErr := filepath.Walk(sourceDir, func(entryPath string, info os.FileInfo, err error) error { //nolint:gosec // sourceDir is validated by resolveArtifactPath before this call
+		if err != nil {
+			return err
+		}
+
+		relPath, relErr := filepath.Rel(sourceDir, entryPath)
+		if relErr != nil {
+			return fmt.Errorf("failed to get relative path: %w", relErr)
+		}
+		if relPath == "." {
+			return nil
+		}
+
+		if budget.remainingEntries <= 0 {
+			return fmt.Errorf("%w: too many archive entries", errArtifactLimitExceeded)
+		}
+		budget.remainingEntries--
+
+		memberName := filepath.ToSlash(relPath)
+		if budget.maxMemberPathBytes > 0 && int64(len(memberName)) > budget.maxMemberPathBytes {
+			return fmt.Errorf("%w: archive member path %q is longer than %d bytes",
+				errArtifactLimitExceeded, memberName, budget.maxMemberPathBytes)
+		}
+
+		mode := info.Mode()
+		switch {
+		case mode.IsDir(), mode.IsRegular():
+			// supported
+		case mode&os.ModeSymlink != 0:
+			return fmt.Errorf(
+				"local artifact %q contains the symlink %q; read-only validation cannot transport symlinks, so remove or dereference it rather than validating an archive with the file missing",
+				canonical, memberName)
+		default:
+			return fmt.Errorf(
+				"local artifact %q contains %q, which is not a regular file or directory (mode %s) and cannot be validated",
+				canonical, memberName, mode)
+		}
+
+		header, headerErr := tar.FileInfoHeader(info, "")
+		if headerErr != nil {
+			return fmt.Errorf("failed to create tar header: %w", headerErr)
+		}
+		// Same layout as the normal build archive: entries are named relative to
+		// the artifact directory's own root.
+		header.Name = relPath
+
+		if writeErr := tarWriter.WriteHeader(header); writeErr != nil {
+			return fmt.Errorf("failed to write tar header: %w", writeErr)
+		}
+
+		if !mode.IsRegular() {
+			return nil
+		}
+
+		file, openErr := os.Open(filepath.Clean(entryPath))
+		if openErr != nil {
+			return fmt.Errorf("failed to read %q inside local artifact %q: %w", memberName, canonical, openErr)
+		}
+		defer file.Close()
+
+		copied, copyErr := io.Copy(&boundedWriter{
+			dst:       tarWriter,
+			remaining: &budget.remainingExtracted,
+			what:      "the total uncompressed artifact size",
+			limit:     budget.remainingExtracted,
+		}, file)
+		if copyErr != nil {
+			return fmt.Errorf("failed to read %q inside local artifact %q: %w", memberName, canonical, copyErr)
+		}
+
+		// Abort rather than substitute content: if the file changed between the
+		// header being written and the bytes being read, the archive no longer
+		// describes anything that exists on disk.
+		after, statErr := os.Lstat(entryPath)
+		if statErr != nil {
+			return fmt.Errorf("failed to re-read %q inside local artifact %q: %w", memberName, canonical, statErr)
+		}
+		if copied != info.Size() || after.Size() != info.Size() || !after.ModTime().Equal(info.ModTime()) {
+			return fmt.Errorf(
+				"%q inside local artifact %q changed while the archive was being written; aborting rather than validating content that was never on disk",
+				memberName, canonical)
+		}
+
+		return nil
+	})
+	if walkErr != nil {
+		return nil, walkErr
+	}
+
+	if err := tarWriter.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close tar writer: %w", err)
+	}
+	if err := gzWriter.Close(); err != nil {
+		return nil, fmt.Errorf("failed to close gzip writer: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}

--- a/internal/dataaccess/client.go
+++ b/internal/dataaccess/client.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httputil"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
@@ -13,6 +17,105 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 )
+
+// ValidateServiceSpecPath is the wire path of the read-only build validation
+// endpoint. It is declared here (and not only in the generated client) because
+// the debug-logging policy below has to recognise the route.
+const ValidateServiceSpecPath = "/2022-09-01-00/service/spec/validate"
+
+// redactedHeaderPlaceholder replaces credential-bearing header values in debug
+// dumps, and omittedBodyPlaceholder stands in for the body itself.
+const (
+	redactedHeaderPlaceholder = "[REDACTED]"
+	omittedBodyPlaceholder    = "[body omitted: sensitive validation payload]"
+)
+
+// sensitiveHeaders are never written to a debug log for any route.
+var sensitiveHeaders = map[string]struct{}{
+	"authorization":       {},
+	"proxy-authorization": {},
+	"cookie":              {},
+	"set-cookie":          {},
+	"x-api-key":           {},
+}
+
+// isSensitiveBodyPath reports whether a request/response body for this route may
+// never be written to a debug log.
+//
+// This is a deliberately narrow policy covering only the read-only validation
+// route added by the build --dry-run work. Its body carries the user's raw
+// specification, compose configs and secrets, and base64 tar.gz archives of
+// local Terraform/Helm/Kustomize directories — none of which may ever reach a
+// log file. Every other route keeps the pre-existing dump behaviour.
+func isSensitiveBodyPath(u *url.URL) bool {
+	if u == nil {
+		return false
+	}
+	return u.Path == ValidateServiceSpecPath
+}
+
+// metadataOnlyRequestDump renders request metadata with credential headers
+// redacted and the body deliberately omitted. It never touches req.Body, so it
+// cannot consume or leak the payload.
+func metadataOnlyRequestDump(req *http.Request) string {
+	var b strings.Builder
+	writeMetadataLine(&b, req.Method+" "+req.URL.RequestURI()+" HTTP/"+
+		strconv.Itoa(req.ProtoMajor)+"."+strconv.Itoa(req.ProtoMinor))
+	switch {
+	case req.Host != "":
+		writeMetadataLine(&b, "Host: "+req.Host)
+	case req.URL != nil:
+		writeMetadataLine(&b, "Host: "+req.URL.Host)
+	}
+	writeRedactedHeaders(&b, req.Header)
+	if req.ContentLength > 0 {
+		writeMetadataLine(&b, "Content-Length: "+strconv.FormatInt(req.ContentLength, 10))
+	}
+	b.WriteString("\r\n")
+	b.WriteString(omittedBodyPlaceholder)
+	return b.String()
+}
+
+// metadataOnlyResponseDump is the response counterpart. The validation result is
+// surfaced on stdout by the command itself, so nothing is lost by keeping the
+// body out of the log.
+func metadataOnlyResponseDump(res *http.Response) string {
+	var b strings.Builder
+	writeMetadataLine(&b, "HTTP/"+strconv.Itoa(res.ProtoMajor)+"."+strconv.Itoa(res.ProtoMinor)+" "+res.Status)
+	writeRedactedHeaders(&b, res.Header)
+	if res.ContentLength > 0 {
+		writeMetadataLine(&b, "Content-Length: "+strconv.FormatInt(res.ContentLength, 10))
+	}
+	b.WriteString("\r\n")
+	b.WriteString(omittedBodyPlaceholder)
+	return b.String()
+}
+
+// writeMetadataLine appends one header-shaped line. Values are written with
+// WriteString rather than a format verb so no untrusted value can be treated as
+// a format string, and CR/LF are stripped so a header value cannot forge extra
+// lines in the log.
+func writeMetadataLine(b *strings.Builder, line string) {
+	b.WriteString(strings.NewReplacer("\r", "", "\n", "").Replace(line))
+	b.WriteString("\r\n")
+}
+
+func writeRedactedHeaders(b *strings.Builder, header http.Header) {
+	names := make([]string, 0, len(header))
+	for name := range header {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if _, sensitive := sensitiveHeaders[strings.ToLower(name)]; sensitive {
+			writeMetadataLine(b, name+": "+redactedHeaderPlaceholder)
+			continue
+		}
+		for _, value := range header[name] {
+			writeMetadataLine(b, name+": "+value)
+		}
+	}
+}
 
 // Configure registration api client
 func getV1Client() *openapiclientv1.APIClient {
@@ -105,6 +208,13 @@ func getRetryableHttpClient() *http.Client {
 	httpClient.Logger = NewLeveledLogger()
 	httpClient.RequestLogHook = func(logger retryablehttp.Logger, req *http.Request, retryNumber int) {
 		if config.IsDebugLogLevel() {
+			// Narrow sensitive-body policy: the read-only validation route
+			// carries specification bytes, compose configs/secrets and local
+			// artifact archives, so only its metadata is ever logged.
+			if isSensitiveBodyPath(req.URL) {
+				log.Debug().Msgf("Request %s %s\n%s", req.Method, req.URL, metadataOnlyRequestDump(req))
+				return
+			}
 			dump, err := httputil.DumpRequestOut(req, true)
 			if err != nil {
 				log.Err(err).Msg("Failed to dump request")
@@ -114,6 +224,10 @@ func getRetryableHttpClient() *http.Client {
 	}
 	httpClient.ResponseLogHook = func(logger retryablehttp.Logger, res *http.Response) {
 		if config.IsDebugLogLevel() {
+			if res != nil && res.Request != nil && isSensitiveBodyPath(res.Request.URL) {
+				log.Debug().Msgf("Response %s\n%s", res.Status, metadataOnlyResponseDump(res))
+				return
+			}
 			dump, err := httputil.DumpResponse(res, true)
 			if err != nil {
 				log.Err(err).Msg("Failed to dump response")

--- a/internal/dataaccess/docs_validate_test.go
+++ b/internal/dataaccess/docs_validate_test.go
@@ -1,8 +1,10 @@
 package dataaccess
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -176,4 +178,166 @@ func TestValidateSpecWithSchemaFileRejectsMalformedYAML(t *testing.T) {
 	_, err := ValidateSpecWithSchemaFile("plan.yaml", []byte("name: [unclosed\n"), "service-plan", writeSchema(t))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "plan.yaml")
+}
+
+// servicePlanSchemaFixture is a snapshot of the authoritative ServicePlanSpec schema
+// the platform serves at /schema/service-spec-schema.json. It is generated, never
+// hand-edited; regenerate it after any change to the Go models the schema is
+// reflected from, or to the schema normalization that runs before publication:
+//
+//	cd <workspace>/ows-orchestration
+//	SERVICE_PLAN_SCHEMA_FIXTURE=<workspace>/ctl/internal/dataaccess/testdata/service-plan-schema.json \
+//	  go test ./v1/pkg/registration/service/servicebuild/serviceplan/ \
+//	    -run TestWriteServicePlanSchemaFixture -count=1
+//
+// That generator reads extension.GetSchemaJSON("service-plan"), the same accessor the
+// schema endpoint returns, so the fixture cannot drift from what a user downloads.
+const servicePlanSchemaFixture = "testdata/service-plan-schema.json"
+
+// helmPlanSpec renders a minimal valid plan whose single service is a Helm chart with
+// the given source block, so a verdict can only come from the source rules.
+func helmPlanSpec(sourceBlock string) []byte {
+	lines := strings.Split(strings.TrimRight(sourceBlock, "\n"), "\n")
+	for i, line := range lines {
+		if line != "" {
+			lines[i] = "      " + line
+		}
+	}
+
+	return []byte(`name: Helm Source Plan
+tenancyType: OMNISTRATE_DEDICATED_TENANCY
+services:
+  - name: Chart
+    helmChartConfiguration:
+` + strings.Join(lines, "\n") + "\n")
+}
+
+// TestValidateSpec_HelmArtifactSource is the CLI half of the Helm source alignment:
+// `omnistrate-ctl docs validate` has to accept exactly the specs the platform builds.
+// It is structural validation, so no artifact needs to exist or have been uploaded.
+func TestValidateSpec_HelmArtifactSource(t *testing.T) {
+	tests := []struct {
+		name       string
+		sourceYAML string
+		valid      bool
+	}{
+		{
+			name: "repository backed chart",
+			sourceYAML: `chartName: nginx
+chartVersion: 1.0.0
+chartRepoName: bitnami
+chartRepoURL: https://charts.bitnami.com/bitnami`,
+			valid: true,
+		},
+		{
+			name:       "artifact backed chart with a relative path",
+			sourceYAML: `artifactRelativePath: charts/my-chart.tgz`,
+			valid:      true,
+		},
+		{
+			name:       "artifact backed chart with the legacy alias",
+			sourceYAML: `artifactsLocalPath: ./charts/my-chart.tgz`,
+			valid:      true,
+		},
+		{
+			name: "artifact backed chart may still name the chart",
+			sourceYAML: `artifactRelativePath: charts/my-chart.tgz
+chartName: my-chart
+chartVersion: 0.1.0`,
+			valid: true,
+		},
+		{
+			name: "artifact backed chart with blank repository fields",
+			sourceYAML: `artifactRelativePath: charts/my-chart.tgz
+chartRepoName: ""
+chartRepoURL: "  "`,
+			valid: true,
+		},
+		{
+			name: "repository backed chart missing its repository url",
+			sourceYAML: `chartName: nginx
+chartVersion: 1.0.0
+chartRepoName: bitnami`,
+		},
+		{
+			name: "repository backed chart with a whitespace-only repository name",
+			sourceYAML: `chartName: nginx
+chartVersion: 1.0.0
+chartRepoName: "   "
+chartRepoURL: https://charts.bitnami.com/bitnami`,
+		},
+		{
+			name: "mixed repository and artifact source",
+			sourceYAML: `artifactRelativePath: charts/my-chart.tgz
+chartName: nginx
+chartVersion: 1.0.0
+chartRepoName: bitnami
+chartRepoURL: https://charts.bitnami.com/bitnami`,
+		},
+		{
+			name: "artifact source with a repository name only",
+			sourceYAML: `artifactRelativePath: charts/my-chart.tgz
+chartRepoName: bitnami`,
+		},
+		{
+			name: "both artifact aliases set",
+			sourceYAML: `artifactRelativePath: charts/my-chart.tgz
+artifactsLocalPath: /local/charts/my-chart.tgz`,
+		},
+		{
+			name: "both artifact aliases set to the same path",
+			sourceYAML: `artifactRelativePath: charts/my-chart.tgz
+artifactsLocalPath: charts/my-chart.tgz`,
+		},
+		{
+			name: "artifact source with repository credentials",
+			sourceYAML: `artifactRelativePath: charts/my-chart.tgz
+authProvider:
+  username: user
+  password: secret`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := ValidateSpecWithSchemaFile("plan.yaml", helmPlanSpec(test.sourceYAML),
+				"service-plan", servicePlanSchemaFixture)
+			require.NoError(t, err)
+			assert.Equal(t, test.valid, result.Valid, "violations: %+v", result.Violations)
+		})
+	}
+}
+
+// TestValidateSpec_HelmArtifactSourceFixtureIsUsable compiles the generated fixture
+// and checks it is the corrected schema, so a stale or partially regenerated snapshot
+// fails loudly instead of quietly passing every case above.
+func TestValidateSpec_HelmArtifactSourceFixtureIsUsable(t *testing.T) {
+	raw, err := os.ReadFile(servicePlanSchemaFixture)
+	require.NoError(t, err)
+
+	var document map[string]any
+	require.NoError(t, json.Unmarshal(raw, &document))
+
+	definitions, ok := document["$defs"].(map[string]any)
+	require.True(t, ok, "expected $defs in the generated fixture")
+
+	helmChart, ok := definitions["HelmChartConfiguration"].(map[string]any)
+	require.True(t, ok, "expected a HelmChartConfiguration definition")
+	assert.NotContains(t, helmChart, "required",
+		"the repository coordinates must not be unconditionally required")
+
+	alternatives, ok := helmChart["allOf"].([]any)
+	require.True(t, ok, "expected the source rule under allOf")
+	require.Len(t, alternatives, 1)
+	branches, ok := alternatives[0].(map[string]any)["oneOf"].([]any)
+	require.True(t, ok)
+	assert.Len(t, branches, 3, "repository, artifactRelativePath and artifactsLocalPath")
+
+	// An escaped backslash-u would match the letter "u" rather than whitespace.
+	assert.NotContains(t, string(raw), `\\u`)
+
+	// Operator Helm dependencies must not have been relaxed along with the chart.
+	operator, ok := definitions["OperatorHelmChartDependency"].(map[string]any)
+	require.True(t, ok)
+	assert.Len(t, operator["required"], 4)
 }

--- a/internal/dataaccess/service.go
+++ b/internal/dataaccess/service.go
@@ -3,6 +3,7 @@ package dataaccess
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	openapiclient "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
 )
@@ -96,6 +97,98 @@ func BuildServiceFromServicePlanSpec(ctx context.Context, token string, request 
 	}()
 	if err != nil {
 		return nil, handleV1Error(err)
+	}
+
+	return resp, nil
+}
+
+// ValidationSpecTypeServicePlan and ValidationSpecTypeCompose are the only two
+// values the validation endpoint accepts for ValidateServiceSpecRequest2.SpecType.
+const (
+	ValidationSpecTypeServicePlan = "service-plan"
+	ValidationSpecTypeCompose     = "compose"
+)
+
+// ValidationStatus values returned by the read-only validation endpoint.
+const (
+	ValidationStatusValid      = "VALID"
+	ValidationStatusInvalid    = "INVALID"
+	ValidationStatusIncomplete = "INCOMPLETE"
+)
+
+// ValidationArtifactEncoding is the single permitted encoding for artifact
+// content supplied to the validation endpoint.
+const ValidationArtifactEncoding = "tar+gzip+base64"
+
+// ValidateServiceSpecError wraps a failed ValidateServiceSpec call and preserves
+// the HTTP status code, which handleV1Error otherwise discards. The build
+// --dry-run route needs the status to distinguish "this server has no read-only
+// validation endpoint" (404/405) from a genuine authentication or transport
+// failure, without ever falling back to the legacy build endpoints.
+type ValidateServiceSpecError struct {
+	// StatusCode is the HTTP status, or 0 when the request never got a response.
+	StatusCode int
+	Err        error
+}
+
+func (e *ValidateServiceSpecError) Error() string {
+	if e == nil || e.Err == nil {
+		return "validate service spec failed"
+	}
+	return e.Err.Error()
+}
+
+func (e *ValidateServiceSpecError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// ServerLacksValidationEndpoint reports whether the server answered in a way
+// that means the read-only validation route is not deployed there.
+func (e *ValidateServiceSpecError) ServerLacksValidationEndpoint() bool {
+	if e == nil {
+		return false
+	}
+	return e.StatusCode == http.StatusNotFound || e.StatusCode == http.StatusMethodNotAllowed
+}
+
+// ValidateServiceSpec performs one read-only specification validation request.
+// It creates, updates, releases, promotes and publishes nothing: the endpoint is
+// the only server interaction the build --dry-run route is permitted to make.
+//
+// The request body carries specification bytes, compose configs/secrets and
+// local artifact archives, so it is registered as a sensitive-body route in
+// client.go and is never dumped into debug logs.
+func ValidateServiceSpec(ctx context.Context, token string, request openapiclient.ValidateServiceSpecRequest2) (*openapiclient.ValidateServiceSpecResult, error) {
+	ctxWithToken := context.WithValue(ctx, openapiclient.ContextAccessToken, token)
+	apiClient := getV1Client()
+
+	resp, r, err := apiClient.ServiceApiAPI.ServiceApiValidateServiceSpec(ctxWithToken).
+		ValidateServiceSpecRequest2(request).
+		Execute()
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+	if err != nil {
+		statusCode := 0
+		if r != nil {
+			statusCode = r.StatusCode
+		}
+		return nil, &ValidateServiceSpecError{StatusCode: statusCode, Err: handleV1Error(err)}
+	}
+	if resp == nil {
+		statusCode := 0
+		if r != nil {
+			statusCode = r.StatusCode
+		}
+		return nil, &ValidateServiceSpecError{
+			StatusCode: statusCode,
+			Err:        fmt.Errorf("empty response from the validation endpoint"),
+		}
 	}
 
 	return resp, nil

--- a/internal/dataaccess/service_validation_test.go
+++ b/internal/dataaccess/service_validation_test.go
@@ -1,0 +1,499 @@
+package dataaccess
+
+// SDK wire-contract evidence for specification 02 —
+// dry-run-implementation-specs/02-regression-tests.md.
+//
+// These tests pin the request serialisation of the two calls that
+// `omnistrate-ctl build --dry-run` makes today against a local httptest.Server.
+// They are deliberately untagged and green: they document the current contract
+// so that spec 04 cannot change it by accident, and they supply the
+// deterministic-request-count and no-real-network guarantees that 02 requires of
+// the CLI suite.
+//
+// The read-only ValidateServiceSpec wrapper specified in 03/04 does not exist
+// yet. Its CLI-level contract is asserted from cmd/build/dry_run_target_test.go
+// behind the `dryrun_target` build tag; there is nothing here to call until the
+// generated SDK ships the new operation.
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	openapiclient "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/require"
+)
+
+const validationTestToken = "dry-run-wire-token" //nolint:gosec // G101: fixed fake token used only by the local test server
+
+type capturedRequest struct {
+	Method string
+	Path   string
+	Auth   string
+	Body   map[string]any
+	Raw    []byte
+}
+
+type validationTestServer struct {
+	mu       sync.Mutex
+	requests []capturedRequest
+	// violations is written from the handler goroutine and asserted on the main
+	// goroutine; the handler never calls require.FailNow.
+	violations []string
+	respond    func(n int, w http.ResponseWriter)
+}
+
+func (s *validationTestServer) record(w http.ResponseWriter, r *http.Request) {
+	raw, err := io.ReadAll(r.Body)
+
+	s.mu.Lock()
+	if err != nil {
+		s.violations = append(s.violations, "failed to read request body: "+err.Error())
+	}
+	captured := capturedRequest{
+		Method: r.Method,
+		Path:   r.URL.Path,
+		Auth:   r.Header.Get("Authorization"),
+		Raw:    raw,
+	}
+	if len(raw) > 0 {
+		if decodeErr := json.Unmarshal(raw, &captured.Body); decodeErr != nil {
+			s.violations = append(s.violations, "request body is not JSON: "+decodeErr.Error())
+		}
+	}
+	s.requests = append(s.requests, captured)
+	n := len(s.requests) - 1
+	respond := s.respond
+	s.mu.Unlock()
+
+	respond(n, w)
+}
+
+func (s *validationTestServer) snapshot() []capturedRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]capturedRequest, len(s.requests))
+	copy(out, s.requests)
+	return out
+}
+
+func (s *validationTestServer) assertNoViolations(t *testing.T) {
+	t.Helper()
+	s.mu.Lock()
+	violations := append([]string(nil), s.violations...)
+	s.mu.Unlock()
+	require.Empty(t, violations)
+}
+
+// startValidationWireServer points the SDK clients at a local server and turns
+// retries off so request counts are exact.
+func startValidationWireServer(t *testing.T, respond func(n int, w http.ResponseWriter)) *validationTestServer {
+	t.Helper()
+
+	srv := &validationTestServer{respond: respond}
+	httpServer := httptest.NewServer(http.HandlerFunc(srv.record))
+	t.Cleanup(httpServer.Close)
+
+	parsed, err := url.Parse(httpServer.URL)
+	require.NoError(t, err)
+
+	t.Setenv("OMNISTRATE_HOST", parsed.Host)
+	t.Setenv("OMNISTRATE_HOST_SCHEME", parsed.Scheme)
+	t.Setenv("OMNISTRATE_RETRY_MAX", "0")
+	t.Setenv("OMNISTRATE_RETRY_WAIT_MIN_IN_SECONDS", "0")
+	t.Setenv("OMNISTRATE_RETRY_WAIT_MAX_IN_SECONDS", "0")
+	t.Setenv("OMNISTRATE_CLIENT_TIMEOUT_IN_SECONDS", "20")
+
+	return srv
+}
+
+func okJSON(payload any) func(int, http.ResponseWriter) {
+	return func(_ int, w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(payload)
+	}
+}
+
+// TestPrepareServicePlanSpecDryRunValidationHasNoDryRunField documents the root
+// cause recorded in ctl-build-dry-run-investigation.md: the prepare request that
+// CTL sends before a dry run cannot express that it is only validating, so the
+// backend legitimately treats it as a real preparation.
+func TestPrepareServicePlanSpecDryRunValidationHasNoDryRunField(t *testing.T) {
+	srv := startValidationWireServer(t, okJSON(map[string]any{
+		"serviceID":               "s-1",
+		"serviceEnvironmentID":    "se-1",
+		"productTierID":           "pt-1",
+		"isNewProductTierCreated": false,
+	}))
+
+	spec := []byte("name: plan\n")
+	_, err := PrepareServiceFromServicePlanSpec(context.Background(), validationTestToken,
+		openapiclient.PrepareServiceFromServicePlanSpecRequest2{
+			Name:            "Wire Contract Service",
+			Environment:     "Dev",
+			EnvironmentType: "DEV",
+			FileContent:     base64.StdEncoding.EncodeToString(spec),
+		})
+	require.NoError(t, err)
+	srv.assertNoViolations(t)
+
+	requests := srv.snapshot()
+	require.Len(t, requests, 1, "retries are disabled, so exactly one request is expected")
+	require.Equal(t, http.MethodPut, requests[0].Method)
+	require.Equal(t, "/2022-09-01-00/service/serviceplanspec/prepare", requests[0].Path)
+	require.Equal(t, "Bearer "+validationTestToken, requests[0].Auth)
+
+	for key := range requests[0].Body {
+		require.NotContains(t, key, "dryrun")
+		require.NotContains(t, key, "dryRun")
+	}
+	require.Equal(t, base64.StdEncoding.EncodeToString(spec), requests[0].Body["fileContent"])
+}
+
+// TestBuildServicePlanSpecDryRunValidationForwardsDryrunFlag pins the wire name
+// and value of the flag the SDK sends for a ServicePlanSpec dry run.
+func TestBuildServicePlanSpecDryRunValidationForwardsDryrunFlag(t *testing.T) {
+	srv := startValidationWireServer(t, okJSON(map[string]any{
+		"serviceID":            "s-1",
+		"serviceEnvironmentID": "se-1",
+		"productTierID":        "pt-1",
+	}))
+
+	spec := []byte("name: plan\n")
+	_, err := BuildServiceFromServicePlanSpec(context.Background(), validationTestToken,
+		openapiclient.BuildServiceFromServicePlanSpecRequest2{
+			Name:               "Wire Contract Service",
+			FileContent:        base64.StdEncoding.EncodeToString(spec),
+			Dryrun:             ptr(true),
+			Release:            ptr(false),
+			ReleaseAsPreferred: ptr(false),
+		})
+	require.NoError(t, err)
+	srv.assertNoViolations(t)
+
+	requests := srv.snapshot()
+	require.Len(t, requests, 1)
+	require.Equal(t, http.MethodPut, requests[0].Method)
+	require.Equal(t, "/2022-09-01-00/service/serviceplanspec", requests[0].Path)
+	require.Equal(t, true, requests[0].Body["dryrun"])
+	require.Equal(t, false, requests[0].Body["release"], "false flags must be sent explicitly")
+	require.Equal(t, false, requests[0].Body["releaseAsPreferred"])
+}
+
+// TestBuildComposeSpecDryRunValidationForwardsDryrunFlag is the Compose
+// counterpart, including the base64 configs/secrets convention that 03 reuses.
+func TestBuildComposeSpecDryRunValidationForwardsDryrunFlag(t *testing.T) {
+	srv := startValidationWireServer(t, okJSON(map[string]any{
+		"serviceID":            "s-1",
+		"serviceEnvironmentID": "se-1",
+		"productTierID":        "pt-1",
+	}))
+
+	configs := map[string]string{"app": base64.StdEncoding.EncodeToString([]byte("conf"))}
+	secrets := map[string]string{"app": base64.StdEncoding.EncodeToString([]byte("secret"))}
+
+	_, err := BuildServiceFromComposeSpec(context.Background(), validationTestToken,
+		openapiclient.BuildServiceFromComposeSpecRequest2{
+			Name:        "Wire Contract Service",
+			FileContent: base64.StdEncoding.EncodeToString([]byte("services: {}\n")),
+			Dryrun:      ptr(true),
+			Configs:     &configs,
+			Secrets:     &secrets,
+		})
+	require.NoError(t, err)
+	srv.assertNoViolations(t)
+
+	requests := srv.snapshot()
+	require.Len(t, requests, 1)
+	require.Equal(t, http.MethodPut, requests[0].Method)
+	require.Equal(t, "/2022-09-01-00/service/composespec", requests[0].Path)
+	require.Equal(t, true, requests[0].Body["dryrun"])
+
+	sentConfigs, ok := requests[0].Body["configs"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, configs["app"], sentConfigs["app"])
+
+	sentSecrets, ok := requests[0].Body["secrets"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, secrets["app"], sentSecrets["app"])
+}
+
+// TestDryRunValidationRetriesAreDisabledForDeterministicCounts proves the test
+// configuration used by the whole 02 CLI suite really does stop retryablehttp
+// from repeating a request. Without this, "exactly one validation request"
+// assertions would be meaningless.
+func TestDryRunValidationRetriesAreDisabledForDeterministicCounts(t *testing.T) {
+	srv := startValidationWireServer(t, func(_ int, w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":        "test-error",
+			"name":      "unavailable",
+			"message":   "try later",
+			"fault":     false,
+			"temporary": true,
+			"timeout":   false,
+		})
+	})
+
+	_, err := BuildServiceFromServicePlanSpec(context.Background(), validationTestToken,
+		openapiclient.BuildServiceFromServicePlanSpecRequest2{
+			Name:        "Wire Contract Service",
+			FileContent: base64.StdEncoding.EncodeToString([]byte("name: plan\n")),
+			Dryrun:      ptr(true),
+		})
+	require.Error(t, err)
+	srv.assertNoViolations(t)
+
+	require.Len(t, srv.snapshot(), 1, "OMNISTRATE_RETRY_MAX=0 must suppress all retries")
+}
+
+// ---------------------------------------------------------------------------
+// ValidateServiceSpec — the read-only route added by spec 04
+// ---------------------------------------------------------------------------
+
+func validationOKResult() map[string]any {
+	return map[string]any{
+		"status":             "VALID",
+		"validationVersion":  "1",
+		"inputDigest":        "0000000000000000000000000000000000000000000000000000000000000000",
+		"checks":             []map[string]any{{"name": "syntax", "status": "PASSED"}},
+		"diagnostics":        []map[string]any{},
+		"requiredArtifacts":  []map[string]any{},
+		"validatedArtifacts": []map[string]any{},
+	}
+}
+
+// TestValidateServiceSpecWireContract pins the request serialisation of the new
+// operation: method, path, auth header, wire field names, explicit false flags
+// and the artifact envelope from 04 §"Wire types".
+func TestValidateServiceSpecWireContract(t *testing.T) {
+	srv := startValidationWireServer(t, okJSON(validationOKResult()))
+
+	spec := []byte("name: plan\n")
+	result, err := ValidateServiceSpec(context.Background(), validationTestToken,
+		openapiclient.ValidateServiceSpecRequest2{
+			Name:                             "Wire Contract Service",
+			SpecType:                         ValidationSpecTypeServicePlan,
+			FileContent:                      base64.StdEncoding.EncodeToString(spec),
+			Environment:                      ptr("Dev"),
+			EnvironmentType:                  ptr("DEV"),
+			Release:                          ptr(false),
+			ReleaseAsPreferred:               ptr(false),
+			ForceCreateNewServicePlanVersion: ptr(false),
+			Artifacts: []openapiclient.ValidationArtifactInput{{
+				LogicalPath:         "terraform/network",
+				Encoding:            ValidationArtifactEncoding,
+				ArchiveContent:      "H4sIAAAAAAAA",
+				Sha256:              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+				CompressedSizeBytes: 1234,
+			}},
+		})
+	require.NoError(t, err)
+	srv.assertNoViolations(t)
+	require.Equal(t, "VALID", result.Status)
+
+	requests := srv.snapshot()
+	require.Len(t, requests, 1, "retries are disabled, so exactly one request is expected")
+	require.Equal(t, http.MethodPost, requests[0].Method)
+	require.Equal(t, ValidateServiceSpecPath, requests[0].Path)
+	require.Equal(t, "Bearer "+validationTestToken, requests[0].Auth)
+
+	body := requests[0].Body
+	require.Equal(t, "service-plan", body["specType"])
+	require.Equal(t, base64.StdEncoding.EncodeToString(spec), body["fileContent"])
+	require.Equal(t, false, body["release"], "false flags must be sent explicitly")
+	require.Equal(t, false, body["releaseAsPreferred"])
+	require.Equal(t, false, body["forceCreateNewServicePlanVersion"])
+
+	// The validation envelope has no public dry-run flag.
+	for key := range body {
+		require.NotContains(t, key, "dryrun")
+		require.NotContains(t, key, "dryRun")
+	}
+
+	artifacts, ok := body["artifacts"].([]any)
+	require.True(t, ok, "artifacts missing from request body: %v", body)
+	require.Len(t, artifacts, 1)
+	artifact := artifacts[0].(map[string]any)
+	require.Equal(t, "terraform/network", artifact["logicalPath"])
+	require.Equal(t, "tar+gzip+base64", artifact["encoding"])
+	require.Equal(t, "H4sIAAAAAAAA", artifact["archiveContent"])
+	require.Len(t, artifact["sha256"], 64)
+	require.Equal(t, float64(1234), artifact["compressedSizeBytes"])
+}
+
+// TestValidateServiceSpecPreservesTheHTTPStatus proves the wrapper keeps the
+// status handleV1Error would otherwise discard, so the CLI can tell "this server
+// has no validation endpoint" from a genuine authentication failure without ever
+// falling back to a legacy build request.
+func TestValidateServiceSpecPreservesTheHTTPStatus(t *testing.T) {
+	cases := []struct {
+		status      int
+		wantUpgrade bool
+	}{
+		{status: http.StatusNotFound, wantUpgrade: true},
+		{status: http.StatusMethodNotAllowed, wantUpgrade: true},
+		{status: http.StatusUnauthorized},
+		{status: http.StatusForbidden},
+		{status: http.StatusBadRequest},
+	}
+
+	for _, tc := range cases {
+		t.Run(http.StatusText(tc.status), func(t *testing.T) {
+			status := tc.status
+			srv := startValidationWireServer(t, func(_ int, w http.ResponseWriter) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(status)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id": "e", "name": "failed", "message": "no",
+					"fault": false, "temporary": false, "timeout": false,
+				})
+			})
+
+			_, err := ValidateServiceSpec(context.Background(), validationTestToken,
+				openapiclient.ValidateServiceSpecRequest2{
+					Name:        "Wire Contract Service",
+					SpecType:    ValidationSpecTypeCompose,
+					FileContent: base64.StdEncoding.EncodeToString([]byte("services: {}\n")),
+				})
+			require.Error(t, err)
+			srv.assertNoViolations(t)
+
+			var validationErr *ValidateServiceSpecError
+			require.ErrorAs(t, err, &validationErr)
+			require.Equal(t, status, validationErr.StatusCode)
+			require.Equal(t, tc.wantUpgrade, validationErr.ServerLacksValidationEndpoint())
+			require.Len(t, srv.snapshot(), 1, "no retry, no fallback")
+		})
+	}
+}
+
+// TestValidateServiceSpecPostRetryPolicy checks the bounded-retry behaviour of
+// the existing retryPolicy against this POST route: only the transient gateway
+// and rate-limit statuses are repeated, and the request is immutable, so a
+// repeat cannot have a business effect.
+func TestValidateServiceSpecPostRetryPolicy(t *testing.T) {
+	cases := []struct {
+		status       int
+		wantRequests int
+	}{
+		{status: http.StatusServiceUnavailable, wantRequests: 3}, // retried
+		{status: http.StatusTooManyRequests, wantRequests: 3},    // retried
+		{status: http.StatusInternalServerError, wantRequests: 1},
+		{status: http.StatusBadRequest, wantRequests: 1},
+	}
+
+	for _, tc := range cases {
+		t.Run(http.StatusText(tc.status), func(t *testing.T) {
+			status := tc.status
+			srv := startValidationWireServer(t, func(_ int, w http.ResponseWriter) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(status)
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"id": "e", "name": "failed", "message": "no",
+					"fault": false, "temporary": true, "timeout": false,
+				})
+			})
+			t.Setenv("OMNISTRATE_RETRY_MAX", "2")
+
+			_, err := ValidateServiceSpec(context.Background(), validationTestToken,
+				openapiclient.ValidateServiceSpecRequest2{
+					Name:        "Wire Contract Service",
+					SpecType:    ValidationSpecTypeCompose,
+					FileContent: base64.StdEncoding.EncodeToString([]byte("services: {}\n")),
+				})
+			require.Error(t, err)
+			srv.assertNoViolations(t)
+			require.Len(t, srv.snapshot(), tc.wantRequests)
+		})
+	}
+}
+
+// TestValidateServiceSpecDebugLogsOmitTheBody is the secret-sentinel test from
+// 04 §"Output and logging". It is a red/green pair: the same sentinel is sent
+// through the legacy build route, where DumpRequestOut still writes the whole
+// body, and through the validation route, where the narrow policy must keep it
+// out. Without the control the assertion could pass because nothing was logged
+// at all.
+func TestValidateServiceSpecDebugLogsOmitTheBody(t *testing.T) {
+	const sentinel = "SENTINEL-PAYLOAD-9d4e1f7a"
+	payload := base64.StdEncoding.EncodeToString([]byte(sentinel))
+
+	t.Run("ControlLegacyBuildRouteStillDumpsTheBody", func(t *testing.T) {
+		srv := startValidationWireServer(t, okJSON(map[string]any{
+			"serviceID": "s-1", "serviceEnvironmentID": "se-1", "productTierID": "pt-1",
+		}))
+
+		logs := captureDataAccessDebugLogs(t, func() {
+			_, err := BuildServiceFromServicePlanSpec(context.Background(), validationTestToken,
+				openapiclient.BuildServiceFromServicePlanSpecRequest2{
+					Name:        "Wire Contract Service",
+					FileContent: payload,
+				})
+			require.NoError(t, err)
+		})
+		srv.assertNoViolations(t)
+
+		require.Contains(t, logs, payload,
+			"the control must show that debug dumps really do include request bodies")
+	})
+
+	t.Run("ValidationRouteLogsMetadataOnly", func(t *testing.T) {
+		srv := startValidationWireServer(t, okJSON(validationOKResult()))
+
+		logs := captureDataAccessDebugLogs(t, func() {
+			_, err := ValidateServiceSpec(context.Background(), validationTestToken,
+				openapiclient.ValidateServiceSpecRequest2{
+					Name:        "Wire Contract Service",
+					SpecType:    ValidationSpecTypeServicePlan,
+					FileContent: payload,
+					Secrets:     &map[string]string{"app": payload},
+					Artifacts: []openapiclient.ValidationArtifactInput{{
+						LogicalPath:         "terraform/network",
+						Encoding:            ValidationArtifactEncoding,
+						ArchiveContent:      payload,
+						Sha256:              "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+						CompressedSizeBytes: 12,
+					}},
+				})
+			require.NoError(t, err)
+		})
+		srv.assertNoViolations(t)
+
+		require.NotEmpty(t, logs)
+		require.Contains(t, logs, ValidateServiceSpecPath, "request metadata must still be logged")
+		require.Contains(t, logs, "body omitted")
+		require.Contains(t, logs, "[REDACTED]")
+
+		require.NotContains(t, logs, sentinel, "the raw sentinel reached the debug log")
+		require.NotContains(t, logs, payload, "the encoded payload reached the debug log")
+		require.NotContains(t, logs, validationTestToken, "the token reached the debug log")
+		require.NotContains(t, logs, "Bearer ", "the Authorization value reached the debug log")
+	})
+}
+
+// captureDataAccessDebugLogs redirects the global zerolog logger into a buffer
+// and turns on the debug level that gates the request/response dumps.
+func captureDataAccessDebugLogs(t *testing.T, fn func()) string {
+	t.Helper()
+	t.Setenv("OMNISTRATE_LOG_LEVEL", "debug")
+
+	var buf bytes.Buffer
+	original := log.Logger
+	log.Logger = zerolog.New(&buf).Level(zerolog.DebugLevel)
+	t.Cleanup(func() { log.Logger = original })
+
+	fn()
+	return buf.String()
+}

--- a/internal/dataaccess/testdata/service-plan-schema.json
+++ b/internal/dataaccess/testdata/service-plan-schema.json
@@ -1,0 +1,2587 @@
+{
+  "$defs": {
+    "APIParameterConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "defaultValue": {
+          "type": "string"
+        },
+        "dependentResourceKey": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "export": {
+          "type": "boolean"
+        },
+        "key": {
+          "type": "string"
+        },
+        "labeledOptions": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "limits": {
+          "$ref": "#/$defs/Limits"
+        },
+        "modifiable": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "options": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "parameterDependencyMap": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "regex": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "scope": {
+          "$ref": "#/$defs/InputParameterScope"
+        },
+        "type": {
+          "enum": [
+            "boolean",
+            "Boolean",
+            "int",
+            "Int",
+            "int32",
+            "Int32",
+            "int64",
+            "Int64",
+            "uint",
+            "Uint",
+            "uint32",
+            "Uint32",
+            "uint64",
+            "Uint64",
+            "float32",
+            "Float32",
+            "float64",
+            "Float64",
+            "string",
+            "String",
+            "bytes",
+            "Bytes",
+            "json",
+            "Json",
+            "any",
+            "Any",
+            "resource",
+            "Resource",
+            "password",
+            "Password",
+            "secret",
+            "Secret"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "AcceleratorConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "count": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ActionHook": {
+      "additionalProperties": false,
+      "properties": {
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "commandTemplate": {
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "inPod": {
+          "type": "boolean"
+        },
+        "scope": {
+          "enum": [
+            "CLUSTER",
+            "NODE"
+          ],
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "INIT",
+            "ADD",
+            "REMOVE",
+            "PROMOTE",
+            "DEMOTE",
+            "POST_START",
+            "PRE_START",
+            "POST_UPGRADE",
+            "PRE_UPGRADE",
+            "PRE_STOP",
+            "POST_STOP",
+            "HEALTH_CHECK",
+            "READINESS_CHECK",
+            "STARTUP_CHECK",
+            "VALIDATE",
+            "PRE_INSTALL",
+            "POST_INSTALL",
+            "BACKUP"
+          ],
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "AddCapacityWorkflowConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "outputParameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "workflow": {
+          "$ref": "#/$defs/WorkflowSpec"
+        },
+        "workflowFile": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "AgentCodeInterpreterConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "allowedPackages": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "timeout": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "AgentConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "codeInterpreter": {
+          "$ref": "#/$defs/AgentCodeInterpreterConfiguration"
+        },
+        "dockerfile": {
+          "type": "string"
+        },
+        "evaluations": {
+          "items": {
+            "$ref": "#/$defs/AgentEvaluation"
+          },
+          "type": "array"
+        },
+        "memory": {
+          "$ref": "#/$defs/AgentMemoryConfiguration"
+        },
+        "monitoring": {
+          "$ref": "#/$defs/AgentMonitoringConfiguration"
+        },
+        "vectorStore": {
+          "$ref": "#/$defs/AgentVectorStoreConfiguration"
+        }
+      },
+      "type": "object"
+    },
+    "AgentEvaluation": {
+      "additionalProperties": false,
+      "properties": {
+        "metrics": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "schedule": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "AgentMemoryConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "AgentMonitoringConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "AgentVectorStoreConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "Arguments": {
+      "additionalProperties": false,
+      "properties": {
+        "parameters": {
+          "items": {
+            "$ref": "#/$defs/Parameter"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "AutoscalingConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "idleMinutesBeforeScalingDown": {
+          "type": "integer"
+        },
+        "idleThreshold": {
+          "type": "integer"
+        },
+        "maxReplicas": {
+          "$ref": "#/$defs/IntOrString"
+        },
+        "minReplicas": {
+          "$ref": "#/$defs/IntOrString"
+        },
+        "overUtilizedMinutesBeforeScalingUp": {
+          "type": "integer"
+        },
+        "overUtilizedThreshold": {
+          "type": "integer"
+        },
+        "policyType": {
+          "type": "string"
+        },
+        "scalingMetric": {
+          "$ref": "#/$defs/ScalingMetric"
+        }
+      },
+      "type": "object"
+    },
+    "AzureFileShareConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "redundancy": {
+          "type": "string"
+        },
+        "shareQuota": {
+          "type": "integer"
+        },
+        "tier": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "BackupConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "backupPeriodInHours": {
+          "type": "integer"
+        },
+        "backupRetentionInDays": {
+          "type": "integer"
+        },
+        "snapshotBeforeDeletion": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "BackupWorkflowConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "outputParameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "workflow": {
+          "$ref": "#/$defs/WorkflowSpec"
+        },
+        "workflowFile": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "BillingProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "disableInvoiceGeneration": {
+          "type": "boolean"
+        },
+        "enablePaywall": {
+          "type": "boolean"
+        },
+        "externalProductID": {
+          "type": "string"
+        },
+        "isDefault": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "Capabilities": {
+      "additionalProperties": false,
+      "properties": {
+        "autoscaling": {
+          "$ref": "#/$defs/AutoscalingConfiguration"
+        },
+        "backupConfiguration": {
+          "$ref": "#/$defs/BackupConfiguration"
+        },
+        "customDNS": {
+          "$ref": "#/$defs/CustomDNSConfig"
+        },
+        "enableClusterLoadBalancer": {
+          "type": "boolean"
+        },
+        "enableCustomZone": {
+          "type": "boolean"
+        },
+        "enableEndpointPerReplica": {
+          "type": "boolean"
+        },
+        "enableMultiZone": {
+          "type": "boolean"
+        },
+        "enableNodeLoadBalancer": {
+          "type": "boolean"
+        },
+        "enableStableEgressIP": {
+          "type": "boolean"
+        },
+        "httpReverseProxy": {
+          "$ref": "#/$defs/HTTPReverseProxyConfiguration"
+        },
+        "networkType": {
+          "type": "string"
+        },
+        "nodeWarmPool": {
+          "$ref": "#/$defs/NodeWarmPoolConfiguration"
+        },
+        "serverlessConfiguration": {
+          "type": "object"
+        },
+        "serviceAccountPolicies": {
+          "type": "object"
+        },
+        "sidecars": {
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "ChartAffinityControl": {
+      "additionalProperties": false,
+      "properties": {
+        "enableInjection": {
+          "type": "boolean"
+        },
+        "enableSharedHost": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "enableInjection",
+        "enableSharedHost"
+      ],
+      "type": "object"
+    },
+    "Compute": {
+      "additionalProperties": false,
+      "properties": {
+        "autoscalingMaxReplicasAPIParam": {
+          "type": "string"
+        },
+        "autoscalingMinReplicasAPIParam": {
+          "type": "string"
+        },
+        "cpuArchitecture": {
+          "type": "string"
+        },
+        "instanceTypes": {
+          "items": {
+            "$ref": "#/$defs/InstanceTypeConfiguration"
+          },
+          "type": "array"
+        },
+        "limits": {
+          "$ref": "#/$defs/ComputeUnit"
+        },
+        "replicaCount": {
+          "type": "integer"
+        },
+        "replicaCountAPIParam": {
+          "type": "string"
+        },
+        "reservations": {
+          "$ref": "#/$defs/ComputeUnit"
+        },
+        "resourceLimitCPUAPIParam": {
+          "type": "string"
+        },
+        "resourceLimitMemoryAPIParam": {
+          "type": "string"
+        },
+        "resourceRequestCPUAPIParam": {
+          "type": "string"
+        },
+        "resourceRequestMemoryAPIParam": {
+          "type": "string"
+        },
+        "rootVolumeSizeGi": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "ComputeUnit": {
+      "additionalProperties": false,
+      "properties": {
+        "cpu": {
+          "$ref": "#/$defs/Quantity"
+        },
+        "memory": {
+          "$ref": "#/$defs/Quantity"
+        }
+      },
+      "type": "object"
+    },
+    "ConfigurationOverride": {
+      "additionalProperties": false,
+      "properties": {
+        "EphemeralStorageLocalSsdConfig": {
+          "$ref": "#/$defs/EphemeralStorageLocalSsdConfig"
+        },
+        "GpuClusterID": {
+          "type": "string"
+        },
+        "InstanceLifecycleType": {
+          "type": "string"
+        },
+        "LocalNvmeSsdBlockConfig": {
+          "$ref": "#/$defs/LocalNvmeSsdBlockConfig"
+        },
+        "OsFamily": {
+          "type": "string"
+        },
+        "RootVolumeSizeGi": {
+          "type": "integer"
+        },
+        "RootVolumeSizeGiAPIParam": {
+          "type": "string"
+        },
+        "WarmPoolConfiguration": {
+          "$ref": "#/$defs/WarmPoolConfiguration"
+        },
+        "acceleratorConfiguration": {
+          "$ref": "#/$defs/AcceleratorConfiguration"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "migProfile": {
+          "type": "string"
+        },
+        "taints": {
+          "items": {
+            "$ref": "#/$defs/TaintConfiguration"
+          },
+          "type": "array"
+        },
+        "timeSlicingReplicas": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "ContainerImage": {
+      "additionalProperties": false,
+      "properties": {
+        "imageName": {
+          "type": "string"
+        },
+        "imageTag": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ContainerImagesRegistry": {
+      "additionalProperties": false,
+      "properties": {
+        "credentials": {
+          "$ref": "#/$defs/ContainerImagesRegistryCredentials"
+        },
+        "registryUrl": {
+          "type": "string"
+        },
+        "repositoryName": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ContainerImagesRegistryCopyConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "images": {
+          "items": {
+            "$ref": "#/$defs/ContainerImage"
+          },
+          "type": "array"
+        },
+        "pullMode": {
+          "type": "string"
+        },
+        "pullSource": {
+          "$ref": "#/$defs/ContainerImagesRegistry"
+        },
+        "pushTarget": {
+          "$ref": "#/$defs/ContainerImagesRegistry"
+        }
+      },
+      "type": "object"
+    },
+    "ContainerImagesRegistryCredentials": {
+      "additionalProperties": false,
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "CreateWorkflowConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "outputParameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "workflow": {
+          "$ref": "#/$defs/WorkflowSpec"
+        },
+        "workflowFile": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "CustomDNSConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "Name": {
+          "type": "string"
+        },
+        "TargetKubernetesService": {
+          "$ref": "#/$defs/KubernetesServiceConfig"
+        },
+        "TargetPort": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "CustomMeteringConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "metrics": {
+          "items": {
+            "$ref": "#/$defs/CustomMeteringMetric"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "metrics"
+      ],
+      "type": "object"
+    },
+    "CustomMeteringMetric": {
+      "additionalProperties": false,
+      "properties": {
+        "aggregationFunction": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "aggregationFunction"
+      ],
+      "type": "object"
+    },
+    "CustomServicePlanSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "billingProductID": {
+          "type": "string"
+        },
+        "billingProviders": {
+          "items": {
+            "$ref": "#/$defs/BillingProvider"
+          },
+          "type": "array"
+        },
+        "customMetering": {
+          "$ref": "#/$defs/CustomMeteringConfiguration"
+        },
+        "customWorkflows": {
+          "items": {
+            "$ref": "#/$defs/CustomWorkflowConfiguration"
+          },
+          "type": "array"
+        },
+        "deployment": {
+          "additionalProperties": false,
+          "properties": {
+            "byoaDeployment": {
+              "$ref": "#/$defs/Deployment"
+            },
+            "hostedDeployment": {
+              "$ref": "#/$defs/Deployment"
+            },
+            "onPremCopilotDeployment": {
+              "$ref": "#/$defs/Deployment"
+            },
+            "onPremDeployment": {
+              "$ref": "#/$defs/OnPremDeployment"
+            }
+          },
+          "type": "object"
+        },
+        "enableDeletionProtection": {
+          "type": "boolean"
+        },
+        "features": {
+          "additionalProperties": {
+            "type": "object"
+          },
+          "type": "object"
+        },
+        "loadBalancers": {
+          "$ref": "#/$defs/OmnistrateLoadBalancer"
+        },
+        "maxNumberOfInstancesAllowed": {
+          "type": "integer"
+        },
+        "metering": {
+          "$ref": "#/$defs/MeteringConfiguration"
+        },
+        "name": {
+          "type": "string"
+        },
+        "pricing": {
+          "items": {
+            "$ref": "#/$defs/DimensionPricing"
+          },
+          "type": "array"
+        },
+        "services": {
+          "items": {
+            "$ref": "#/$defs/ResourceConfiguration"
+          },
+          "type": "array"
+        },
+        "sharedFileSystems": {
+          "items": {
+            "$ref": "#/$defs/SharedFileSystemConfiguration"
+          },
+          "type": "array"
+        },
+        "systemWorkflows": {
+          "$ref": "#/$defs/SystemWorkflowsConfiguration"
+        },
+        "tenancyType": {
+          "type": "string"
+        },
+        "validPaymentMethodRequired": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "services"
+      ],
+      "type": "object"
+    },
+    "CustomWorkflowConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "apiParameters": {
+          "items": {
+            "$ref": "#/$defs/WorkflowParameter"
+          },
+          "type": "array"
+        },
+        "description": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "outputParameterSpecs": {
+          "items": {
+            "$ref": "#/$defs/WorkflowOutputParameterSpec"
+          },
+          "type": "array"
+        },
+        "outputParameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "scope": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "verb": {
+          "type": "string"
+        },
+        "workflow": {
+          "$ref": "#/$defs/WorkflowSpec"
+        },
+        "workflowFile": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "verb",
+        "displayName"
+      ],
+      "type": "object"
+    },
+    "DAGTask": {
+      "additionalProperties": false,
+      "properties": {
+        "arguments": {
+          "$ref": "#/$defs/Arguments"
+        },
+        "dependencies": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "template": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "template"
+      ],
+      "type": "object"
+    },
+    "DAGTemplate": {
+      "additionalProperties": false,
+      "properties": {
+        "failFast": {
+          "type": "boolean"
+        },
+        "tasks": {
+          "items": {
+            "$ref": "#/$defs/DAGTask"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "tasks"
+      ],
+      "type": "object"
+    },
+    "DeleteBackupWorkflowConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "outputParameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "workflow": {
+          "$ref": "#/$defs/WorkflowSpec"
+        },
+        "workflowFile": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "DeleteWorkflowConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "outputParameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "workflow": {
+          "$ref": "#/$defs/WorkflowSpec"
+        },
+        "workflowFile": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Deployment": {
+      "additionalProperties": false,
+      "properties": {
+        "awsAccountId": {
+          "type": "string"
+        },
+        "awsBootstrapRoleAccountArn": {
+          "type": "string"
+        },
+        "azureSubscriptionId": {
+          "type": "string"
+        },
+        "azureTenantId": {
+          "type": "string"
+        },
+        "cluster_name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "gcpProjectId": {
+          "type": "string"
+        },
+        "gcpProjectNumber": {
+          "type": "string"
+        },
+        "gcpServiceAccountEmail": {
+          "type": "string"
+        },
+        "nebiusTenantId": {
+          "type": "string"
+        },
+        "ociDomainId": {
+          "type": "string"
+        },
+        "ociTenancyId": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "DeploymentRequirements": {
+      "additionalProperties": false,
+      "properties": {
+        "minimumK8sVersion": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "DeploymentTarget": {
+      "additionalProperties": false,
+      "properties": {
+        "account": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "DimensionPricing": {
+      "additionalProperties": false,
+      "properties": {
+        "dimension": {
+          "type": "string"
+        },
+        "price": {
+          "type": "number"
+        },
+        "timeUnit": {
+          "type": "string"
+        },
+        "unit": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "EFSFileSystemConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "performanceMode": {
+          "type": "string"
+        },
+        "provisionedThroughputInMibps": {
+          "type": "number"
+        },
+        "throughputMode": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "EndpointConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "disableMonitoring": {
+          "type": "boolean"
+        },
+        "host": {
+          "type": "string"
+        },
+        "networkingType": {
+          "type": "string"
+        },
+        "portExpressions": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ports": {
+          "$ref": "#/$defs/PortList"
+        },
+        "primary": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "EphemeralStorageLocalSsdConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "dataCacheCount": {
+          "type": "integer"
+        },
+        "localSsdCount": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "FailoverWorkflowConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "outputParameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "workflow": {
+          "$ref": "#/$defs/WorkflowSpec"
+        },
+        "workflowFile": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "FileSystemConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "azureFileShareConfig": {
+          "$ref": "#/$defs/AzureFileShareConfig"
+        },
+        "efsFileSystemConfig": {
+          "$ref": "#/$defs/EFSFileSystemConfig"
+        },
+        "gcpFilestoreConfig": {
+          "$ref": "#/$defs/GCPFilestoreConfig"
+        },
+        "nebiusFileSystemConfig": {
+          "$ref": "#/$defs/NebiusFileSystemConfig"
+        }
+      },
+      "type": "object"
+    },
+    "Files": {
+      "additionalProperties": false,
+      "properties": {
+        "content": {
+          "contentEncoding": "base64",
+          "type": "string"
+        },
+        "mountPath": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "mountPath",
+        "content"
+      ],
+      "type": "object"
+    },
+    "GCPFilestoreConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "capacity": {
+          "type": "string"
+        },
+        "max_iops_per_tb": {
+          "type": "integer"
+        },
+        "tier": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "GenericMap": {
+      "type": "object"
+    },
+    "GitConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "accessToken": {
+          "type": "string"
+        },
+        "commitSHA": {
+          "type": "string"
+        },
+        "reference": {
+          "type": "string"
+        },
+        "repositoryUrl": {
+          "type": "string"
+        },
+        "userName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "repositoryUrl"
+      ],
+      "type": "object"
+    },
+    "HTTPReverseProxyConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "targetPort": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "HelmChartConfiguration": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "$comment": "omnistrate: helm chart source alternatives",
+          "oneOf": [
+            {
+              "description": "The chart is pulled from a Helm repository, so its name, version, repository name and repository URL are all required and neither local artifact path may be set.",
+              "properties": {
+                "artifactRelativePath": {
+                  "const": ""
+                },
+                "artifactsLocalPath": {
+                  "const": ""
+                },
+                "chartName": {
+                  "pattern": "[^\t-\r    - \u2028\u2029  　]",
+                  "type": "string"
+                },
+                "chartRepoName": {
+                  "pattern": "[^\t-\r    - \u2028\u2029  　]",
+                  "type": "string"
+                },
+                "chartRepoURL": {
+                  "pattern": "[^\t-\r    - \u2028\u2029  　]",
+                  "type": "string"
+                },
+                "chartVersion": {
+                  "pattern": "[^\t-\r    - \u2028\u2029  　]",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "chartName",
+                "chartVersion",
+                "chartRepoName",
+                "chartRepoURL"
+              ],
+              "title": "Helm repository source"
+            },
+            {
+              "description": "The chart is packaged as a deployment artifact, so repository coordinates and repository credentials do not apply and the chart name and version are read from the chart itself. Only one of artifactRelativePath and artifactsLocalPath may be set.",
+              "properties": {
+                "artifactRelativePath": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "artifactsLocalPath": {
+                  "const": ""
+                },
+                "authProvider": {
+                  "properties": {
+                    "password": {
+                      "pattern": "^[\t-\r    - \u2028\u2029  　]*$",
+                      "type": "string"
+                    },
+                    "username": {
+                      "pattern": "^[\t-\r    - \u2028\u2029  　]*$",
+                      "type": "string"
+                    }
+                  }
+                },
+                "chartRepoName": {
+                  "pattern": "^[\t-\r    - \u2028\u2029  　]*$",
+                  "type": "string"
+                },
+                "chartRepoURL": {
+                  "pattern": "^[\t-\r    - \u2028\u2029  　]*$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "artifactRelativePath"
+              ],
+              "title": "Helm deployment artifact source (artifactRelativePath)"
+            },
+            {
+              "description": "The chart is packaged as a deployment artifact, so repository coordinates and repository credentials do not apply and the chart name and version are read from the chart itself. Only one of artifactRelativePath and artifactsLocalPath may be set.",
+              "properties": {
+                "artifactRelativePath": {
+                  "const": ""
+                },
+                "artifactsLocalPath": {
+                  "minLength": 1,
+                  "type": "string"
+                },
+                "authProvider": {
+                  "properties": {
+                    "password": {
+                      "pattern": "^[\t-\r    - \u2028\u2029  　]*$",
+                      "type": "string"
+                    },
+                    "username": {
+                      "pattern": "^[\t-\r    - \u2028\u2029  　]*$",
+                      "type": "string"
+                    }
+                  }
+                },
+                "chartRepoName": {
+                  "pattern": "^[\t-\r    - \u2028\u2029  　]*$",
+                  "type": "string"
+                },
+                "chartRepoURL": {
+                  "pattern": "^[\t-\r    - \u2028\u2029  　]*$",
+                  "type": "string"
+                }
+              },
+              "required": [
+                "artifactsLocalPath"
+              ],
+              "title": "Helm deployment artifact source (artifactsLocalPath)"
+            }
+          ]
+        }
+      ],
+      "properties": {
+        "artifactRelativePath": {
+          "type": "string"
+        },
+        "artifactsLocalPath": {
+          "type": "string"
+        },
+        "authProvider": {
+          "$ref": "#/$defs/HelmRepoAuthProvider"
+        },
+        "autoDiscoverImagesTag": {
+          "type": "string"
+        },
+        "chartAffinityControl": {
+          "$ref": "#/$defs/ChartAffinityControl"
+        },
+        "chartName": {
+          "type": "string"
+        },
+        "chartRepoName": {
+          "type": "string"
+        },
+        "chartRepoURL": {
+          "type": "string"
+        },
+        "chartValues": {
+          "$ref": "#/$defs/GenericMap"
+        },
+        "chartVersion": {
+          "type": "string"
+        },
+        "disableReconciliation": {
+          "type": "boolean"
+        },
+        "layeredChartValues": {
+          "items": {
+            "$ref": "#/$defs/LayeredChartValuesRef"
+          },
+          "type": "array"
+        },
+        "namespace": {
+          "type": "string"
+        },
+        "releaseName": {
+          "type": "string"
+        },
+        "runtimeConfiguration": {
+          "$ref": "#/$defs/HelmRuntimeConfiguration"
+        }
+      },
+      "type": "object"
+    },
+    "HelmRepoAuthProvider": {
+      "additionalProperties": false,
+      "properties": {
+        "password": {
+          "type": "string"
+        },
+        "username": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "username",
+        "password"
+      ],
+      "type": "object"
+    },
+    "HelmRuntimeConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "disableHooks": {
+          "type": "boolean"
+        },
+        "disableReconciliation": {
+          "type": "boolean"
+        },
+        "recreate": {
+          "type": "boolean"
+        },
+        "resetThenReuseValues": {
+          "type": "boolean"
+        },
+        "resetValues": {
+          "type": "boolean"
+        },
+        "reuseValues": {
+          "type": "boolean"
+        },
+        "skipCRDs": {
+          "type": "boolean"
+        },
+        "timeoutNanos": {
+          "type": "integer"
+        },
+        "upgradeCRDs": {
+          "type": "boolean"
+        },
+        "wait": {
+          "type": "boolean"
+        },
+        "waitForJobs": {
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "InputParameterScope": {
+      "additionalProperties": false,
+      "properties": {
+        "cloudProviders": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "Inputs": {
+      "additionalProperties": false,
+      "properties": {
+        "parameters": {
+          "items": {
+            "$ref": "#/$defs/Parameter"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "InstanceTypeConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "apiParam": {
+          "type": "string"
+        },
+        "cloudProvider": {
+          "enum": [
+            "aws",
+            "azure",
+            "gcp",
+            "oci",
+            "nebius",
+            "generic",
+            "private",
+            "byoc-onprem",
+            "all"
+          ],
+          "type": "string"
+        },
+        "configurationOverrides": {
+          "$ref": "#/$defs/ConfigurationOverride"
+        },
+        "name": {
+          "type": "string"
+        },
+        "platform": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "IntOrString": {
+      "additionalProperties": false,
+      "properties": {
+        "IntVal": {
+          "type": "integer"
+        },
+        "StrVal": {
+          "type": "string"
+        },
+        "Type": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "Type",
+        "IntVal",
+        "StrVal"
+      ],
+      "type": "object"
+    },
+    "JobResourceConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "activeDeadlineSeconds": {
+          "type": "integer"
+        },
+        "backoffLimit": {
+          "type": "integer"
+        },
+        "scheduleConfig": {
+          "$ref": "#/$defs/ScheduleConfig"
+        }
+      },
+      "type": "object"
+    },
+    "KubernetesServiceConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "TargetName": {
+          "type": "string"
+        },
+        "TargetPort": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "KustomizeConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "artifactsLocalPath": {
+          "type": "string"
+        },
+        "disableReconciliation": {
+          "type": "boolean"
+        },
+        "gitConfiguration": {
+          "$ref": "#/$defs/GitConfiguration"
+        },
+        "kustomizePath": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "kustomizePath"
+      ],
+      "type": "object"
+    },
+    "L4LoadBalancerConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "ports": {
+          "items": {
+            "$ref": "#/$defs/L4LoadBalancerPortConfiguration"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "ports"
+      ],
+      "type": "object"
+    },
+    "L4LoadBalancerPortConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "associatedResourceKeys": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "backendPort": {
+          "type": "integer"
+        },
+        "ingressPort": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "associatedResourceKeys",
+        "backendPort",
+        "ingressPort"
+      ],
+      "type": "object"
+    },
+    "L7LoadBalancerConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "enableCustomDNS": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        },
+        "paths": {
+          "items": {
+            "$ref": "#/$defs/L7LoadBalancerPathConfiguration"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "paths"
+      ],
+      "type": "object"
+    },
+    "L7LoadBalancerPathConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "associatedResourceKey": {
+          "type": "string"
+        },
+        "backendPort": {
+          "type": "integer"
+        },
+        "path": {
+          "type": "string"
+        },
+        "targetKubernetesServiceName": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "associatedResourceKey",
+        "path",
+        "backendPort"
+      ],
+      "type": "object"
+    },
+    "LayeredChartValuesRef": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "scope": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "values": true,
+        "valuesFile": {
+          "$ref": "#/$defs/ValuesFile"
+        }
+      },
+      "type": "object"
+    },
+    "Limits": {
+      "additionalProperties": false,
+      "properties": {
+        "max": {
+          "type": "integer"
+        },
+        "maxLength": {
+          "type": "integer"
+        },
+        "min": {
+          "type": "integer"
+        },
+        "minLength": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "LocalNvmeSsdBlockConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "localSsdCount": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "MeteringConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "gcsBucketName": {
+          "type": "string"
+        },
+        "s3BucketArn": {
+          "type": "string"
+        },
+        "s3BucketRegion": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ModifyWorkflowConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "outputParameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "workflow": {
+          "$ref": "#/$defs/WorkflowSpec"
+        },
+        "workflowFile": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "NebiusFileSystemConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "filesystemType": {
+          "type": "string"
+        },
+        "sizeGibibytes": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "Network": {
+      "additionalProperties": false,
+      "properties": {
+        "namedPorts": {
+          "type": "object"
+        },
+        "ports": {
+          "items": true,
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "NodeWarmPoolConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "minFreeNodes": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "OmnistrateLoadBalancer": {
+      "additionalProperties": false,
+      "properties": {
+        "https": {
+          "items": {
+            "$ref": "#/$defs/L7LoadBalancerConfiguration"
+          },
+          "type": "array"
+        },
+        "tcp": {
+          "items": {
+            "$ref": "#/$defs/L4LoadBalancerConfiguration"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "OnPremDeployment": {
+      "additionalProperties": false,
+      "properties": {
+        "awsAccountId": {
+          "type": "string"
+        },
+        "awsBootstrapRoleAccountArn": {
+          "type": "string"
+        },
+        "azureSubscriptionId": {
+          "type": "string"
+        },
+        "azureTenantId": {
+          "type": "string"
+        },
+        "cluster_name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "gcpProjectId": {
+          "type": "string"
+        },
+        "gcpProjectNumber": {
+          "type": "string"
+        },
+        "gcpServiceAccountEmail": {
+          "type": "string"
+        },
+        "nebiusTenantId": {
+          "type": "string"
+        },
+        "ociDomainId": {
+          "type": "string"
+        },
+        "ociTenancyId": {
+          "type": "string"
+        },
+        "onPremInstallerTools": {
+          "$ref": "#/$defs/OnPremInstallerTools"
+        },
+        "requirements": {
+          "$ref": "#/$defs/DeploymentRequirements"
+        }
+      },
+      "type": "object"
+    },
+    "OnPremInstallerTools": {
+      "additionalProperties": false,
+      "properties": {
+        "helperUserScript": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "OperatorCRDConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "artifactsLocalPath": {
+          "type": "string"
+        },
+        "disableReconciliation": {
+          "type": "boolean"
+        },
+        "helmChartDependencies": {
+          "items": {
+            "$ref": "#/$defs/OperatorHelmChartDependency"
+          },
+          "type": "array"
+        },
+        "outputParameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "readinessConditions": {
+          "type": "object"
+        },
+        "supplementalFiles": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "template": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "OperatorHelmChartDependency": {
+      "additionalProperties": false,
+      "properties": {
+        "authProvider": {
+          "$ref": "#/$defs/HelmRepoAuthProvider"
+        },
+        "chartName": {
+          "type": "string"
+        },
+        "chartRepoName": {
+          "type": "string"
+        },
+        "chartRepoURL": {
+          "type": "string"
+        },
+        "chartValues": {
+          "$ref": "#/$defs/GenericMap"
+        },
+        "chartVersion": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "chartName",
+        "chartVersion",
+        "chartRepoName",
+        "chartRepoURL"
+      ],
+      "type": "object"
+    },
+    "Parameter": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "PortList": {
+      "items": {
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "Quantity": {
+      "additionalProperties": false,
+      "properties": {
+        "Format": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "Format"
+      ],
+      "type": "object"
+    },
+    "RemoveCapacityWorkflowConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "outputParameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "workflow": {
+          "$ref": "#/$defs/WorkflowSpec"
+        },
+        "workflowFile": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ResourceConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "actionHooks": {
+          "items": {
+            "$ref": "#/$defs/ActionHook"
+          },
+          "type": "array"
+        },
+        "addSecurityCapabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "agentConfiguration": {
+          "$ref": "#/$defs/AgentConfiguration"
+        },
+        "apiParameters": {
+          "items": {
+            "$ref": "#/$defs/APIParameterConfiguration"
+          },
+          "type": "array"
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "capabilities": {
+          "$ref": "#/$defs/Capabilities"
+        },
+        "command": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "compute": {
+          "$ref": "#/$defs/Compute"
+        },
+        "configs": {
+          "items": {
+            "$ref": "#/$defs/Files"
+          },
+          "type": "array"
+        },
+        "containerImagesRegistryCopyConfiguration": {
+          "$ref": "#/$defs/ContainerImagesRegistryCopyConfiguration"
+        },
+        "customWorkflows": {
+          "items": {
+            "$ref": "#/$defs/CustomWorkflowConfiguration"
+          },
+          "type": "array"
+        },
+        "dependsOn": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "deploymentTarget": {
+          "$ref": "#/$defs/DeploymentTarget"
+        },
+        "description": {
+          "type": "string"
+        },
+        "disable": {
+          "type": "string"
+        },
+        "dropSecurityCapabilities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "endpointConfiguration": {
+          "additionalProperties": {
+            "$ref": "#/$defs/EndpointConfiguration"
+          },
+          "type": "object"
+        },
+        "environmentVariables": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "groupIDs": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "helmChartConfiguration": {
+          "$ref": "#/$defs/HelmChartConfiguration"
+        },
+        "image": {
+          "type": "string"
+        },
+        "internal": {
+          "type": "boolean"
+        },
+        "jobResourceConfiguration": {
+          "$ref": "#/$defs/JobResourceConfiguration"
+        },
+        "kustomizeConfiguration": {
+          "$ref": "#/$defs/KustomizeConfiguration"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "name": {
+          "type": "string"
+        },
+        "network": {
+          "$ref": "#/$defs/Network"
+        },
+        "operatorCRDConfiguration": {
+          "$ref": "#/$defs/OperatorCRDConfiguration"
+        },
+        "passive": {
+          "type": "boolean"
+        },
+        "privileged": {
+          "type": "boolean"
+        },
+        "proxyType": {
+          "type": "string"
+        },
+        "secrets": {
+          "items": {
+            "$ref": "#/$defs/Files"
+          },
+          "type": "array"
+        },
+        "storage": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/$defs/StorageVolumeParameters"
+            },
+            "type": "array"
+          },
+          "type": "object"
+        },
+        "sysctls": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "systemWorkflows": {
+          "$ref": "#/$defs/SystemWorkflowsConfiguration"
+        },
+        "terraformConfigurations": {
+          "$ref": "#/$defs/TerraformConfigurations"
+        },
+        "ulimits": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ULimitValue"
+          },
+          "type": "object"
+        },
+        "userID": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "ResourceTemplate": {
+      "additionalProperties": false,
+      "properties": {
+        "action": {
+          "type": "string"
+        },
+        "failureCondition": {
+          "type": "string"
+        },
+        "flags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "manifest": {
+          "type": "string"
+        },
+        "mergeStrategy": {
+          "type": "string"
+        },
+        "successCondition": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "action",
+        "manifest"
+      ],
+      "type": "object"
+    },
+    "RestartWorkflowConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "outputParameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "workflow": {
+          "$ref": "#/$defs/WorkflowSpec"
+        },
+        "workflowFile": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "RestoreWorkflowConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "outputParameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "workflow": {
+          "$ref": "#/$defs/WorkflowSpec"
+        },
+        "workflowFile": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ScalingMetric": {
+      "additionalProperties": false,
+      "properties": {
+        "metricEndpoint": {
+          "type": "string"
+        },
+        "metricLabelName": {
+          "type": "string"
+        },
+        "metricLabelValue": {
+          "type": "string"
+        },
+        "metricName": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ScheduleConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "CronExpression": {
+          "type": "string"
+        },
+        "SimpleInterval": {
+          "type": "string"
+        },
+        "Timezone": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "CronExpression",
+        "SimpleInterval",
+        "Timezone"
+      ],
+      "type": "object"
+    },
+    "SharedFileSystemConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "fileSystemConfig": {
+          "$ref": "#/$defs/FileSystemConfig"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "StartWorkflowConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "outputParameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "workflow": {
+          "$ref": "#/$defs/WorkflowSpec"
+        },
+        "workflowFile": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "StopWorkflowConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "outputParameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "workflow": {
+          "$ref": "#/$defs/WorkflowSpec"
+        },
+        "workflowFile": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "StorageVolumeParameters": {
+      "additionalProperties": false,
+      "properties": {
+        "clusterStorageType": {
+          "type": "string"
+        },
+        "clusterStorageTypeAPIParam": {
+          "type": "string"
+        },
+        "instanceStorageIOPS": {
+          "type": "number"
+        },
+        "instanceStorageIOPSAPIParam": {
+          "type": "string"
+        },
+        "instanceStorageSizeGi": {
+          "type": "number"
+        },
+        "instanceStorageSizeGiAPIParam": {
+          "type": "string"
+        },
+        "instanceStorageThroughputAPIParam": {
+          "type": "string"
+        },
+        "instanceStorageThroughputMiBps": {
+          "type": "number"
+        },
+        "instanceStorageType": {
+          "type": "string"
+        },
+        "instanceStorageTypeAPIParam": {
+          "type": "string"
+        },
+        "storageResourceName": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "SystemWorkflowsConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "addCapacity": {
+          "$ref": "#/$defs/AddCapacityWorkflowConfiguration"
+        },
+        "backup": {
+          "$ref": "#/$defs/BackupWorkflowConfiguration"
+        },
+        "create": {
+          "$ref": "#/$defs/CreateWorkflowConfiguration"
+        },
+        "delete": {
+          "$ref": "#/$defs/DeleteWorkflowConfiguration"
+        },
+        "deleteBackup": {
+          "$ref": "#/$defs/DeleteBackupWorkflowConfiguration"
+        },
+        "failover": {
+          "$ref": "#/$defs/FailoverWorkflowConfiguration"
+        },
+        "modify": {
+          "$ref": "#/$defs/ModifyWorkflowConfiguration"
+        },
+        "removeCapacity": {
+          "$ref": "#/$defs/RemoveCapacityWorkflowConfiguration"
+        },
+        "restart": {
+          "$ref": "#/$defs/RestartWorkflowConfiguration"
+        },
+        "restore": {
+          "$ref": "#/$defs/RestoreWorkflowConfiguration"
+        },
+        "start": {
+          "$ref": "#/$defs/StartWorkflowConfiguration"
+        },
+        "stop": {
+          "$ref": "#/$defs/StopWorkflowConfiguration"
+        },
+        "update": {
+          "$ref": "#/$defs/UpdateWorkflowConfiguration"
+        }
+      },
+      "type": "object"
+    },
+    "TaintConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "effect": {
+          "type": "string"
+        },
+        "key": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "Template": {
+      "additionalProperties": false,
+      "properties": {
+        "activeDeadlineSeconds": {
+          "type": "integer"
+        },
+        "dag": {
+          "$ref": "#/$defs/DAGTemplate"
+        },
+        "inputs": {
+          "$ref": "#/$defs/Inputs"
+        },
+        "name": {
+          "type": "string"
+        },
+        "resource": {
+          "$ref": "#/$defs/ResourceTemplate"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "TerraformConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "artifactRelativePath": {
+          "type": "string"
+        },
+        "artifactsLocalPath": {
+          "type": "string"
+        },
+        "cliConfigFileOverride": {
+          "type": "string"
+        },
+        "gitConfiguration": {
+          "$ref": "#/$defs/GitConfiguration"
+        },
+        "privateKeyPEM": {
+          "type": "string"
+        },
+        "publicKeyID": {
+          "type": "string"
+        },
+        "requiredOutputKeys": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "requiredOutputs": {
+          "items": {
+            "$ref": "#/$defs/TerraformOutput"
+          },
+          "type": "array"
+        },
+        "serviceAccountID": {
+          "type": "string"
+        },
+        "terraformExecutionIdentity": {
+          "type": "string"
+        },
+        "terraformPath": {
+          "type": "string"
+        },
+        "variablesValuesFileOverride": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "terraformPath"
+      ],
+      "type": "object"
+    },
+    "TerraformConfigurations": {
+      "additionalProperties": false,
+      "properties": {
+        "configurationPerCloudProvider": {
+          "additionalProperties": {
+            "$ref": "#/$defs/TerraformConfiguration"
+          },
+          "type": "object"
+        },
+        "configurationPerOnPremPlatform": {
+          "additionalProperties": {
+            "$ref": "#/$defs/TerraformConfiguration"
+          },
+          "type": "object"
+        }
+      },
+      "type": "object"
+    },
+    "TerraformOutput": {
+      "additionalProperties": false,
+      "properties": {
+        "exported": {
+          "type": "boolean"
+        },
+        "key": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ULimitValue": {
+      "additionalProperties": false,
+      "properties": {
+        "hard": {
+          "type": "integer"
+        },
+        "soft": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "UpdateWorkflowConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "outputParameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "type": "object"
+        },
+        "workflow": {
+          "$ref": "#/$defs/WorkflowSpec"
+        },
+        "workflowFile": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "ValuesFile": {
+      "additionalProperties": false,
+      "properties": {
+        "gitConfiguration": {
+          "$ref": "#/$defs/GitConfiguration"
+        },
+        "path": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "WarmPoolConfiguration": {
+      "additionalProperties": false,
+      "properties": {
+        "minimumNodesInPool": {
+          "type": "integer"
+        }
+      },
+      "type": "object"
+    },
+    "WorkflowOutputParameterSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "valueRef": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "valueRef",
+        "type"
+      ],
+      "type": "object"
+    },
+    "WorkflowParameter": {
+      "additionalProperties": false,
+      "properties": {
+        "custom": {
+          "type": "boolean"
+        },
+        "defaultValue": {
+          "type": "string"
+        },
+        "dependentResourceID": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "displayName": {
+          "type": "string"
+        },
+        "isList": {
+          "type": "boolean"
+        },
+        "key": {
+          "type": "string"
+        },
+        "modifiable": {
+          "type": "boolean"
+        },
+        "options": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "regex": {
+          "type": "string"
+        },
+        "required": {
+          "type": "boolean"
+        },
+        "tabIndex": {
+          "type": "integer"
+        },
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "key",
+        "displayName",
+        "type"
+      ],
+      "type": "object"
+    },
+    "WorkflowSpec": {
+      "additionalProperties": false,
+      "properties": {
+        "activeDeadlineSeconds": {
+          "type": "integer"
+        },
+        "arguments": {
+          "$ref": "#/$defs/Arguments"
+        },
+        "entrypoint": {
+          "type": "string"
+        },
+        "templates": {
+          "items": {
+            "$ref": "#/$defs/Template"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "entrypoint",
+        "templates"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://github.com/omnistrate/ows-orchestration/v1/pkg/registration/service/servicebuild/serviceplan/custom-service-plan-spec",
+  "$ref": "#/$defs/CustomServicePlanSpec",
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
+}

--- a/mkdocs/docs/omnistrate-ctl_build.md
+++ b/mkdocs/docs/omnistrate-ctl_build.md
@@ -44,6 +44,9 @@ omnistrate-ctl build --file omnistrate-compose.yaml --product-name "My Service" 
 # Build service with compose spec interactively
 omnistrate-ctl build --file omnistrate-compose.yaml --product-name "My Service" --interactive
 
+# Validate a spec without changing anything (read-only; exits nonzero unless the result is VALID)
+omnistrate-ctl build --file omnistrate-compose.yaml --product-name "My Service" --dry-run
+
 # Build service with compose spec with service description and service logo
 omnistrate-ctl build --file omnistrate-compose.yaml --product-name "My Service" --description "My Service Description" --service-logo-url "https://example.com/logo.png"
 
@@ -71,7 +74,7 @@ omnistrate-ctl build --image docker.io/namespace/my-image:v1.2 --product-name "M
 
 ```
       --description string                  A short description for the whole service. A service can have multiple service plans.
-  -d, --dry-run                             Simulate building the service without actually creating resources
+  -d, --dry-run                             Validate the specification without changing anything. Sends it to the server's read-only build validation endpoint: nothing is created, updated, released, promoted or uploaded. Local Terraform, Helm, Kustomize and operator content declared by the specification is sent for validation only, bounded at 16 MiB compressed and 64 MiB uncompressed in total across all artifacts. Exits zero only when the result is VALID; INVALID and INCOMPLETE (a check that could not be completed) both exit nonzero
       --environment string                  Name of the environment to build the service in (default "Dev")
       --environment-type string             Type of environment. Valid options include: 'dev', 'prod', 'qa', 'canary', 'staging', 'private') (default "dev")
   -f, --file string                         Path to the docker compose file (defaults to omnistrate-compose.yaml, docker-compose.yaml or spec.yaml in that order).If docker-compose.yaml is found, it is detected but not supported; please convert it to omnistrate-compose.yaml


### PR DESCRIPTION
> **Blocked on an SDK release.** `go.mod` still pins `v0.0.124`, which has no `ValidateServiceSpec`. Verified against a temporary Go workspace; no absolute-path `replace` is committed, per the execution guide.

Backend: omnistrate/ows-orchestration#3670 · Contract: omnistrate/api-design#1898 · SDK: omnistrate-oss/omnistrate-sdk-go#138

## Problem

`build --dry-run` performed real writes. For a service-plan spec it called `FindOrCreateServiceHierarchy` **first**, issuing `PUT /service/serviceplanspec/prepare` — a mutating request whose body has no dry-run field at all — and only then sent the build request with `dryrun=true`. With `--interactive`, answering the post-build prompt could create a production environment and promote to it.

Recorded against a local test server, before and after:

```
ServicePlanSpec --dry-run
  before   PUT  /service/serviceplanspec/prepare        <- mutating
           PUT  /service/serviceplanspec                {"dryrun": true}
  after    POST /service/spec/validate

Compose --dry-run --interactive, answering "y"
  before   POST /service/{id}/environment               <- creates PROD
           POST /service/{id}/environment/{id}/promote
  after    POST /service/spec/validate
```

Zero prepare, build, upload, environment or promote calls in every case. The test server records any other request as a violation.

## Where the branch sits

After token acquisition and spec rendering, **before `FindOrCreateServiceHierarchy`** — the only business write ahead of the build call. Nothing downstream is reachable: no prepare, upload, build, release, environment creation, promotion, browser or release URL.

## Artifacts: two-request flow

The backend keeps ownership of discovery rules. Request one omits archives; the backend reports what it needs; the client retries **exactly once** with those paths packaged. The second response's `inputDigest` must match the first. No unbounded retry, no mutation fallback.

## The server is not trusted with paths

Each server-supplied requirement path is canonicalized — rejecting NUL, backslashes, absolute and volume-qualified paths and any `..` component **before** normalization — then checked against an allowlist collected from the spec's own local source declarations, then resolved through `EvalSymlinks` with a containment check.

A server cannot request an unrelated credentials directory merely because it sits inside the working directory. Tests assert the credential bytes never appear in any recorded request body. Sibling prefixes like `terraform-other/` remain legal.

## Other behavior

**Rendering no longer writes `<basename>.tmp` into the source tree.** Validation uses a temp file outside it while preserving the project directory for relative env and config resolution.

**Exit status is zero only for VALID.** INVALID and INCOMPLETE print exactly one JSON document and return a non-zero error *through Cobra* rather than exiting inside a print helper — `utils.PrintError` calls `os.Exit(1)`, which would kill the process before Cobra saw the error.

**A server without the endpoint** produces an upgrade message and never falls back to the legacy build API.

**Debug logging** for this route is metadata-only, Authorization and cookies redacted, body never dumped. The sentinel test has a **control** that asserts the same secret *is* dumped on the legacy route first, so it cannot pass vacuously.

**`--dry-run --image` is validated rather than refused.** The two `compose-gen` calls were checked and are reads — grepping that package for `.Create(`/`.Save(`/`.Update(`/`.Delete(`/`ExecuteWorkflow`/`Upload` returns zero hits — so the branch can produce a candidate without mutating.

## Test changes worth reviewing

Several pre-existing tests were reproductions asserting the defect and no longer describe reality. Each was renamed and keeps a comment recording what it used to pin — e.g. `…IssuesPrepareBeforeValidation` → `…NeverIssuesPrepare`.

`TestBuildDryRunRenderFileOverwritesSpecTmpSentinel` is deliberately **unchanged**: `RenderFile` still behaves that way and real builds still use it.

Three assumptions in the pre-written target tests were wrong and are annotated `RECONCILED` — most notably a "same envelope" check that compared `inputDigest` across two *request* bodies, a response-only field, so it was vacuously `nil == nil`.

`build.go` was split into `parseBuildOptions` + `runBuildWithOptions` so the route is testable ahead of `buildService`. A token *provider* rather than a resolved token preserves ordering: login currently happens after file loading, so resolving early would make a missing file trigger a login prompt.

## Verification

`go test ./cmd/build -race` ok · 166 tests across both packages · `golangci-lint` 0 issues · `make gen-doc` regenerated. All run under a scratchpad `GOWORK`.

End-to-end against the built binary: VALID ⇒ exit 0; INVALID ⇒ exit 1 with one JSON document; 404 ⇒ exit 1 with the upgrade message and zero legacy requests.

## Note for the reviewer

`internal/dataaccess/k8sclient_test.go` is a **pre-existing untracked file that does not compile** — it references `restConfigForHostClusterKubeConfig` and `k8sRequestTimeout`, which exist neither in the working tree nor at HEAD. It breaks `go test ./internal/dataaccess`, `make unit-test` and `make lint` independently of this change. It is deliberately **not** included in this PR and was left byte-identical; verification used a Go overlay. It needs fixing or removing by its owner.

## At release time

Publish the SDK, bump `omnistrate-sdk-go` in `go.mod` to that real tag, `go mod tidy`. No source change needed. Deploy the backend endpoint **before** releasing this client.