### PR TITLE
feat: add --customer-email to instance create

### DIFF
--- a/cmd/account/customer_create.go
+++ b/cmd/account/customer_create.go
@@ -607,7 +607,7 @@ func resolveCustomerAccountSubscription(
 		}
 	}
 
-	if isProductionEnvironmentType(target.EnvironmentType) && customerEmail == "" && subscriptionID == "" {
+	if utils.IsProductionEnvironmentType(target.EnvironmentType) && customerEmail == "" && subscriptionID == "" {
 		currentUser, err := describeCurrentUserFn(ctx, token)
 		if err != nil {
 			return "", fmt.Errorf("failed to resolve the calling user for production subscription lookup: %w", err)
@@ -649,10 +649,6 @@ func resolveCustomerAccountSubscription(
 	}
 
 	return strings.TrimSpace(subscription.Id), nil
-}
-
-func isProductionEnvironmentType(environmentType string) bool {
-	return utils.IsProductionEnvironmentType(environmentType)
 }
 
 func buildCustomerAccountRequestParams(

--- a/cmd/account/customer_create.go
+++ b/cmd/account/customer_create.go
@@ -627,10 +627,13 @@ func resolveCustomerAccountSubscription(
 	subscription, err := resolveCustomerSubscriptionByEmail(
 		ctx,
 		token,
-		target.ServiceID,
-		target.EnvironmentID,
-		target.ProductTierID,
-		customerEmail,
+		dataaccess.CustomerSubscriptionLookup{
+			ServiceID:       target.ServiceID,
+			EnvironmentID:   target.EnvironmentID,
+			EnvironmentType: target.EnvironmentType,
+			PlanID:          target.ProductTierID,
+			CustomerEmail:   customerEmail,
+		},
 	)
 	if err != nil {
 		return "", fmt.Errorf(
@@ -649,12 +652,7 @@ func resolveCustomerAccountSubscription(
 }
 
 func isProductionEnvironmentType(environmentType string) bool {
-	switch strings.ToUpper(strings.TrimSpace(environmentType)) {
-	case "PROD", "PRODUCTION":
-		return true
-	default:
-		return false
-	}
+	return utils.IsProductionEnvironmentType(environmentType)
 }
 
 func buildCustomerAccountRequestParams(

--- a/cmd/account/customer_create_test.go
+++ b/cmd/account/customer_create_test.go
@@ -407,6 +407,7 @@ func TestResolveCustomerAccountSubscription_ProductionDefaultsToCallingUserSubsc
 		assert.Equal(t, "token", token)
 		assert.Equal(t, "svc-1", lookup.ServiceID)
 		assert.Equal(t, "env-1", lookup.EnvironmentID)
+		assert.Equal(t, "PROD", lookup.EnvironmentType)
 		assert.Equal(t, "pt-1", lookup.PlanID)
 		assert.Equal(t, "caller@example.com", lookup.CustomerEmail)
 		return &openapiclientfleet.FleetDescribeSubscriptionResult{Id: "sub-456"}, nil

--- a/cmd/account/customer_create_test.go
+++ b/cmd/account/customer_create_test.go
@@ -359,7 +359,7 @@ func TestResolveCustomerAccountSubscription_NonProductionUsesProvidedSubscriptio
 		describeCurrentUserFn = originalDescribeCurrentUser
 	})
 
-	resolveCustomerSubscriptionByEmail = func(context.Context, string, string, string, string, string) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+	resolveCustomerSubscriptionByEmail = func(context.Context, string, dataaccess.CustomerSubscriptionLookup) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
 		t.Fatal("subscription lookup should not be called")
 		return nil, nil
 	}
@@ -403,12 +403,12 @@ func TestResolveCustomerAccountSubscription_ProductionDefaultsToCallingUserSubsc
 			Email: strPtr("caller@example.com"),
 		}, nil
 	}
-	resolveCustomerSubscriptionByEmail = func(ctx context.Context, token, serviceID, environmentID, planID, customerEmail string) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+	resolveCustomerSubscriptionByEmail = func(ctx context.Context, token string, lookup dataaccess.CustomerSubscriptionLookup) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
 		assert.Equal(t, "token", token)
-		assert.Equal(t, "svc-1", serviceID)
-		assert.Equal(t, "env-1", environmentID)
-		assert.Equal(t, "pt-1", planID)
-		assert.Equal(t, "caller@example.com", customerEmail)
+		assert.Equal(t, "svc-1", lookup.ServiceID)
+		assert.Equal(t, "env-1", lookup.EnvironmentID)
+		assert.Equal(t, "pt-1", lookup.PlanID)
+		assert.Equal(t, "caller@example.com", lookup.CustomerEmail)
 		return &openapiclientfleet.FleetDescribeSubscriptionResult{Id: "sub-456"}, nil
 	}
 
@@ -436,7 +436,7 @@ func TestResolveCustomerAccountSubscription_ProductionFailsWhenCallingUserEmailI
 		describeCurrentUserFn = originalDescribeCurrentUser
 	})
 
-	resolveCustomerSubscriptionByEmail = func(context.Context, string, string, string, string, string) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+	resolveCustomerSubscriptionByEmail = func(context.Context, string, dataaccess.CustomerSubscriptionLookup) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
 		t.Fatal("subscription lookup should not be called")
 		return nil, nil
 	}
@@ -477,7 +477,7 @@ func TestResolveCustomerAccountSubscription_ProductionAllowsSubscriptionIDOverri
 		describeCurrentUserFn = originalDescribeCurrentUser
 	})
 
-	resolveCustomerSubscriptionByEmail = func(context.Context, string, string, string, string, string) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+	resolveCustomerSubscriptionByEmail = func(context.Context, string, dataaccess.CustomerSubscriptionLookup) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
 		t.Fatal("subscription lookup should not be called")
 		return nil, nil
 	}

--- a/cmd/instance/create.go
+++ b/cmd/instance/create.go
@@ -46,7 +46,10 @@ omnistrate-ctl instance create --service=Nebius --environment=dev --plan='Nebius
 omnistrate-ctl instance create --service=MyService --environment=dev --plan='AWS BYOA' --resource=myResource --cloud-provider=aws --region=us-east-2 --customer-account-id instance-cg1tthkj0 --cloud-provider-native-network-id vpc-0123456789abcdef0
 
 # Create an air-gapped/on-prem installer-backed instance. Do not pass --cloud-provider or --region with --onprem-platform.
-omnistrate-ctl instance create --service=MyService --environment=dev --plan='Airgap' --resource=myResource --onprem-platform=Generic --param-file /path/to/params.json`
+omnistrate-ctl instance create --service=MyService --environment=dev --plan='Airgap' --resource=myResource --onprem-platform=Generic --param-file /path/to/params.json
+
+# Create an instance deployment on behalf of an end customer, resolved from their email
+omnistrate-ctl instance create --service=mysql --environment=prod --plan=mysql --resource=mySQL --cloud-provider=aws --region=us-east-2 --param-file /path/to/params.json --customer-email customer@example.com`
 
 	customerAccountConfigIDParamKey      = "cloud_provider_account_config_id"
 	cloudProviderNativeNetworkIDParamKey = "cloud_provider_native_network_id"
@@ -79,7 +82,7 @@ var InstanceID string
 var SubscriptionID string
 
 var createCmd = &cobra.Command{
-	Use:          "create --service=[service] --environment=[environment] --plan=[plan] --version=[version] --resource=[resource] [--cloud-provider=aws|gcp|azure|nebius] [--region=region] [--param=param] [--param-file=file-path] [--instance-id=id] [--customer-account-id=account-instance-id] [--cloud-provider-native-network-id=network-id] [--network-type=PUBLIC|INTERNAL] [--onprem-platform=platform] [--tags key=value,key2=value2] [--breakpoints id-or-key[:event[|event...]],...]",
+	Use:          "create --service=[service] --environment=[environment] --plan=[plan] --version=[version] --resource=[resource] [--cloud-provider=aws|gcp|azure|nebius] [--region=region] [--param=param] [--param-file=file-path] [--instance-id=id] [--customer-email=email] [--customer-account-id=account-instance-id] [--cloud-provider-native-network-id=network-id] [--network-type=PUBLIC|INTERNAL] [--onprem-platform=platform] [--tags key=value,key2=value2] [--breakpoints id-or-key[:event[|event...]],...]",
 	Short:        "Create an instance deployment",
 	Long:         `This command helps you create an instance deployment for your service.`,
 	Example:      createExample,
@@ -104,6 +107,7 @@ func init() {
 	createCmd.Flags().String("tags", "", `Custom tags to add to the instance deployment (format: key=value,key2=value2). Escape commas inside values with \,`)
 	createCmd.Flags().String("breakpoints", "", "Workflow breakpoint resource IDs or resource keys, optionally scoped to events as id-or-key:event or id-or-key:event|event")
 	createCmd.Flags().StringP("subscription-id", "", "", "Subscription ID to use for the instance deployment. If not provided, instance deployment will be created in your own subscription.")
+	createCmd.Flags().String("customer-email", "", "Customer email to create the instance deployment on behalf of. Resolves the customer's subscription for this service plan, creating one if they have none. Cannot be combined with --subscription-id.")
 	createCmd.Flags().String("instance-id", "", "ID of a previously deleted instance to restore")
 	createCmd.Flags().Bool("wait", false, "Wait for deployment to complete and show progress")
 
@@ -201,6 +205,11 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		utils.PrintError(err)
 		return err
 	}
+	customerEmail, err := cmd.Flags().GetString("customer-email")
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
 	instanceID, err := cmd.Flags().GetString("instance-id")
 	if err != nil {
 		utils.PrintError(err)
@@ -232,6 +241,10 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	if err = validateCreateCloudTarget(cloudProvider, region, onpremPlatform); err != nil {
+		utils.PrintError(err)
+		return err
+	}
+	if err = validateCustomerEmailFlags(customerEmail, subscriptionID); err != nil {
 		utils.PrintError(err)
 		return err
 	}
@@ -309,6 +322,18 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	offering := *selectedOffering
+
+	subscriptionID, err = resolveInstanceSubscriptionID(cmd.Context(), token, dataaccess.CustomerSubscriptionLookup{
+		ServiceID:       serviceID,
+		EnvironmentID:   environmentID,
+		EnvironmentType: offering.ServiceEnvironmentType,
+		PlanID:          productTierID,
+		CustomerEmail:   customerEmail,
+	}, subscriptionID)
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
 
 	// Format parameters
 	formattedParams, err := common.FormatParams(param, paramFile)
@@ -868,6 +893,49 @@ func applyCloudProviderNativeNetworkIDParam(
 	}
 	params[cloudProviderNativeNetworkIDParamKey] = cloudProviderNativeNetworkID
 	return params
+}
+
+// resolveInstanceSubscriptionByEmail is a package variable so tests can exercise the
+// resolution wiring without a live API.
+var resolveInstanceSubscriptionByEmail = dataaccess.GetSubscriptionByCustomerEmailInEnvironment
+
+// validateCustomerEmailFlags checks the flag combination before any API call is made.
+func validateCustomerEmailFlags(customerEmail, subscriptionID string) error {
+	customerEmail = strings.TrimSpace(customerEmail)
+	if customerEmail == "" {
+		return nil
+	}
+	if strings.TrimSpace(subscriptionID) != "" {
+		return fmt.Errorf("cannot specify both --customer-email and --subscription-id")
+	}
+	if err := utils.ValidateEmail(customerEmail); err != nil {
+		return fmt.Errorf("invalid --customer-email value: %w", err)
+	}
+	return nil
+}
+
+// resolveInstanceSubscriptionID returns the subscription the instance should be created
+// under. Without --customer-email the requested subscription ID passes through unchanged,
+// which keeps the existing behaviour of letting the platform choose.
+func resolveInstanceSubscriptionID(
+	ctx context.Context,
+	token string,
+	lookup dataaccess.CustomerSubscriptionLookup,
+	requestedSubscriptionID string,
+) (string, error) {
+	if strings.TrimSpace(lookup.CustomerEmail) == "" {
+		return requestedSubscriptionID, nil
+	}
+
+	subscription, err := resolveInstanceSubscriptionByEmail(ctx, token, lookup)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve subscription for customer %s: %w", lookup.CustomerEmail, err)
+	}
+	if subscription == nil || strings.TrimSpace(subscription.Id) == "" {
+		return "", fmt.Errorf("subscription lookup for customer %s returned an empty subscription ID", lookup.CustomerEmail)
+	}
+
+	return strings.TrimSpace(subscription.Id), nil
 }
 
 func validateCreateCloudTarget(cloudProvider, region, onpremPlatform string) error {

--- a/cmd/instance/create.go
+++ b/cmd/instance/create.go
@@ -929,7 +929,7 @@ func resolveInstanceSubscriptionID(
 
 	subscription, err := resolveInstanceSubscriptionByEmail(ctx, token, lookup)
 	if err != nil {
-		return "", fmt.Errorf("failed to resolve subscription for customer %s: %w", lookup.CustomerEmail, err)
+		return "", fmt.Errorf("failed to resolve --customer-email to a subscription: %w", err)
 	}
 	if subscription == nil || strings.TrimSpace(subscription.Id) == "" {
 		return "", fmt.Errorf("subscription lookup for customer %s returned an empty subscription ID", lookup.CustomerEmail)

--- a/cmd/instance/create_test.go
+++ b/cmd/instance/create_test.go
@@ -2,13 +2,21 @@ package instance
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/mitchellh/go-homedir"
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/config"
 	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
 	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
 	openapiclientv1 "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -610,4 +618,293 @@ func TestResolveInstanceSubscriptionIDRejectsEmptyResult(t *testing.T) {
 
 func TestCreateExampleDocumentsCustomerEmail(t *testing.T) {
 	assert.Contains(t, createExample, "--customer-email")
+}
+
+// --- Regression coverage: the resolved subscription ID must reach the create-instance
+// request wire, not just the pure resolveInstanceSubscriptionID helper.
+//
+// TestResolveInstanceSubscriptionID* above prove resolveInstanceSubscriptionID itself is
+// correct, but nothing exercised runCreate's wiring: `subscriptionID, err =
+// resolveInstanceSubscriptionID(...)` at the call site in runCreate. If that were ever
+// changed from `=` to `:=`, the reassignment would silently shadow the outer subscriptionID,
+// --customer-email would stop doing anything, and every test above would still pass green.
+// This test drives runCreate end-to-end against a stub HTTP server standing in for the
+// Omnistrate API and asserts the resolved subscription ID reaches the create-instance request
+// body.
+
+// fakeJWT builds a syntactically valid, unsigned JWT whose exp claim is far enough in the
+// future for config.IsTokenExpired to treat it as fresh. GetTokenWithLogin only decodes the
+// exp claim locally to decide whether a refresh is needed; the signature itself is never
+// verified client-side (that happens server-side), so a placeholder signature segment is fine
+// for a stub server.
+func fakeJWT(t *testing.T, exp time.Time) string {
+	t.Helper()
+
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payloadBytes, err := json.Marshal(map[string]int64{"exp": exp.Unix()})
+	require.NoError(t, err)
+	payload := base64.RawURLEncoding.EncodeToString(payloadBytes)
+
+	return header + "." + payload + ".sig"
+}
+
+// startCreateInstanceTestServer points the SDK's v1 and fleet clients at a stub server for the
+// duration of the test. Mirrors internal/dataaccess/subscription_test.go's
+// startSubscriptionTestServer; duplicated locally because that helper is unexported across the
+// package boundary.
+func startCreateInstanceTestServer(t *testing.T, handler http.HandlerFunc) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	t.Setenv("OMNISTRATE_HOST", serverURL.Host)
+	t.Setenv("OMNISTRATE_HOST_SCHEME", serverURL.Scheme)
+	t.Setenv("CLIENT_TIMEOUT_IN_SECONDS", "5")
+	t.Setenv("OMNISTRATE_RETRY_MAX", "0")
+}
+
+// v1ServiceOfferingFixture builds a fully populated v1 ServiceOffering, i.e. every property
+// the SDK's generated UnmarshalJSON requires. Unlike the deliberately sparse
+// serviceOfferingFixture above (which is only ever consumed in-process, never round-tripped
+// through JSON), this one must survive an actual HTTP response decode.
+func v1ServiceOfferingFixture(environmentID, productTierID, resourceID, resourceName string) openapiclientv1.ServiceOffering {
+	return openapiclientv1.ServiceOffering{
+		ProductTierDocumentation: "doc",
+		ProductTierID:            productTierID,
+		ProductTierName:          "test-plan",
+		ProductTierPricing:       map[string]interface{}{},
+		ProductTierSupport:       "community",
+		ProductTierType:          "PAID",
+		ProductTierURLKey:        "plan-key",
+		ProductTierVersion:       "1.0",
+		ResourceParameters: []openapiclientv1.ResourceEntity{
+			{Name: resourceName, ResourceId: resourceID, UrlKey: "res-v1-key"},
+		},
+		ServiceAPIID:                 "api-test",
+		ServiceAPIVersion:            "v1",
+		ServiceEnvironmentID:         environmentID,
+		ServiceEnvironmentName:       "prod",
+		ServiceEnvironmentType:       "PROD",
+		ServiceEnvironmentURLKey:     "env-key",
+		ServiceEnvironmentVisibility: "PUBLIC",
+		ServiceModelID:               "model-test",
+		ServiceModelName:             "test-model",
+		ServiceModelStatus:           "ACTIVE",
+		ServiceModelType:             "STANDARD",
+		ServiceModelURLKey:           "model-key",
+	}
+}
+
+// externalDescribeServiceOfferingFixture wraps v1ServiceOfferingFixture in the response
+// envelope ExternalDescribeServiceOffering (the v1 API resource resolution calls) expects.
+func externalDescribeServiceOfferingFixture(serviceID string, offerings ...openapiclientv1.ServiceOffering) *openapiclientv1.DescribeServiceOfferingResult {
+	return &openapiclientv1.DescribeServiceOfferingResult{
+		ServiceId:           serviceID,
+		ServiceName:         "test-service",
+		ServiceOrgId:        "org-abc123",
+		ServiceProviderId:   "sp-test",
+		ServiceProviderName: "test-provider",
+		ServiceURLKey:       "svc-url-key",
+		Offerings:           offerings,
+	}
+}
+
+// fleetServiceOfferingFixture builds a fully populated fleet ServiceOffering matching the
+// environment/plan/resource the test resolves via getResource.
+func fleetServiceOfferingFixture(environmentID, productTierID, resourceName, resourceURLKey string) openapiclientfleet.ServiceOffering {
+	return openapiclientfleet.ServiceOffering{
+		ProductTierDocumentation: "doc",
+		ProductTierID:            productTierID,
+		ProductTierName:          "test-plan",
+		ProductTierPricing:       map[string]interface{}{},
+		ProductTierSupport:       "community",
+		ProductTierType:          "PAID",
+		ProductTierURLKey:        "plan-key",
+		ProductTierVersion:       "1.0",
+		ResourceParameters: []openapiclientfleet.ResourceEntity{
+			{Name: resourceName, ResourceId: "res-fleet-test", UrlKey: resourceURLKey},
+		},
+		ServiceAPIID:                 "api-test",
+		ServiceAPIVersion:            "v1",
+		ServiceEnvironmentID:         environmentID,
+		ServiceEnvironmentName:       "prod",
+		ServiceEnvironmentType:       "PROD",
+		ServiceEnvironmentURLKey:     "env-key",
+		ServiceEnvironmentVisibility: "PUBLIC",
+		ServiceModelID:               "model-test",
+		ServiceModelName:             "test-model",
+		ServiceModelStatus:           "ACTIVE",
+		ServiceModelType:             "STANDARD",
+		ServiceModelURLKey:           "model-key",
+	}
+}
+
+// fleetDescribeServiceOfferingFixture wraps fleetServiceOfferingFixture in the response
+// envelope the fleet DescribeServiceOffering endpoint returns.
+func fleetDescribeServiceOfferingFixture(serviceID string, offerings ...openapiclientfleet.ServiceOffering) *openapiclientfleet.InventoryDescribeServiceOfferingResult {
+	return &openapiclientfleet.InventoryDescribeServiceOfferingResult{
+		ConsumptionDescribeServiceOfferingResult: &openapiclientfleet.DescribeServiceOfferingResult{
+			ServiceId:           serviceID,
+			ServiceName:         "test-service",
+			ServiceOrgId:        "org-abc123",
+			ServiceProviderId:   "sp-test",
+			ServiceProviderName: "test-provider",
+			ServiceURLKey:       "svc-url-key",
+			Offerings:           offerings,
+		},
+	}
+}
+
+// resourceInstanceFixture builds the minimal fleet ResourceInstance that satisfies the SDK's
+// required-property validation, for the DescribeResourceInstance response after creation.
+func resourceInstanceFixture(serviceID, environmentID, subscriptionID string) openapiclientfleet.ResourceInstance {
+	return openapiclientfleet.ResourceInstance{
+		CloudProvider:                     "aws",
+		ConsumptionResourceInstanceResult: openapiclientfleet.DescribeResourceInstanceResult{},
+		EnvironmentId:                     environmentID,
+		InputParams:                       map[string]interface{}{},
+		InstanceDebugCommands:             []string{},
+		IntegrationsStatus:                []openapiclientfleet.IntegrationStatus{},
+		OrganizationId:                    "org-abc123",
+		OrganizationName:                  "test-org",
+		ProductTierId:                     "pt-test",
+		ProductTierName:                   "test-plan",
+		ProductTierType:                   "PAID",
+		ResourceVersionSummaries:          []openapiclientfleet.ResourceVersionSummary{},
+		ServiceEnvName:                    "prod",
+		ServiceId:                         serviceID,
+		ServiceModelId:                    "model-test",
+		ServiceModelName:                  "test-model",
+		ServiceModelType:                  "STANDARD",
+		ServiceName:                       "test-service",
+		SubscriptionId:                    subscriptionID,
+		SubscriptionOwnerName:             "test-customer",
+		TierVersion:                       "1.0",
+		TierVersionReleasedAt:             "2026-09-07T00:00:00Z",
+		TierVersionReleasedByUserId:       "user-test",
+		TierVersionReleasedByUserName:     "test-customer",
+		TierVersionStatus:                 "ACTIVE",
+	}
+}
+
+// newTestCreateCommand builds a *cobra.Command exposing exactly the flags runCreate reads.
+// It intentionally does not reuse the package-level createCmd (avoiding shared mutable flag
+// state across tests) and does not go through the real root command tree (cmd/root.go imports
+// this package, so importing it back here would cycle); "output" in particular is normally a
+// persistent flag inherited from RootCmd, so it is registered locally here instead.
+func newTestCreateCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "create"}
+	flags := cmd.Flags()
+	flags.String("service", "", "")
+	flags.String("environment", "", "")
+	flags.String("plan", "", "")
+	flags.String("version", "preferred", "")
+	flags.String("resource", "", "")
+	flags.String("cloud-provider", "", "")
+	flags.String("region", "", "")
+	flags.String("param", "", "")
+	flags.String("param-file", "", "")
+	flags.String("customer-account-id", "", "")
+	flags.String("cloud-provider-native-network-id", "", "")
+	flags.String("network-type", "", "")
+	flags.String("onprem-platform", "", "")
+	flags.String("tags", "", "")
+	flags.String("breakpoints", "", "")
+	flags.String("subscription-id", "", "")
+	flags.String("customer-email", "", "")
+	flags.String("instance-id", "", "")
+	flags.Bool("wait", false, "")
+	flags.String("output", "table", "")
+	return cmd
+}
+
+func TestRunCreateWiresResolvedSubscriptionIDIntoCreateRequest(t *testing.T) {
+	// Isolate the config directory so GetTokenWithLogin reads/writes a throwaway auth
+	// config under a temp HOME, never the real user's ~/.omnistrate. go-homedir caches the
+	// resolved home directory process-wide, so the cache must be reset after pointing HOME
+	// at the temp dir (to pick it up) and again after HOME is restored (so later tests, and
+	// the real environment, aren't left resolving into a deleted temp dir). t.Cleanup runs
+	// LIFO, so registering the reset before t.Setenv makes it run *after* Setenv's own
+	// restore-cleanup.
+	t.Cleanup(func() { homedir.Reset() })
+	t.Setenv("HOME", t.TempDir())
+	homedir.Reset()
+
+	token := fakeJWT(t, time.Now().Add(time.Hour))
+	require.NoError(t, config.CreateOrUpdateAuthConfig(config.AuthConfig{Token: token}))
+
+	const (
+		serviceID         = "s-test"
+		environmentID     = "se-test"
+		productTierID     = "pt-test"
+		resourceName      = "myResource"
+		resourceURLKey    = "myresource-key"
+		wantSubscription  = "sub-test"
+		createdInstanceID = "instance-test"
+	)
+
+	var (
+		createRequestSeen bool
+		createRequestBody map[string]any
+	)
+
+	startCreateInstanceTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/2022-09-01-00/user":
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": "user-test"}))
+		case r.Method == http.MethodGet && r.URL.Path == "/2022-09-01-00/service":
+			require.NoError(t, json.NewEncoder(w).Encode(servicesFixture(
+				serviceFixture(serviceID, "test-service", environmentID, "prod", productTierID, "test-plan"),
+			)))
+		case r.Method == http.MethodGet && r.URL.Path == "/2022-09-01-00/service-offering/"+serviceID:
+			require.NoError(t, json.NewEncoder(w).Encode(externalDescribeServiceOfferingFixture(
+				serviceID,
+				v1ServiceOfferingFixture(environmentID, productTierID, "res-v1-test", resourceName),
+			)))
+		case r.Method == http.MethodGet && r.URL.Path == "/2022-09-01-00/fleet/service-offering/"+serviceID:
+			require.NoError(t, json.NewEncoder(w).Encode(fleetDescribeServiceOfferingFixture(
+				serviceID,
+				fleetServiceOfferingFixture(environmentID, productTierID, resourceName, resourceURLKey),
+			)))
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/2022-09-01-00/fleet/resource-instance/"):
+			createRequestSeen = true
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&createRequestBody))
+			require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"id": createdInstanceID}))
+		case r.Method == http.MethodGet && r.URL.Path == "/2022-09-01-00/fleet/service/"+serviceID+"/environment/"+environmentID+"/instance/"+createdInstanceID:
+			require.NoError(t, json.NewEncoder(w).Encode(resourceInstanceFixture(serviceID, environmentID, wantSubscription)))
+		default:
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+	})
+
+	// Stub only the customer-email-to-subscription lookup (already covered by
+	// TestResolveInstanceSubscriptionID* above) so this test's HTTP surface stays limited to
+	// what runCreate itself talks to.
+	original := resolveInstanceSubscriptionByEmail
+	t.Cleanup(func() { resolveInstanceSubscriptionByEmail = original })
+	resolveInstanceSubscriptionByEmail = func(context.Context, string, dataaccess.CustomerSubscriptionLookup) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+		return &openapiclientfleet.FleetDescribeSubscriptionResult{Id: wantSubscription}, nil
+	}
+
+	cmd := newTestCreateCommand()
+	cmd.SetContext(context.Background())
+	require.NoError(t, cmd.Flags().Set("service", serviceID))
+	require.NoError(t, cmd.Flags().Set("environment", environmentID))
+	require.NoError(t, cmd.Flags().Set("plan", productTierID))
+	require.NoError(t, cmd.Flags().Set("resource", resourceName))
+	require.NoError(t, cmd.Flags().Set("cloud-provider", "aws"))
+	require.NoError(t, cmd.Flags().Set("region", "us-east-2"))
+	require.NoError(t, cmd.Flags().Set("customer-email", "customer@example.com"))
+	require.NoError(t, cmd.Flags().Set("output", "json"))
+
+	err := runCreate(cmd, nil)
+	require.NoError(t, err)
+
+	require.True(t, createRequestSeen, "expected the create-resource-instance request to reach the stub server")
+	assert.Equal(t, wantSubscription, createRequestBody["subscriptionId"],
+		"the subscription resolved from --customer-email must reach the create-instance request body")
 }

--- a/cmd/instance/create_test.go
+++ b/cmd/instance/create_test.go
@@ -1,9 +1,12 @@
 package instance
 
 import (
+	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"
 	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
 	openapiclientv1 "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
 	"github.com/stretchr/testify/assert"
@@ -47,7 +50,7 @@ func TestCreateCommandFlags_AllExpectedFlags(t *testing.T) {
 		"service", "environment", "plan", "version", "resource",
 		"cloud-provider", "region", "param", "param-file",
 		"customer-account-id", "cloud-provider-native-network-id", "onprem-platform", "tags", "breakpoints",
-		"subscription-id", "instance-id", "wait", "network-type",
+		"subscription-id", "instance-id", "wait", "network-type", "customer-email",
 	}
 	for _, flagName := range expectedFlags {
 		flag := createCmd.Flags().Lookup(flagName)
@@ -511,4 +514,100 @@ func serviceOfferingFixture(resourceID, resourceName string) *openapiclientv1.De
 			},
 		},
 	}
+}
+
+func TestCreateCommandFlags_CustomerEmail(t *testing.T) {
+	flag := createCmd.Flags().Lookup("customer-email")
+	require.NotNil(t, flag, "Expected flag 'customer-email' to be registered")
+	assert.Contains(t, flag.Usage, "subscription")
+	assert.Equal(t, "", flag.DefValue)
+}
+
+func TestValidateCustomerEmailFlags(t *testing.T) {
+	require.NoError(t, validateCustomerEmailFlags("", ""))
+	require.NoError(t, validateCustomerEmailFlags("", "sub-test"))
+	require.NoError(t, validateCustomerEmailFlags("customer@example.com", ""))
+
+	err := validateCustomerEmailFlags("customer@example.com", "sub-test")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--customer-email")
+	assert.Contains(t, err.Error(), "--subscription-id")
+
+	err = validateCustomerEmailFlags("not-an-email", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--customer-email")
+}
+
+func TestResolveInstanceSubscriptionIDWithoutEmailPassesThrough(t *testing.T) {
+	original := resolveInstanceSubscriptionByEmail
+	t.Cleanup(func() { resolveInstanceSubscriptionByEmail = original })
+
+	resolveInstanceSubscriptionByEmail = func(context.Context, string, dataaccess.CustomerSubscriptionLookup) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+		t.Fatal("subscription lookup should not be called without --customer-email")
+		return nil, nil
+	}
+
+	subscriptionID, err := resolveInstanceSubscriptionID(
+		context.Background(),
+		"token",
+		dataaccess.CustomerSubscriptionLookup{ServiceID: "s-test"},
+		"sub-test",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "sub-test", subscriptionID)
+}
+
+func TestResolveInstanceSubscriptionIDResolvesEmail(t *testing.T) {
+	original := resolveInstanceSubscriptionByEmail
+	t.Cleanup(func() { resolveInstanceSubscriptionByEmail = original })
+
+	resolveInstanceSubscriptionByEmail = func(ctx context.Context, token string, lookup dataaccess.CustomerSubscriptionLookup) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+		assert.Equal(t, "token", token)
+		assert.Equal(t, "s-test", lookup.ServiceID)
+		assert.Equal(t, "se-test", lookup.EnvironmentID)
+		assert.Equal(t, "PROD", lookup.EnvironmentType)
+		assert.Equal(t, "pt-test", lookup.PlanID)
+		assert.Equal(t, "customer@example.com", lookup.CustomerEmail)
+		return &openapiclientfleet.FleetDescribeSubscriptionResult{Id: "sub-test"}, nil
+	}
+
+	subscriptionID, err := resolveInstanceSubscriptionID(
+		context.Background(),
+		"token",
+		dataaccess.CustomerSubscriptionLookup{
+			ServiceID:       "s-test",
+			EnvironmentID:   "se-test",
+			EnvironmentType: "PROD",
+			PlanID:          "pt-test",
+			CustomerEmail:   "customer@example.com",
+		},
+		"",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "sub-test", subscriptionID)
+}
+
+func TestResolveInstanceSubscriptionIDRejectsEmptyResult(t *testing.T) {
+	original := resolveInstanceSubscriptionByEmail
+	t.Cleanup(func() { resolveInstanceSubscriptionByEmail = original })
+
+	resolveInstanceSubscriptionByEmail = func(context.Context, string, dataaccess.CustomerSubscriptionLookup) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+		return &openapiclientfleet.FleetDescribeSubscriptionResult{}, nil
+	}
+
+	_, err := resolveInstanceSubscriptionID(
+		context.Background(),
+		"token",
+		dataaccess.CustomerSubscriptionLookup{CustomerEmail: "customer@example.com"},
+		"",
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "empty subscription id")
+}
+
+func TestCreateExampleDocumentsCustomerEmail(t *testing.T) {
+	assert.Contains(t, createExample, "--customer-email")
 }

--- a/cmd/instance/create_test.go
+++ b/cmd/instance/create_test.go
@@ -886,7 +886,11 @@ func TestRunCreateWiresResolvedSubscriptionIDIntoCreateRequest(t *testing.T) {
 	// what runCreate itself talks to.
 	original := resolveInstanceSubscriptionByEmail
 	t.Cleanup(func() { resolveInstanceSubscriptionByEmail = original })
-	resolveInstanceSubscriptionByEmail = func(context.Context, string, dataaccess.CustomerSubscriptionLookup) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+	resolveInstanceSubscriptionByEmail = func(_ context.Context, _ string, lookup dataaccess.CustomerSubscriptionLookup) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+		// The fixture's offering carries ServiceEnvironmentType "PROD"; this must reach the
+		// lookup unchanged so the production org-scoped fallback stays wired in. Dropping
+		// this field on the caller side silently reinstates the duplicate-subscription bug.
+		assert.Equal(t, "PROD", lookup.EnvironmentType)
 		return &openapiclientfleet.FleetDescribeSubscriptionResult{Id: wantSubscription}, nil
 	}
 

--- a/docs/superpowers/plans/2026-09-07-instance-create-customer-email.md
+++ b/docs/superpowers/plans/2026-09-07-instance-create-customer-email.md
@@ -1068,8 +1068,11 @@ In `internal/dataaccess/subscription.go`, replace the `if customerUserID == "" &
 	}
 ```
 
-Note the response body is now closed on both the success and error paths; the original closed it
-only after the error check.
+The original already closed the response body on both paths, via two identical close sites; this
+collapses them into one before the error check, which is behaviour-neutral. The one real
+behaviour change is in the extracted matcher: the original dereferenced `*user.UserId`
+unconditionally once the email matched, so a user with a nil `UserId` would panic.
+`matchUserIDByEmail` guards it and skips the entry.
 
 Then add, next to the other helpers:
 

--- a/docs/superpowers/plans/2026-09-07-instance-create-customer-email.md
+++ b/docs/superpowers/plans/2026-09-07-instance-create-customer-email.md
@@ -1356,7 +1356,7 @@ Expected: PASS.
 
 - [ ] **Step 7: Regenerate the docs**
 
-Run: `make docs`
+Run: `make gen-doc` (note: there is no `docs` target — a `docs/` directory shadows that name)
 Then: `git status --short mkdocs/` — expect a modified `omnistrate-ctl_instance_create.md` containing `--customer-email`.
 
 - [ ] **Step 8: Verify no identifying data leaked**

--- a/docs/superpowers/plans/2026-09-07-instance-create-customer-email.md
+++ b/docs/superpowers/plans/2026-09-07-instance-create-customer-email.md
@@ -1,0 +1,1441 @@
+# `instance create --customer-email` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let `omnistrate-ctl instance create` accept `--customer-email` and resolve (or create) the customer's subscription for the target service plan, instead of requiring a hand-copied `--subscription-id`.
+
+**Architecture:** The resolution lives in the shared `internal/dataaccess` lookup that `instance adopt` and `account customer create` already call, so all three commands gain the same behaviour. That lookup is rewritten to paginate, to fall back to the production-only org-scoped email form (`<local>+<orgID>@<domain>`), and to reject non-ACTIVE subscriptions with an actionable error. `cmd/instance/create.go` mirrors the flag handling of `account customer create`.
+
+**Tech Stack:** Go 1.26, cobra, `omnistrate-sdk-go` (fleet + v1 clients), testify, `net/http/httptest` for dataaccess tests.
+
+**Spec:** `docs/superpowers/specs/2026-09-07-instance-create-customer-email-design.md`
+
+## Global Constraints
+
+- **No identifying data anywhere.** Code, comments, test fixtures, docs, and commit/PR text use placeholders only: `customer@example.com`, `provider@example.com`, `org-abc123`, `s-test`, `se-test`, `pt-test`, `sub-test`. Never a real customer, organization, person, or domain.
+- **Org scoping is production-only.** The `<local>+<orgID>@<domain>` fallback must never run outside a production environment type.
+- **Subscription status vocabulary:** `ACTIVE`, `SUSPENDED`, `CANCELLED`, `TERMINATED`. Only `ACTIVE` may back a new instance.
+- **Do not enable `IncludeInactive` on the subscription listing.** It switches the server to an unscoped query that returns soft-deleted (terminated) rows, which would block legitimate re-subscription.
+- `account customer create` (`cmd/account/customer_create.go`) is the reference for flag naming, validation, and call ordering. Do not replicate its PROD "default to the calling user's own email" behaviour (`customer_create.go:610`) in `instance create`.
+- Run `make unit-test` before every commit. Commit only with tests passing.
+
+## Before you start
+
+The working tree may contain an untracked `internal/dataaccess/k8sclient_test.go` that does not
+compile (it references `restConfigForHostClusterKubeConfig` and `k8sRequestTimeout`, which do not
+exist). It is unrelated to this work, but it fails the build of the whole `internal/dataaccess`
+test binary, so every `go test ./internal/dataaccess/...` in this plan will fail until it is dealt
+with. Check first:
+
+```bash
+git status --short internal/dataaccess/k8sclient_test.go
+go vet ./internal/dataaccess/
+```
+
+If it is present and broken, move it out of the package for the duration of this work and put it
+back afterwards. Do not delete it and do not commit it — it is someone's work in progress.
+
+All fixture payloads used in this plan were verified to decode against the SDK models
+(`FleetListSubscriptionsResult`, `FleetListAllUsersResult`, `FleetDescribeSubscriptionResult`,
+`FleetCreateSubscriptionOnBehalfOfCustomerResult`, v1 `DescribeUserResult`), so a decode failure in
+these tests means the fixture was altered, not that a required field is missing.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `internal/utils/scopedemail.go` (create) | Pure org-scoped email helpers + production environment-type predicate. No API calls. |
+| `internal/utils/scopedemail_test.go` (create) | Unit tests for the above. |
+| `internal/dataaccess/subscription.go` (modify) | Candidate matching, status gate, the rewritten lookup, and the extracted user-ID resolver. |
+| `internal/dataaccess/subscription_test.go` (create) | Pure-function tests plus `httptest`-backed lookup tests. |
+| `cmd/account/customer_create.go` (modify) | Call the lookup with the new options struct; delegate the PROD predicate to `utils`. |
+| `cmd/account/customer_create_test.go` (modify) | Update the injected stub signature. |
+| `cmd/instance/create.go` (modify) | `--customer-email` flag, validation, and subscription resolution. |
+| `cmd/instance/create_test.go` (modify) | Flag registration, validation, and resolution wiring tests. |
+| `mkdocs/docs/` (regenerate) | Generated CLI reference. |
+
+---
+
+### Task 1: Org-scoped email helpers
+
+Pure string helpers mirroring the server's `commons/pkg/utils/scopedorgutils.go`, plus the production predicate that gates when scoping applies. No dependencies on other tasks.
+
+**Files:**
+- Create: `internal/utils/scopedemail.go`
+- Test: `internal/utils/scopedemail_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `utils.FormatEmailWithScopedOrg(email, orgID string) (string, error)`
+  - `utils.EmailHasScopedOrg(email string) bool`
+  - `utils.IsProductionEnvironmentType(environmentType string) bool`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/utils/scopedemail_test.go`:
+
+```go
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatEmailWithScopedOrg(t *testing.T) {
+	scoped, err := FormatEmailWithScopedOrg("customer@example.com", "org-abc123")
+	require.NoError(t, err)
+	assert.Equal(t, "customer+org-abc123@example.com", scoped)
+}
+
+func TestFormatEmailWithScopedOrgPreservesExistingPlusTag(t *testing.T) {
+	scoped, err := FormatEmailWithScopedOrg("customer+team@example.com", "org-abc123")
+	require.NoError(t, err)
+	assert.Equal(t, "customer+team+org-abc123@example.com", scoped)
+}
+
+func TestFormatEmailWithScopedOrgRejectsAlreadyScopedEmail(t *testing.T) {
+	_, err := FormatEmailWithScopedOrg("customer+org-abc123@example.com", "org-abc123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already scoped")
+}
+
+func TestFormatEmailWithScopedOrgRejectsBadInput(t *testing.T) {
+	for name, tc := range map[string]struct{ email, orgID string }{
+		"no at sign":    {"customer.example.com", "org-abc123"},
+		"two at signs":  {"customer@example@com", "org-abc123"},
+		"empty org":     {"customer@example.com", ""},
+		"org bad shape": {"customer@example.com", "abc123"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := FormatEmailWithScopedOrg(tc.email, tc.orgID)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestEmailHasScopedOrg(t *testing.T) {
+	assert.True(t, EmailHasScopedOrg("customer+org-abc123@example.com"))
+	assert.True(t, EmailHasScopedOrg("customer+team+org-abc123@example.com"))
+	assert.False(t, EmailHasScopedOrg("customer@example.com"))
+	assert.False(t, EmailHasScopedOrg("customer+team@example.com"))
+	assert.False(t, EmailHasScopedOrg("not-an-email"))
+}
+
+func TestIsProductionEnvironmentType(t *testing.T) {
+	assert.True(t, IsProductionEnvironmentType("PROD"))
+	assert.True(t, IsProductionEnvironmentType("production"))
+	assert.True(t, IsProductionEnvironmentType("  Prod  "))
+	assert.False(t, IsProductionEnvironmentType("DEV"))
+	assert.False(t, IsProductionEnvironmentType(""))
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/utils/ -run 'ScopedOrg|ProductionEnvironmentType' -v`
+Expected: FAIL — `undefined: FormatEmailWithScopedOrg`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `internal/utils/scopedemail.go`:
+
+```go
+package utils
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// scopedOrgIDRegex matches an organization ID. It mirrors the server-side definition so the
+// CLI and the platform agree on what the trailing segment of a scoped address looks like.
+var scopedOrgIDRegex = regexp.MustCompile(`^org-[a-zA-Z0-9][a-zA-Z0-9._\-]*$`)
+
+// FormatEmailWithScopedOrg returns the org-scoped form of an address, which is how the
+// platform stores an end customer's identity inside a service provider's organization:
+//
+//	("customer@example.com", "org-abc123") -> "customer+org-abc123@example.com"
+//
+// Any plus tag already present is preserved, with the organization ID appended after it.
+func FormatEmailWithScopedOrg(email, orgID string) (string, error) {
+	localPart, domain, err := splitEmail(email)
+	if err != nil {
+		return "", err
+	}
+	if !scopedOrgIDRegex.MatchString(orgID) {
+		return "", fmt.Errorf("invalid organization ID %q", orgID)
+	}
+	if localPartHasScopedOrg(localPart) {
+		return "", fmt.Errorf("email %q is already scoped to an organization", email)
+	}
+
+	return fmt.Sprintf("%s+%s@%s", localPart, orgID, domain), nil
+}
+
+// EmailHasScopedOrg reports whether an address already carries an organization ID as the
+// last segment of its local part.
+func EmailHasScopedOrg(email string) bool {
+	localPart, _, err := splitEmail(email)
+	if err != nil {
+		return false
+	}
+	return localPartHasScopedOrg(localPart)
+}
+
+// IsProductionEnvironmentType reports whether an environment type is a production one.
+// Org-scoped customer identities only exist in production environments.
+func IsProductionEnvironmentType(environmentType string) bool {
+	switch strings.ToUpper(strings.TrimSpace(environmentType)) {
+	case "PROD", "PRODUCTION":
+		return true
+	default:
+		return false
+	}
+}
+
+func splitEmail(email string) (localPart, domain string, err error) {
+	parts := strings.Split(strings.TrimSpace(email), "@")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid email address %q", email)
+	}
+	return parts[0], parts[1], nil
+}
+
+func localPartHasScopedOrg(localPart string) bool {
+	segments := strings.Split(localPart, "+")
+	if len(segments) < 2 {
+		return false
+	}
+	return scopedOrgIDRegex.MatchString(segments[len(segments)-1])
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/utils/ -run 'ScopedOrg|ProductionEnvironmentType' -v`
+Expected: PASS, all subtests included.
+
+- [ ] **Step 5: Run the package suite and commit**
+
+Run: `go test ./internal/utils/`
+Expected: PASS.
+
+```bash
+git add internal/utils/scopedemail.go internal/utils/scopedemail_test.go
+git commit -m "feat: add org-scoped email helpers
+
+Adds the formatting and detection helpers for the <local>+<orgID>@<domain>
+identity form, plus the production environment-type predicate that gates
+where that form applies."
+```
+
+---
+
+### Task 2: Candidate matching and the subscription status gate
+
+Two pure functions in `internal/dataaccess`, with no network access, that decide which subscription a customer email resolves to and what error a non-usable one produces.
+
+**Files:**
+- Modify: `internal/dataaccess/subscription.go` (add functions; leave existing ones untouched in this task)
+- Test: `internal/dataaccess/subscription_test.go` (create)
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces:
+  - `matchSubscriptionsByEmail(subscriptions []openapiclientfleet.FleetDescribeSubscriptionResult, planID, email string) []openapiclientfleet.FleetDescribeSubscriptionResult`
+  - `selectCustomerSubscription(candidates []openapiclientfleet.FleetDescribeSubscriptionResult, customerEmail string) (*openapiclientfleet.FleetDescribeSubscriptionResult, error)` — returns `(nil, nil)` when there are no candidates, which tells the caller to create one.
+  - `const subscriptionStatusActive = "ACTIVE"`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/dataaccess/subscription_test.go`:
+
+```go
+package dataaccess
+
+import (
+	"testing"
+
+	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testSubscription(id, email, status string) openapiclientfleet.FleetDescribeSubscriptionResult {
+	return openapiclientfleet.FleetDescribeSubscriptionResult{
+		Id:              id,
+		ProductTierId:   "pt-test",
+		ProductTierName: "test-plan",
+		RootUserEmail:   email,
+		Status:          status,
+	}
+}
+
+func TestMatchSubscriptionsByEmailIsCaseInsensitive(t *testing.T) {
+	subscriptions := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "Customer@Example.com", "ACTIVE"),
+	}
+
+	matches := matchSubscriptionsByEmail(subscriptions, "pt-test", "customer@example.com")
+
+	require.Len(t, matches, 1)
+	assert.Equal(t, "sub-1", matches[0].Id)
+}
+
+func TestMatchSubscriptionsByEmailFiltersOtherPlans(t *testing.T) {
+	other := testSubscription("sub-2", "customer@example.com", "ACTIVE")
+	other.ProductTierId = "pt-other"
+	subscriptions := []openapiclientfleet.FleetDescribeSubscriptionResult{other}
+
+	matches := matchSubscriptionsByEmail(subscriptions, "pt-test", "customer@example.com")
+
+	assert.Empty(t, matches)
+}
+
+func TestMatchSubscriptionsByEmailDoesNotMatchScopedFormImplicitly(t *testing.T) {
+	subscriptions := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "customer+org-abc123@example.com", "ACTIVE"),
+	}
+
+	matches := matchSubscriptionsByEmail(subscriptions, "pt-test", "customer@example.com")
+
+	assert.Empty(t, matches, "the scoped form must only match when the caller asks for it explicitly")
+}
+
+func TestSelectCustomerSubscriptionNoCandidatesSignalsCreate(t *testing.T) {
+	subscription, err := selectCustomerSubscription(nil, "customer@example.com")
+
+	require.NoError(t, err)
+	assert.Nil(t, subscription)
+}
+
+func TestSelectCustomerSubscriptionReturnsSingleActive(t *testing.T) {
+	candidates := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "customer@example.com", "ACTIVE"),
+	}
+
+	subscription, err := selectCustomerSubscription(candidates, "customer@example.com")
+
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+	assert.Equal(t, "sub-1", subscription.Id)
+}
+
+func TestSelectCustomerSubscriptionIgnoresNonActiveWhenAnActiveExists(t *testing.T) {
+	candidates := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "customer@example.com", "SUSPENDED"),
+		testSubscription("sub-2", "customer@example.com", "ACTIVE"),
+	}
+
+	subscription, err := selectCustomerSubscription(candidates, "customer@example.com")
+
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+	assert.Equal(t, "sub-2", subscription.Id)
+}
+
+func TestSelectCustomerSubscriptionRejectsMultipleActive(t *testing.T) {
+	candidates := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "customer@example.com", "ACTIVE"),
+		testSubscription("sub-2", "customer@example.com", "ACTIVE"),
+	}
+
+	_, err := selectCustomerSubscription(candidates, "customer@example.com")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sub-1")
+	assert.Contains(t, err.Error(), "sub-2")
+	assert.Contains(t, err.Error(), "--subscription-id")
+}
+
+func TestSelectCustomerSubscriptionReportsSuspended(t *testing.T) {
+	candidates := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "customer@example.com", "SUSPENDED"),
+	}
+
+	_, err := selectCustomerSubscription(candidates, "customer@example.com")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sub-1")
+	assert.Contains(t, err.Error(), "SUSPENDED")
+	assert.Contains(t, err.Error(), "omnistrate-ctl subscription resume sub-1")
+}
+
+func TestSelectCustomerSubscriptionReportsOtherNonActiveStatus(t *testing.T) {
+	candidates := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "customer@example.com", "CANCELLED"),
+	}
+
+	_, err := selectCustomerSubscription(candidates, "customer@example.com")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CANCELLED")
+	assert.Contains(t, err.Error(), "expected ACTIVE")
+	assert.NotContains(t, err.Error(), "subscription resume")
+}
+
+func TestSelectCustomerSubscriptionReportsEveryNonActiveCandidate(t *testing.T) {
+	candidates := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "customer@example.com", "SUSPENDED"),
+		testSubscription("sub-2", "customer@example.com", "CANCELLED"),
+	}
+
+	_, err := selectCustomerSubscription(candidates, "customer@example.com")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sub-1 (SUSPENDED)")
+	assert.Contains(t, err.Error(), "sub-2 (CANCELLED)")
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/dataaccess/ -run 'MatchSubscriptionsByEmail|SelectCustomerSubscription' -v`
+Expected: FAIL — `undefined: matchSubscriptionsByEmail`.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `internal/dataaccess/subscription.go`:
+
+```go
+// subscriptionStatusActive is the only subscription status that may back a new instance.
+// The platform's full vocabulary is ACTIVE, SUSPENDED, CANCELLED and TERMINATED.
+const subscriptionStatusActive = "ACTIVE"
+
+// matchSubscriptionsByEmail returns the subscriptions on a plan whose root user is the
+// given address. The plan filter is redundant with the server-side query parameter and is
+// kept so the matching is correct on its own terms.
+func matchSubscriptionsByEmail(
+	subscriptions []openapiclientfleet.FleetDescribeSubscriptionResult,
+	planID string,
+	email string,
+) []openapiclientfleet.FleetDescribeSubscriptionResult {
+	matches := make([]openapiclientfleet.FleetDescribeSubscriptionResult, 0, 1)
+	for _, subscription := range subscriptions {
+		if planID != "" && !strings.EqualFold(subscription.ProductTierId, planID) {
+			continue
+		}
+		if !strings.EqualFold(subscription.RootUserEmail, email) {
+			continue
+		}
+		matches = append(matches, subscription)
+	}
+	return matches
+}
+
+// selectCustomerSubscription picks the one subscription that may back a new instance.
+// It returns (nil, nil) when there is nothing to choose from, which tells the caller to
+// create a subscription instead.
+func selectCustomerSubscription(
+	candidates []openapiclientfleet.FleetDescribeSubscriptionResult,
+	customerEmail string,
+) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	active := make([]openapiclientfleet.FleetDescribeSubscriptionResult, 0, len(candidates))
+	for _, candidate := range candidates {
+		if strings.EqualFold(candidate.Status, subscriptionStatusActive) {
+			active = append(active, candidate)
+		}
+	}
+
+	switch len(active) {
+	case 1:
+		selected := active[0]
+		return &selected, nil
+	case 0:
+		return nil, unusableSubscriptionError(candidates, customerEmail)
+	default:
+		ids := make([]string, 0, len(active))
+		for _, candidate := range active {
+			ids = append(ids, candidate.Id)
+		}
+		return nil, errors.Errorf(
+			"found %d active subscriptions for customer %s on plan %s (%s). Pass --subscription-id to choose one",
+			len(active),
+			customerEmail,
+			active[0].ProductTierName,
+			strings.Join(ids, ", "),
+		)
+	}
+}
+
+// unusableSubscriptionError explains why the subscriptions a customer does own cannot back
+// a new instance, and names the remedy when there is one.
+func unusableSubscriptionError(
+	candidates []openapiclientfleet.FleetDescribeSubscriptionResult,
+	customerEmail string,
+) error {
+	if len(candidates) == 1 {
+		candidate := candidates[0]
+		if strings.EqualFold(candidate.Status, "SUSPENDED") {
+			return errors.Errorf(
+				"subscription %s for customer %s on plan %s is SUSPENDED and cannot be used to create an instance. "+
+					"Resume it with 'omnistrate-ctl subscription resume %s', or pass --subscription-id to use a different subscription",
+				candidate.Id,
+				customerEmail,
+				candidate.ProductTierName,
+				candidate.Id,
+			)
+		}
+		return errors.Errorf(
+			"subscription %s for customer %s on plan %s is in status %s, expected ACTIVE, so it cannot be used to create an instance. "+
+				"Pass --subscription-id to use a different subscription",
+			candidate.Id,
+			customerEmail,
+			candidate.ProductTierName,
+			candidate.Status,
+		)
+	}
+
+	described := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		described = append(described, fmt.Sprintf("%s (%s)", candidate.Id, candidate.Status))
+	}
+	return errors.Errorf(
+		"customer %s has no active subscription on plan %s; found %s. "+
+			"Resume a suspended subscription with 'omnistrate-ctl subscription resume', or pass --subscription-id",
+		customerEmail,
+		candidates[0].ProductTierName,
+		strings.Join(described, ", "),
+	)
+}
+```
+
+Add `"fmt"` to the import block of `internal/dataaccess/subscription.go`; `strings` and `github.com/pkg/errors` are already imported.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/dataaccess/ -run 'MatchSubscriptionsByEmail|SelectCustomerSubscription' -v`
+Expected: PASS (10 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/dataaccess/subscription.go internal/dataaccess/subscription_test.go
+git commit -m "feat: add subscription candidate matching and status gate
+
+Adds the pure matching and selection helpers that decide which
+subscription a customer email resolves to, and produce an actionable
+error when the only matches are suspended or otherwise not active."
+```
+
+---
+
+### Task 3: Rewrite the customer-email lookup
+
+Replace the positional lookup with an options struct carrying the environment type, add pagination and the production-only scoped fallback, and apply the Task 2 status gate. The signature change forces the two call sites and their stubs to move in the same commit.
+
+**Files:**
+- Modify: `internal/dataaccess/subscription.go:37-119`
+- Modify: `cmd/account/customer_create.go:626-646` (the `resolveCustomerSubscriptionByEmail` call) and `cmd/account/customer_create.go:651-658` (`isProductionEnvironmentType`)
+- Modify: `cmd/account/customer_create_test.go:362`, `:406`, `:439` (stub signatures)
+- Test: `internal/dataaccess/subscription_test.go` (append)
+
+**Interfaces:**
+- Consumes: `utils.FormatEmailWithScopedOrg`, `utils.EmailHasScopedOrg`, `utils.IsProductionEnvironmentType` (Task 1); `matchSubscriptionsByEmail`, `selectCustomerSubscription` (Task 2).
+- Produces:
+  - `dataaccess.CustomerSubscriptionLookup` struct with fields `ServiceID`, `EnvironmentID`, `EnvironmentType`, `PlanID`, `CustomerEmail` (all `string`).
+  - `dataaccess.GetSubscriptionByCustomerEmailInEnvironment(ctx context.Context, token string, lookup CustomerSubscriptionLookup) (*openapiclientfleet.FleetDescribeSubscriptionResult, error)`
+  - `dataaccess.GetSubscriptionByCustomerEmail(ctx context.Context, token, serviceID, planID, customerEmail string) (*openapiclientfleet.FleetDescribeSubscriptionResult, error)` — signature unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/dataaccess/subscription_test.go`. Add these imports to the file's import block: `"context"`, `"encoding/json"`, `"net/http"`, `"net/http/httptest"`, `"net/url"`, `"strings"`.
+
+```go
+// subscriptionJSON builds a fleet subscription payload with every field the SDK requires.
+func subscriptionJSON(id, email, status string) map[string]any {
+	return map[string]any{
+		"createdAt":         "2026-09-07T00:00:00Z",
+		"id":                id,
+		"instanceCount":     0,
+		"productTierId":     "pt-test",
+		"productTierName":   "test-plan",
+		"rootUserEmail":     email,
+		"rootUserId":        "user-test",
+		"rootUserName":      "test-customer",
+		"serviceId":         "s-test",
+		"serviceName":       "test-service",
+		"status":            status,
+		"updatedAt":         "2026-09-07T00:00:00Z",
+		"updatedByUserId":   "user-test",
+		"updatedByUserName": "test-customer",
+	}
+}
+
+// startSubscriptionTestServer points the SDK clients at a stub server for the duration of
+// the test and returns it.
+func startSubscriptionTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	t.Setenv("OMNISTRATE_HOST", serverURL.Host)
+	t.Setenv("OMNISTRATE_HOST_SCHEME", serverURL.Scheme)
+	t.Setenv("CLIENT_TIMEOUT_IN_SECONDS", "5")
+	t.Setenv("OMNISTRATE_RETRY_MAX", "0")
+
+	return server
+}
+
+func TestGetSubscriptionByCustomerEmailInEnvironmentPaginates(t *testing.T) {
+	var listCalls int
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription", r.URL.Path)
+		require.Equal(t, "pt-test", r.URL.Query().Get("productTierId"))
+		listCalls++
+
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("nextPageToken") == "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ids":           []string{"sub-1"},
+				"subscriptions": []map[string]any{subscriptionJSON("sub-1", "other@example.com", "ACTIVE")},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ids":           []string{"sub-2"},
+			"subscriptions": []map[string]any{subscriptionJSON("sub-2", "customer@example.com", "ACTIVE")},
+		})
+	})
+
+	subscription, err := GetSubscriptionByCustomerEmailInEnvironment(context.Background(), "test-token", CustomerSubscriptionLookup{
+		ServiceID:       "s-test",
+		EnvironmentID:   "se-test",
+		EnvironmentType: "DEV",
+		PlanID:          "pt-test",
+		CustomerEmail:   "customer@example.com",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+	assert.Equal(t, "sub-2", subscription.Id)
+	assert.Equal(t, 2, listCalls, "the lookup must follow nextPageToken")
+}
+
+func TestGetSubscriptionByCustomerEmailInEnvironmentFallsBackToScopedEmailInProd(t *testing.T) {
+	var describeUserCalls int
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/2022-09-01-00/user":
+			describeUserCalls++
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "user-provider", "orgId": "org-abc123"})
+		case "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ids": []string{"sub-1"},
+				"subscriptions": []map[string]any{
+					subscriptionJSON("sub-1", "customer+org-abc123@example.com", "ACTIVE"),
+				},
+			})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	subscription, err := GetSubscriptionByCustomerEmailInEnvironment(context.Background(), "test-token", CustomerSubscriptionLookup{
+		ServiceID:       "s-test",
+		EnvironmentID:   "se-test",
+		EnvironmentType: "PROD",
+		PlanID:          "pt-test",
+		CustomerEmail:   "customer@example.com",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+	assert.Equal(t, "sub-1", subscription.Id)
+	assert.Equal(t, 1, describeUserCalls)
+}
+
+func TestGetSubscriptionByCustomerEmailInEnvironmentSkipsScopedFallbackOutsideProd(t *testing.T) {
+	var createCalls int
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/2022-09-01-00/user":
+			t.Fatal("describe user must not be called outside production")
+		case r.URL.Path == "/2022-09-01-00/fleet/users":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"users": []map[string]any{{"userId": "user-test", "email": "customer@example.com"}},
+			})
+		case r.URL.Path == "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription" && r.Method == http.MethodPost:
+			createCalls++
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "sub-new"})
+		case r.URL.Path == "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ids":           []string{"sub-1"},
+				"subscriptions": []map[string]any{subscriptionJSON("sub-1", "customer+org-abc123@example.com", "ACTIVE")},
+			})
+		case r.URL.Path == "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription/sub-new":
+			_ = json.NewEncoder(w).Encode(subscriptionJSON("sub-new", "customer@example.com", "ACTIVE"))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	subscription, err := GetSubscriptionByCustomerEmailInEnvironment(context.Background(), "test-token", CustomerSubscriptionLookup{
+		ServiceID:       "s-test",
+		EnvironmentID:   "se-test",
+		EnvironmentType: "DEV",
+		PlanID:          "pt-test",
+		CustomerEmail:   "customer@example.com",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+	assert.Equal(t, "sub-new", subscription.Id)
+	assert.Equal(t, 1, createCalls)
+}
+
+func TestGetSubscriptionByCustomerEmailInEnvironmentReportsSuspended(t *testing.T) {
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			t.Fatal("a suspended subscription must not trigger a create")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ids":           []string{"sub-1"},
+			"subscriptions": []map[string]any{subscriptionJSON("sub-1", "customer@example.com", "SUSPENDED")},
+		})
+	})
+
+	_, err := GetSubscriptionByCustomerEmailInEnvironment(context.Background(), "test-token", CustomerSubscriptionLookup{
+		ServiceID:       "s-test",
+		EnvironmentID:   "se-test",
+		EnvironmentType: "DEV",
+		PlanID:          "pt-test",
+		CustomerEmail:   "customer@example.com",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SUSPENDED")
+	assert.Contains(t, err.Error(), "omnistrate-ctl subscription resume sub-1")
+}
+
+func TestGetSubscriptionByCustomerEmailInEnvironmentRequiresEmail(t *testing.T) {
+	_, err := GetSubscriptionByCustomerEmailInEnvironment(context.Background(), "test-token", CustomerSubscriptionLookup{
+		ServiceID:     "s-test",
+		EnvironmentID: "se-test",
+		PlanID:        "pt-test",
+		CustomerEmail: "   ",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "customer email is required")
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/dataaccess/ -run GetSubscriptionByCustomerEmailInEnvironment -v`
+Expected: FAIL — `undefined: CustomerSubscriptionLookup`.
+
+- [ ] **Step 3: Replace the lookup implementation**
+
+In `internal/dataaccess/subscription.go`, replace the whole of `GetSubscriptionByCustomerEmail` and `GetSubscriptionByCustomerEmailInEnvironment` (currently lines 37-119) with:
+
+```go
+// CustomerSubscriptionLookup identifies the customer and the plan a subscription is being
+// resolved for. EnvironmentType decides whether the org-scoped email fallback applies,
+// because org-scoped customer identities only exist in production environments.
+type CustomerSubscriptionLookup struct {
+	ServiceID       string
+	EnvironmentID   string
+	EnvironmentType string
+	PlanID          string
+	CustomerEmail   string
+}
+
+func GetSubscriptionByCustomerEmail(ctx context.Context, token string, serviceID string, planID string, customerEmail string) (resp *openapiclientfleet.FleetDescribeSubscriptionResult, err error) {
+	// Describe the service offering for this service and plan (product tier) ID to get the environment ID
+	serviceOfferingResult, err := DescribeServiceOffering(ctx, token, serviceID, planID, "")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, offering := range serviceOfferingResult.ConsumptionDescribeServiceOfferingResult.Offerings {
+		if offering.ProductTierID == planID {
+			return GetSubscriptionByCustomerEmailInEnvironment(ctx, token, CustomerSubscriptionLookup{
+				ServiceID:       serviceID,
+				EnvironmentID:   offering.ServiceEnvironmentID,
+				EnvironmentType: offering.ServiceEnvironmentType,
+				PlanID:          planID,
+				CustomerEmail:   customerEmail,
+			})
+		}
+	}
+
+	err = errors.New("no subscription found for the given customer email or the plan does not exist")
+	return
+}
+
+// GetSubscriptionByCustomerEmailInEnvironment resolves the subscription a customer owns for
+// a plan, creating one when the customer has none.
+//
+// The listing deliberately leaves IncludeInactive off. Terminating a subscription
+// soft-deletes its row, and only the inactive listing returns soft-deleted rows, so a
+// terminated subscription is correctly invisible here and the customer can be resubscribed.
+// A suspended subscription stays live and is reported rather than silently duplicated.
+func GetSubscriptionByCustomerEmailInEnvironment(
+	ctx context.Context,
+	token string,
+	lookup CustomerSubscriptionLookup,
+) (resp *openapiclientfleet.FleetDescribeSubscriptionResult, err error) {
+	customerEmail := strings.TrimSpace(lookup.CustomerEmail)
+	if customerEmail == "" {
+		return nil, errors.New("customer email is required to look up a subscription")
+	}
+
+	subscriptions, err := ListAllSubscriptions(ctx, token, lookup.ServiceID, lookup.EnvironmentID, &ListSubscriptionsOptions{
+		ProductTierId: &lookup.PlanID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	candidates := matchSubscriptionsByEmail(subscriptions, lookup.PlanID, customerEmail)
+
+	// In production the platform stores an end customer's identity scoped to the service
+	// provider's organization, so a customer with no match under the plain address may still
+	// own a subscription under <local>+<orgID>@<domain>.
+	if len(candidates) == 0 &&
+		utils.IsProductionEnvironmentType(lookup.EnvironmentType) &&
+		!utils.EmailHasScopedOrg(customerEmail) {
+		var scopedEmail string
+		if scopedEmail, err = scopedCustomerEmail(ctx, token, customerEmail); err != nil {
+			return nil, err
+		}
+		candidates = matchSubscriptionsByEmail(subscriptions, lookup.PlanID, scopedEmail)
+	}
+
+	selected, err := selectCustomerSubscription(candidates, customerEmail)
+	if err != nil {
+		return nil, err
+	}
+	if selected != nil {
+		return selected, nil
+	}
+
+	createResp, err := CreateSubscriptionOnBehalf(ctx, token, lookup.ServiceID, lookup.EnvironmentID, &CreateSubscriptionOnBehalfOptions{
+		ProductTierID:           lookup.PlanID,
+		OnBehalfOfCustomerEmail: customerEmail,
+		EnvironmentType:         lookup.EnvironmentType,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create subscription for user %s", customerEmail)
+	}
+
+	subscriptionID := strings.TrimSpace(createResp.GetId())
+	if subscriptionID == "" {
+		return nil, errors.Errorf("subscription creation for user %s returned an empty subscription ID", customerEmail)
+	}
+
+	resp, err = DescribeSubscription(ctx, token, lookup.ServiceID, lookup.EnvironmentID, subscriptionID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to describe newly created subscription for user %s", customerEmail)
+	}
+
+	// A newly created subscription goes through the same status gate, so every "unusable
+	// subscription" message in this command comes from one place.
+	if _, err = selectCustomerSubscription([]openapiclientfleet.FleetDescribeSubscriptionResult{*resp}, customerEmail); err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+// scopedCustomerEmail builds the org-scoped form of a customer address using the calling
+// service provider's organization ID.
+func scopedCustomerEmail(ctx context.Context, token, customerEmail string) (string, error) {
+	user, err := DescribeUser(ctx, token)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to describe the current user to resolve the provider organization ID")
+	}
+	if user == nil || user.OrgId == nil || strings.TrimSpace(*user.OrgId) == "" {
+		return "", errors.New("describe user returned an empty organization ID; cannot check for an org-scoped customer subscription")
+	}
+
+	scopedEmail, err := utils.FormatEmailWithScopedOrg(customerEmail, strings.TrimSpace(*user.OrgId))
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to build the org-scoped form of %s", customerEmail)
+	}
+	return scopedEmail, nil
+}
+```
+
+Add `"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"` to the import block.
+
+- [ ] **Step 4: Add the `EnvironmentType` option field**
+
+In `internal/dataaccess/subscription.go`, add one field to `CreateSubscriptionOnBehalfOptions` (currently at line 370). Task 4 gives it behaviour; it is added here so this task compiles.
+
+```go
+type CreateSubscriptionOnBehalfOptions struct {
+	ProductTierID                        string
+	OnBehalfOfCustomerUserID             string
+	OnBehalfOfCustomerEmail              string
+	// EnvironmentType gates the org-scoped email fallback when resolving the customer's
+	// user ID. Leave empty outside production.
+	EnvironmentType                      string
+	AllowCreatesWhenPaymentNotConfigured *bool
+	BillingProvider                      string
+	CustomPrice                          *bool
+	CustomPricePerUnit                   map[string]interface{}
+	ExternalPayerID                      string
+	MaxNumberOfInstances                 *int64
+	PriceEffectiveDate                   string
+}
+```
+
+- [ ] **Step 5: Update the `account customer create` call site**
+
+In `cmd/account/customer_create.go`, replace the `resolveCustomerSubscriptionByEmail` call (currently lines 626-633):
+
+```go
+	subscription, err := resolveCustomerSubscriptionByEmail(
+		ctx,
+		token,
+		dataaccess.CustomerSubscriptionLookup{
+			ServiceID:       target.ServiceID,
+			EnvironmentID:   target.EnvironmentID,
+			EnvironmentType: target.EnvironmentType,
+			PlanID:          target.ProductTierID,
+			CustomerEmail:   customerEmail,
+		},
+	)
+```
+
+Then replace the body of `isProductionEnvironmentType` (currently lines 651-658) so the production rule has one definition:
+
+```go
+func isProductionEnvironmentType(environmentType string) bool {
+	return utils.IsProductionEnvironmentType(environmentType)
+}
+```
+
+- [ ] **Step 6: Update the `account customer create` test stubs**
+
+In `cmd/account/customer_create_test.go`, change all three `resolveCustomerSubscriptionByEmail` stubs. The two "must not be called" stubs (lines 362 and 439) become:
+
+```go
+	resolveCustomerSubscriptionByEmail = func(context.Context, string, dataaccess.CustomerSubscriptionLookup) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+		t.Fatal("subscription lookup should not be called")
+		return nil, nil
+	}
+```
+
+The asserting stub (line 406) becomes:
+
+```go
+	resolveCustomerSubscriptionByEmail = func(ctx context.Context, token string, lookup dataaccess.CustomerSubscriptionLookup) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+		assert.Equal(t, "token", token)
+		assert.Equal(t, "svc-1", lookup.ServiceID)
+		assert.Equal(t, "env-1", lookup.EnvironmentID)
+		assert.Equal(t, "pt-1", lookup.PlanID)
+		assert.Equal(t, "caller@example.com", lookup.CustomerEmail)
+		return &openapiclientfleet.FleetDescribeSubscriptionResult{Id: "sub-456"}, nil
+	}
+```
+
+Search the file for any remaining `resolveCustomerSubscriptionByEmail = func(` occurrences and convert them the same way:
+
+Run: `grep -n "resolveCustomerSubscriptionByEmail = func" cmd/account/customer_create_test.go`
+
+- [ ] **Step 7: Build, then run the tests to verify they pass**
+
+Run: `go build ./... && go test ./internal/dataaccess/ ./cmd/account/ -v -run 'Subscription|Customer'`
+Expected: PASS. If the build fails, the compiler names every remaining caller of the old signature — fix each to the struct form.
+
+- [ ] **Step 8: Run the full unit suite and commit**
+
+Run: `make unit-test`
+Expected: PASS.
+
+```bash
+git add internal/dataaccess/subscription.go internal/dataaccess/subscription_test.go cmd/account/customer_create.go cmd/account/customer_create_test.go
+git commit -m "fix: paginate and org-scope the customer subscription lookup
+
+The lookup read only the first page of subscriptions and matched the
+plain customer address, so a customer whose production identity is
+stored in the org-scoped form looked absent and a second subscription
+was created for them. It now paginates, falls back to the scoped form in
+production only, and reports a suspended subscription instead of
+returning it as usable."
+```
+
+---
+
+### Task 4: Org-scoped fallback for the customer user-ID lookup
+
+Extract the email-to-user-ID search out of `CreateSubscriptionOnBehalf` and give it the same exact-then-scoped ordering. The fleet users API reports unscoped addresses, so the exact pass is what normally matches; the scoped pass costs no extra request because the user list is already in memory.
+
+**Files:**
+- Modify: `internal/dataaccess/subscription.go` (the `customerUserID` block inside `CreateSubscriptionOnBehalf`)
+- Test: `internal/dataaccess/subscription_test.go` (append)
+
+**Interfaces:**
+- Consumes: `utils.FormatEmailWithScopedOrg`, `utils.EmailHasScopedOrg`, `utils.IsProductionEnvironmentType` (Task 1); `CreateSubscriptionOnBehalfOptions.EnvironmentType` (Task 3).
+- Produces: `matchUserIDByEmail(users []openapiclientfleet.AccessSideUser, email string) string` — returns `""` when no user matches.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/dataaccess/subscription_test.go`:
+
+```go
+func TestMatchUserIDByEmail(t *testing.T) {
+	users := []openapiclientfleet.AccessSideUser{
+		{UserId: utils.ToPtr("user-1"), Email: utils.ToPtr("other@example.com")},
+		{UserId: utils.ToPtr("user-2"), Email: utils.ToPtr("Customer@Example.com")},
+		{UserId: utils.ToPtr("user-3")},
+	}
+
+	assert.Equal(t, "user-2", matchUserIDByEmail(users, "customer@example.com"))
+	assert.Equal(t, "", matchUserIDByEmail(users, "absent@example.com"))
+}
+
+func TestCreateSubscriptionOnBehalfResolvesScopedUserInProd(t *testing.T) {
+	var capturedUserID string
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/2022-09-01-00/fleet/users":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"users": []map[string]any{
+					{"userId": "user-scoped", "email": "customer+org-abc123@example.com"},
+				},
+			})
+		case "/2022-09-01-00/user":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "user-provider", "orgId": "org-abc123"})
+		case "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription":
+			var body map[string]any
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			capturedUserID, _ = body["onBehalfOfCustomerUserId"].(string)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "sub-new"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	result, err := CreateSubscriptionOnBehalf(context.Background(), "test-token", "s-test", "se-test", &CreateSubscriptionOnBehalfOptions{
+		ProductTierID:           "pt-test",
+		OnBehalfOfCustomerEmail: "customer@example.com",
+		EnvironmentType:         "PROD",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "sub-new", result.GetId())
+	assert.Equal(t, "user-scoped", capturedUserID)
+}
+
+func TestCreateSubscriptionOnBehalfReportsUnknownEmail(t *testing.T) {
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/2022-09-01-00/fleet/users":
+			_ = json.NewEncoder(w).Encode(map[string]any{"users": []map[string]any{}})
+		case "/2022-09-01-00/user":
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "user-provider", "orgId": "org-abc123"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	_, err := CreateSubscriptionOnBehalf(context.Background(), "test-token", "s-test", "se-test", &CreateSubscriptionOnBehalfOptions{
+		ProductTierID:           "pt-test",
+		OnBehalfOfCustomerEmail: "customer@example.com",
+		EnvironmentType:         "PROD",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "customer@example.com")
+}
+```
+
+Add `"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"` to the test file's import block.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./internal/dataaccess/ -run 'MatchUserIDByEmail|CreateSubscriptionOnBehalf' -v`
+Expected: FAIL — `undefined: matchUserIDByEmail`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `internal/dataaccess/subscription.go`, replace the `if customerUserID == "" && opts.OnBehalfOfCustomerEmail != ""` block inside `CreateSubscriptionOnBehalf` (currently lines 389-411) with:
+
+```go
+	if customerUserID == "" && opts.OnBehalfOfCustomerEmail != "" {
+		listUsersRes, r, listErr := apiClient.InventoryApiAPI.InventoryApiListAllUsers(ctxWithToken).Execute()
+		if r != nil {
+			_ = r.Body.Close()
+		}
+		if listErr != nil {
+			return nil, handleFleetError(errors.Wrap(listErr, "failed to list users"))
+		}
+
+		customerUserID = matchUserIDByEmail(listUsersRes.Users, opts.OnBehalfOfCustomerEmail)
+
+		// In production a customer may be stored under the org-scoped identity instead.
+		if customerUserID == "" &&
+			utils.IsProductionEnvironmentType(opts.EnvironmentType) &&
+			!utils.EmailHasScopedOrg(opts.OnBehalfOfCustomerEmail) {
+			scopedEmail, scopeErr := scopedCustomerEmail(ctx, token, opts.OnBehalfOfCustomerEmail)
+			if scopeErr != nil {
+				return nil, scopeErr
+			}
+			customerUserID = matchUserIDByEmail(listUsersRes.Users, scopedEmail)
+		}
+
+		if customerUserID == "" {
+			return nil, errors.Errorf("no user found with email %s", opts.OnBehalfOfCustomerEmail)
+		}
+	}
+```
+
+Then add, next to the other helpers:
+
+```go
+// matchUserIDByEmail returns the ID of the user with the given address, or "" when there
+// is none.
+func matchUserIDByEmail(users []openapiclientfleet.AccessSideUser, email string) string {
+	for _, user := range users {
+		if user.Email == nil || user.UserId == nil {
+			continue
+		}
+		if strings.EqualFold(*user.Email, email) {
+			return *user.UserId
+		}
+	}
+	return ""
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `go test ./internal/dataaccess/ -run 'MatchUserIDByEmail|CreateSubscriptionOnBehalf' -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full unit suite and commit**
+
+Run: `make unit-test`
+Expected: PASS.
+
+```bash
+git add internal/dataaccess/subscription.go internal/dataaccess/subscription_test.go
+git commit -m "feat: resolve org-scoped customers when creating a subscription
+
+Extracts the email-to-user-ID search and gives it the same
+exact-then-scoped ordering as the subscription lookup, so a production
+customer stored under the org-scoped identity is found instead of
+reported as unknown."
+```
+
+---
+
+### Task 5: The `--customer-email` flag on `instance create`
+
+Wire the flag into `instance create`, mirroring `account customer create`.
+
+**Files:**
+- Modify: `cmd/instance/create.go:20-49` (examples), `:90-127` (flags), `:129-238` (flag reads and validation), `:300-360` (resolution and request build)
+- Test: `cmd/instance/create_test.go` (append)
+- Regenerate: `mkdocs/docs/`
+
+**Interfaces:**
+- Consumes: `dataaccess.CustomerSubscriptionLookup`, `dataaccess.GetSubscriptionByCustomerEmailInEnvironment` (Task 3).
+- Produces:
+  - `validateCustomerEmailFlags(customerEmail, subscriptionID string) error`
+  - `resolveInstanceSubscriptionID(ctx context.Context, token string, lookup dataaccess.CustomerSubscriptionLookup, requestedSubscriptionID string) (string, error)`
+  - `var resolveInstanceSubscriptionByEmail = dataaccess.GetSubscriptionByCustomerEmailInEnvironment`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `cmd/instance/create_test.go`. Add `"context"`, `"strings"`, and `"github.com/omnistrate-oss/omnistrate-ctl/internal/dataaccess"` to the import block.
+
+```go
+func TestCreateCommandFlags_CustomerEmail(t *testing.T) {
+	flag := createCmd.Flags().Lookup("customer-email")
+	require.NotNil(t, flag, "Expected flag 'customer-email' to be registered")
+	assert.Contains(t, flag.Usage, "subscription")
+	assert.Equal(t, "", flag.DefValue)
+}
+
+func TestValidateCustomerEmailFlags(t *testing.T) {
+	require.NoError(t, validateCustomerEmailFlags("", ""))
+	require.NoError(t, validateCustomerEmailFlags("", "sub-test"))
+	require.NoError(t, validateCustomerEmailFlags("customer@example.com", ""))
+
+	err := validateCustomerEmailFlags("customer@example.com", "sub-test")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--customer-email")
+	assert.Contains(t, err.Error(), "--subscription-id")
+
+	err = validateCustomerEmailFlags("not-an-email", "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--customer-email")
+}
+
+func TestResolveInstanceSubscriptionIDWithoutEmailPassesThrough(t *testing.T) {
+	original := resolveInstanceSubscriptionByEmail
+	t.Cleanup(func() { resolveInstanceSubscriptionByEmail = original })
+
+	resolveInstanceSubscriptionByEmail = func(context.Context, string, dataaccess.CustomerSubscriptionLookup) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+		t.Fatal("subscription lookup should not be called without --customer-email")
+		return nil, nil
+	}
+
+	subscriptionID, err := resolveInstanceSubscriptionID(
+		context.Background(),
+		"token",
+		dataaccess.CustomerSubscriptionLookup{ServiceID: "s-test"},
+		"sub-test",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "sub-test", subscriptionID)
+}
+
+func TestResolveInstanceSubscriptionIDResolvesEmail(t *testing.T) {
+	original := resolveInstanceSubscriptionByEmail
+	t.Cleanup(func() { resolveInstanceSubscriptionByEmail = original })
+
+	resolveInstanceSubscriptionByEmail = func(ctx context.Context, token string, lookup dataaccess.CustomerSubscriptionLookup) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+		assert.Equal(t, "token", token)
+		assert.Equal(t, "s-test", lookup.ServiceID)
+		assert.Equal(t, "se-test", lookup.EnvironmentID)
+		assert.Equal(t, "PROD", lookup.EnvironmentType)
+		assert.Equal(t, "pt-test", lookup.PlanID)
+		assert.Equal(t, "customer@example.com", lookup.CustomerEmail)
+		return &openapiclientfleet.FleetDescribeSubscriptionResult{Id: "sub-test"}, nil
+	}
+
+	subscriptionID, err := resolveInstanceSubscriptionID(
+		context.Background(),
+		"token",
+		dataaccess.CustomerSubscriptionLookup{
+			ServiceID:       "s-test",
+			EnvironmentID:   "se-test",
+			EnvironmentType: "PROD",
+			PlanID:          "pt-test",
+			CustomerEmail:   "customer@example.com",
+		},
+		"",
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, "sub-test", subscriptionID)
+}
+
+func TestResolveInstanceSubscriptionIDRejectsEmptyResult(t *testing.T) {
+	original := resolveInstanceSubscriptionByEmail
+	t.Cleanup(func() { resolveInstanceSubscriptionByEmail = original })
+
+	resolveInstanceSubscriptionByEmail = func(context.Context, string, dataaccess.CustomerSubscriptionLookup) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+		return &openapiclientfleet.FleetDescribeSubscriptionResult{}, nil
+	}
+
+	_, err := resolveInstanceSubscriptionID(
+		context.Background(),
+		"token",
+		dataaccess.CustomerSubscriptionLookup{CustomerEmail: "customer@example.com"},
+		"",
+	)
+
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "empty subscription id")
+}
+
+func TestCreateExampleDocumentsCustomerEmail(t *testing.T) {
+	assert.Contains(t, createExample, "--customer-email")
+}
+```
+
+Also extend the expected-flag list in `TestCreateCommandFlags_AllExpectedFlags` by adding `"customer-email"` to the `expectedFlags` slice.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `go test ./cmd/instance/ -run 'CustomerEmail|ResolveInstanceSubscriptionID' -v`
+Expected: FAIL — `undefined: validateCustomerEmailFlags`.
+
+- [ ] **Step 3: Register the flag and the example**
+
+In `cmd/instance/create.go`, append to the `createExample` const (after the on-prem example, inside the same backtick string):
+
+```
+# Create an instance deployment on behalf of an end customer, resolved from their email
+omnistrate-ctl instance create --service=mysql --environment=prod --plan=mysql --resource=mySQL --cloud-provider=aws --region=us-east-2 --param-file /path/to/params.json --customer-email customer@example.com
+```
+
+In `init()`, next to the `subscription-id` flag registration (line 106):
+
+```go
+	createCmd.Flags().String("customer-email", "", "Customer email to create the instance deployment on behalf of. Resolves the customer's subscription for this service plan, creating one if they have none. Cannot be combined with --subscription-id.")
+```
+
+Add `--customer-email` to the `Use:` string on line 82, after `[--subscription-id=id]` if present, otherwise after `[--instance-id=id]`:
+
+```go
+	Use:          "create --service=[service] --environment=[environment] --plan=[plan] --version=[version] --resource=[resource] [--cloud-provider=aws|gcp|azure|nebius] [--region=region] [--param=param] [--param-file=file-path] [--instance-id=id] [--customer-email=email] [--customer-account-id=account-instance-id] [--cloud-provider-native-network-id=network-id] [--network-type=PUBLIC|INTERNAL] [--onprem-platform=platform] [--tags key=value,key2=value2] [--breakpoints id-or-key[:event[|event...]],...]",
+```
+
+- [ ] **Step 4: Add the helpers**
+
+Add near the other helper functions in `cmd/instance/create.go` (for example above `validateCreateCloudTarget`):
+
+```go
+// resolveInstanceSubscriptionByEmail is a package variable so tests can exercise the
+// resolution wiring without a live API.
+var resolveInstanceSubscriptionByEmail = dataaccess.GetSubscriptionByCustomerEmailInEnvironment
+
+// validateCustomerEmailFlags checks the flag combination before any API call is made.
+func validateCustomerEmailFlags(customerEmail, subscriptionID string) error {
+	customerEmail = strings.TrimSpace(customerEmail)
+	if customerEmail == "" {
+		return nil
+	}
+	if strings.TrimSpace(subscriptionID) != "" {
+		return fmt.Errorf("cannot specify both --customer-email and --subscription-id")
+	}
+	if err := utils.ValidateEmail(customerEmail); err != nil {
+		return fmt.Errorf("invalid --customer-email value: %w", err)
+	}
+	return nil
+}
+
+// resolveInstanceSubscriptionID returns the subscription the instance should be created
+// under. Without --customer-email the requested subscription ID passes through unchanged,
+// which keeps the existing behaviour of letting the platform choose.
+func resolveInstanceSubscriptionID(
+	ctx context.Context,
+	token string,
+	lookup dataaccess.CustomerSubscriptionLookup,
+	requestedSubscriptionID string,
+) (string, error) {
+	if strings.TrimSpace(lookup.CustomerEmail) == "" {
+		return requestedSubscriptionID, nil
+	}
+
+	subscription, err := resolveInstanceSubscriptionByEmail(ctx, token, lookup)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve subscription for customer %s: %w", lookup.CustomerEmail, err)
+	}
+	if subscription == nil || strings.TrimSpace(subscription.Id) == "" {
+		return "", fmt.Errorf("subscription lookup for customer %s returned an empty subscription ID", lookup.CustomerEmail)
+	}
+
+	return strings.TrimSpace(subscription.Id), nil
+}
+```
+
+- [ ] **Step 5: Wire the flag into `runCreate`**
+
+In `runCreate`, read the flag next to the `subscription-id` read (after line 203):
+
+```go
+	customerEmail, err := cmd.Flags().GetString("customer-email")
+	if err != nil {
+		utils.PrintError(err)
+		return err
+	}
+```
+
+Validate early, immediately after the existing `validateCreateCloudTarget` call (line 234-237), so a bad flag combination fails before the spinner and any API call:
+
+```go
+	if err = validateCustomerEmailFlags(customerEmail, subscriptionID); err != nil {
+		utils.PrintError(err)
+		return err
+	}
+```
+
+Resolve after `selectOfferingForEnvironment` and the `offering := *selectedOffering` assignment (line 311), where the environment type is known:
+
+```go
+	subscriptionID, err = resolveInstanceSubscriptionID(cmd.Context(), token, dataaccess.CustomerSubscriptionLookup{
+		ServiceID:       serviceID,
+		EnvironmentID:   environmentID,
+		EnvironmentType: offering.ServiceEnvironmentType,
+		PlanID:          productTierID,
+		CustomerEmail:   customerEmail,
+	}, subscriptionID)
+	if err != nil {
+		utils.HandleSpinnerError(spinner, sm, err)
+		return err
+	}
+```
+
+The existing `if subscriptionID != "" { request.SubscriptionId = ... }` block at line 358 needs no change.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `go test ./cmd/instance/ -run 'CustomerEmail|ResolveInstanceSubscriptionID|CreateCommandFlags|CreateExample' -v`
+Expected: PASS.
+
+- [ ] **Step 7: Regenerate the docs**
+
+Run: `make docs`
+Then: `git status --short mkdocs/` — expect a modified `omnistrate-ctl_instance_create.md` containing `--customer-email`.
+
+- [ ] **Step 8: Verify no identifying data leaked**
+
+List every address and organization ID the change introduces and confirm each one is a
+placeholder. An allowlist review is used rather than a search for specific names, so that this
+plan does not itself have to spell out the data it is guarding against.
+
+```bash
+git add -A
+git diff --cached -U0 | grep '^+' | grep -oE "[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}|org-[A-Za-z0-9]+" | sort -u
+```
+
+Expected: nothing outside `@example.com` addresses and `org-abc123`. Any other real-looking
+domain, personal name, or organization ID must be replaced with a placeholder before committing.
+
+- [ ] **Step 9: Run the full unit suite and commit**
+
+Run: `make unit-test`
+Expected: PASS.
+
+```bash
+git add cmd/instance/create.go cmd/instance/create_test.go mkdocs/
+git commit -m "feat: add --customer-email to instance create
+
+Resolves the customer's subscription for the target service plan from
+their email, creating one when they have none, so operators no longer
+need to look up a subscription ID by hand."
+```
+
+---
+
+## Manual verification
+
+After Task 5, confirm the behaviour against a real tenant. Substitute your own service, plan, and customer values; do not paste real customer data back into the repository.
+
+```bash
+go build -o /tmp/omctl-dev .
+
+# Rejects the flag combination before doing any work
+/tmp/omctl-dev instance create --service=<service> --environment=<env> --plan=<plan> \
+  --resource=<resource> --cloud-provider=aws --region=us-east-2 \
+  --customer-email customer@example.com --subscription-id sub-test
+# Expect: "cannot specify both --customer-email and --subscription-id"
+
+# Resolves an existing production customer stored under the org-scoped identity
+/tmp/omctl-dev instance create --service=<service> --environment=<prod-env> --plan=<plan> \
+  --resource=<resource> --cloud-provider=aws --region=us-east-2 \
+  --param-file ./params.json --customer-email <known-customer-email> --output json
+# Expect: subscriptionId in the output matches the customer's existing subscription,
+# and `omctl subscription list` shows no newly created duplicate.
+```

--- a/docs/superpowers/plans/2026-09-07-instance-create-customer-email.md
+++ b/docs/superpowers/plans/2026-09-07-instance-create-customer-email.md
@@ -833,7 +833,6 @@ func GetSubscriptionByCustomerEmailInEnvironment(
 	createResp, err := CreateSubscriptionOnBehalf(ctx, token, lookup.ServiceID, lookup.EnvironmentID, &CreateSubscriptionOnBehalfOptions{
 		ProductTierID:           lookup.PlanID,
 		OnBehalfOfCustomerEmail: customerEmail,
-		EnvironmentType:         lookup.EnvironmentType,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to create subscription for user %s", customerEmail)
@@ -879,29 +878,7 @@ func scopedCustomerEmail(ctx context.Context, token, customerEmail string) (stri
 
 Add `"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"` to the import block.
 
-- [ ] **Step 4: Add the `EnvironmentType` option field**
-
-In `internal/dataaccess/subscription.go`, add one field to `CreateSubscriptionOnBehalfOptions` (currently at line 370). Task 4 gives it behaviour; it is added here so this task compiles.
-
-```go
-type CreateSubscriptionOnBehalfOptions struct {
-	ProductTierID                        string
-	OnBehalfOfCustomerUserID             string
-	OnBehalfOfCustomerEmail              string
-	// EnvironmentType gates the org-scoped email fallback when resolving the customer's
-	// user ID. Leave empty outside production.
-	EnvironmentType                      string
-	AllowCreatesWhenPaymentNotConfigured *bool
-	BillingProvider                      string
-	CustomPrice                          *bool
-	CustomPricePerUnit                   map[string]interface{}
-	ExternalPayerID                      string
-	MaxNumberOfInstances                 *int64
-	PriceEffectiveDate                   string
-}
-```
-
-- [ ] **Step 5: Update the `account customer create` call site**
+- [ ] **Step 4: Update the `account customer create` call site**
 
 In `cmd/account/customer_create.go`, replace the `resolveCustomerSubscriptionByEmail` call (currently lines 626-633):
 
@@ -927,7 +904,7 @@ func isProductionEnvironmentType(environmentType string) bool {
 }
 ```
 
-- [ ] **Step 6: Update the `account customer create` test stubs**
+- [ ] **Step 5: Update the `account customer create` test stubs**
 
 In `cmd/account/customer_create_test.go`, change all three `resolveCustomerSubscriptionByEmail` stubs. The two "must not be called" stubs (lines 362 and 439) become:
 
@@ -955,12 +932,12 @@ Search the file for any remaining `resolveCustomerSubscriptionByEmail = func(` o
 
 Run: `grep -n "resolveCustomerSubscriptionByEmail = func" cmd/account/customer_create_test.go`
 
-- [ ] **Step 7: Build, then run the tests to verify they pass**
+- [ ] **Step 6: Build, then run the tests to verify they pass**
 
 Run: `go build ./... && go test ./internal/dataaccess/ ./cmd/account/ -v -run 'Subscription|Customer'`
 Expected: PASS. If the build fails, the compiler names every remaining caller of the old signature — fix each to the struct form.
 
-- [ ] **Step 8: Run the full unit suite and commit**
+- [ ] **Step 7: Run the full unit suite and commit**
 
 Run: `make unit-test`
 Expected: PASS.
@@ -979,21 +956,25 @@ returning it as usable."
 
 ---
 
-### Task 4: Org-scoped fallback for the customer user-ID lookup
+### Task 4: Extract the customer user-ID matcher
 
-Extract the email-to-user-ID search out of `CreateSubscriptionOnBehalf` and give it the same exact-then-scoped ordering. The fleet users API reports unscoped addresses, so the exact pass is what normally matches; the scoped pass costs no extra request because the user list is already in memory.
+Pull the email-to-user-ID search out of `CreateSubscriptionOnBehalf` into a named, testable
+function. Behaviour is unchanged: the fleet users API reports unscoped addresses, so a plain
+case-insensitive match is the correct and only lookup.
 
 **Files:**
 - Modify: `internal/dataaccess/subscription.go` (the `customerUserID` block inside `CreateSubscriptionOnBehalf`)
 - Test: `internal/dataaccess/subscription_test.go` (append)
 
 **Interfaces:**
-- Consumes: `utils.FormatEmailWithScopedOrg`, `utils.EmailHasScopedOrg`, `utils.IsProductionEnvironmentType` (Task 1); `CreateSubscriptionOnBehalfOptions.EnvironmentType` (Task 3).
+- Consumes: nothing from Tasks 1-3.
 - Produces: `matchUserIDByEmail(users []openapiclientfleet.AccessSideUser, email string) string` — returns `""` when no user matches.
 
 - [ ] **Step 1: Write the failing tests**
 
-Append to `internal/dataaccess/subscription_test.go`:
+Append to `internal/dataaccess/subscription_test.go`. Add
+`"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"` to the test file's import block if it
+is not already there.
 
 ```go
 func TestMatchUserIDByEmail(t *testing.T) {
@@ -1001,13 +982,16 @@ func TestMatchUserIDByEmail(t *testing.T) {
 		{UserId: utils.ToPtr("user-1"), Email: utils.ToPtr("other@example.com")},
 		{UserId: utils.ToPtr("user-2"), Email: utils.ToPtr("Customer@Example.com")},
 		{UserId: utils.ToPtr("user-3")},
+		{Email: utils.ToPtr("no-id@example.com")},
 	}
 
 	assert.Equal(t, "user-2", matchUserIDByEmail(users, "customer@example.com"))
 	assert.Equal(t, "", matchUserIDByEmail(users, "absent@example.com"))
+	assert.Equal(t, "", matchUserIDByEmail(users, "no-id@example.com"))
+	assert.Equal(t, "", matchUserIDByEmail(nil, "customer@example.com"))
 }
 
-func TestCreateSubscriptionOnBehalfResolvesScopedUserInProd(t *testing.T) {
+func TestCreateSubscriptionOnBehalfResolvesUserByEmail(t *testing.T) {
 	var capturedUserID string
 	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -1015,11 +999,10 @@ func TestCreateSubscriptionOnBehalfResolvesScopedUserInProd(t *testing.T) {
 		case "/2022-09-01-00/fleet/users":
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"users": []map[string]any{
-					{"userId": "user-scoped", "email": "customer+org-abc123@example.com"},
+					{"userId": "user-other", "email": "other@example.com"},
+					{"userId": "user-test", "email": "customer@example.com"},
 				},
 			})
-		case "/2022-09-01-00/user":
-			_ = json.NewEncoder(w).Encode(map[string]any{"id": "user-provider", "orgId": "org-abc123"})
 		case "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription":
 			var body map[string]any
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
@@ -1033,39 +1016,31 @@ func TestCreateSubscriptionOnBehalfResolvesScopedUserInProd(t *testing.T) {
 	result, err := CreateSubscriptionOnBehalf(context.Background(), "test-token", "s-test", "se-test", &CreateSubscriptionOnBehalfOptions{
 		ProductTierID:           "pt-test",
 		OnBehalfOfCustomerEmail: "customer@example.com",
-		EnvironmentType:         "PROD",
 	})
 
 	require.NoError(t, err)
 	assert.Equal(t, "sub-new", result.GetId())
-	assert.Equal(t, "user-scoped", capturedUserID)
+	assert.Equal(t, "user-test", capturedUserID)
 }
 
 func TestCreateSubscriptionOnBehalfReportsUnknownEmail(t *testing.T) {
 	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		switch r.URL.Path {
-		case "/2022-09-01-00/fleet/users":
-			_ = json.NewEncoder(w).Encode(map[string]any{"users": []map[string]any{}})
-		case "/2022-09-01-00/user":
-			_ = json.NewEncoder(w).Encode(map[string]any{"id": "user-provider", "orgId": "org-abc123"})
-		default:
+		if r.URL.Path != "/2022-09-01-00/fleet/users" {
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"users": []map[string]any{}})
 	})
 
 	_, err := CreateSubscriptionOnBehalf(context.Background(), "test-token", "s-test", "se-test", &CreateSubscriptionOnBehalfOptions{
 		ProductTierID:           "pt-test",
 		OnBehalfOfCustomerEmail: "customer@example.com",
-		EnvironmentType:         "PROD",
 	})
 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "customer@example.com")
 }
 ```
-
-Add `"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"` to the test file's import block.
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
@@ -1074,7 +1049,7 @@ Expected: FAIL — `undefined: matchUserIDByEmail`.
 
 - [ ] **Step 3: Write the implementation**
 
-In `internal/dataaccess/subscription.go`, replace the `if customerUserID == "" && opts.OnBehalfOfCustomerEmail != ""` block inside `CreateSubscriptionOnBehalf` (currently lines 389-411) with:
+In `internal/dataaccess/subscription.go`, replace the `if customerUserID == "" && opts.OnBehalfOfCustomerEmail != ""` block inside `CreateSubscriptionOnBehalf` with:
 
 ```go
 	if customerUserID == "" && opts.OnBehalfOfCustomerEmail != "" {
@@ -1087,29 +1062,21 @@ In `internal/dataaccess/subscription.go`, replace the `if customerUserID == "" &
 		}
 
 		customerUserID = matchUserIDByEmail(listUsersRes.Users, opts.OnBehalfOfCustomerEmail)
-
-		// In production a customer may be stored under the org-scoped identity instead.
-		if customerUserID == "" &&
-			utils.IsProductionEnvironmentType(opts.EnvironmentType) &&
-			!utils.EmailHasScopedOrg(opts.OnBehalfOfCustomerEmail) {
-			scopedEmail, scopeErr := scopedCustomerEmail(ctx, token, opts.OnBehalfOfCustomerEmail)
-			if scopeErr != nil {
-				return nil, scopeErr
-			}
-			customerUserID = matchUserIDByEmail(listUsersRes.Users, scopedEmail)
-		}
-
 		if customerUserID == "" {
 			return nil, errors.Errorf("no user found with email %s", opts.OnBehalfOfCustomerEmail)
 		}
 	}
 ```
 
+Note the response body is now closed on both the success and error paths; the original closed it
+only after the error check.
+
 Then add, next to the other helpers:
 
 ```go
 // matchUserIDByEmail returns the ID of the user with the given address, or "" when there
-// is none.
+// is none. The fleet users API reports unscoped addresses, so a plain case-insensitive
+// comparison is the correct match.
 func matchUserIDByEmail(users []openapiclientfleet.AccessSideUser, email string) string {
 	for _, user := range users {
 		if user.Email == nil || user.UserId == nil {
@@ -1135,15 +1102,15 @@ Expected: PASS.
 
 ```bash
 git add internal/dataaccess/subscription.go internal/dataaccess/subscription_test.go
-git commit -m "feat: resolve org-scoped customers when creating a subscription
+git commit -m "refactor: extract the customer user-ID matcher
 
-Extracts the email-to-user-ID search and gives it the same
-exact-then-scoped ordering as the subscription lookup, so a production
-customer stored under the org-scoped identity is found instead of
-reported as unknown."
+Pulls the email-to-user-ID search out of CreateSubscriptionOnBehalf into
+a named function so it can be tested directly, and closes the response
+body on the error path as well as the success path."
 ```
 
 ---
+
 
 ### Task 5: The `--customer-email` flag on `instance create`
 

--- a/docs/superpowers/plans/2026-09-07-instance-create-customer-email.md
+++ b/docs/superpowers/plans/2026-09-07-instance-create-customer-email.md
@@ -409,6 +409,8 @@ Append to `internal/dataaccess/subscription.go`:
 // The platform's full vocabulary is ACTIVE, SUSPENDED, CANCELLED and TERMINATED.
 const subscriptionStatusActive = "ACTIVE"
 
+const subscriptionStatusSuspended = "SUSPENDED"
+
 // matchSubscriptionsByEmail returns the subscriptions on a plan whose root user is the
 // given address. The plan filter is redundant with the server-side query parameter and is
 // kept so the matching is correct on its own terms.
@@ -477,7 +479,7 @@ func unusableSubscriptionError(
 ) error {
 	if len(candidates) == 1 {
 		candidate := candidates[0]
-		if strings.EqualFold(candidate.Status, "SUSPENDED") {
+		if strings.EqualFold(candidate.Status, subscriptionStatusSuspended) {
 			return errors.Errorf(
 				"subscription %s for customer %s on plan %s is SUSPENDED and cannot be used to create an instance. "+
 					"Resume it with 'omnistrate-ctl subscription resume %s', or pass --subscription-id to use a different subscription",
@@ -501,13 +503,29 @@ func unusableSubscriptionError(
 	for _, candidate := range candidates {
 		described = append(described, fmt.Sprintf("%s (%s)", candidate.Id, candidate.Status))
 	}
-	return errors.Errorf(
-		"customer %s has no active subscription on plan %s; found %s. "+
-			"Resume a suspended subscription with 'omnistrate-ctl subscription resume', or pass --subscription-id",
+
+	hasSuspended := false
+	for _, candidate := range candidates {
+		if strings.EqualFold(candidate.Status, subscriptionStatusSuspended) {
+			hasSuspended = true
+			break
+		}
+	}
+
+	msg := fmt.Sprintf(
+		"customer %s has no active subscription on plan %s; found %s",
 		customerEmail,
 		candidates[0].ProductTierName,
 		strings.Join(described, ", "),
 	)
+
+	if hasSuspended {
+		msg += ". Resume a suspended subscription with 'omnistrate-ctl subscription resume', or pass --subscription-id"
+	} else {
+		msg += ". Pass --subscription-id"
+	}
+
+	return errors.New(msg)
 }
 ```
 
@@ -1108,8 +1126,8 @@ git add internal/dataaccess/subscription.go internal/dataaccess/subscription_tes
 git commit -m "refactor: extract the customer user-ID matcher
 
 Pulls the email-to-user-ID search out of CreateSubscriptionOnBehalf into
-a named function so it can be tested directly, and closes the response
-body on the error path as well as the success path."
+a named function so it can be tested directly. This guards against nil
+UserId values, preventing a potential panic in the original implementation."
 ```
 
 ---

--- a/docs/superpowers/specs/2026-09-07-instance-create-customer-email-design.md
+++ b/docs/superpowers/specs/2026-09-07-instance-create-customer-email-design.md
@@ -66,6 +66,10 @@ func FormatEmailWithScopedOrg(email, orgID string) (string, error)
 
 // EmailHasScopedOrg reports whether the local part already ends in an org ID segment.
 func EmailHasScopedOrg(email string) bool
+
+// IsProductionEnvironmentType gates where org scoping applies. It replaces the private
+// copy in cmd/account so the production rule has one definition.
+func IsProductionEnvironmentType(environmentType string) bool
 ```
 
 `FormatEmailWithScopedOrg` errors on a malformed address, a malformed org ID, or an
@@ -130,8 +134,8 @@ The SUSPENDED error names its remedy:
 Any other non-ACTIVE status produces the generic form (`is in status <STATUS>, expected
 ACTIVE`), so a status added later cannot be silently treated as usable.
 
-`CreateSubscriptionOnBehalf`'s inline email-to-user-ID search moves into
-`resolveCustomerUserIDByEmail`, which applies the same exact-then-scoped ordering. The
+`CreateSubscriptionOnBehalf`'s inline email-to-user-ID search moves into a helper and gains
+the same exact-then-scoped ordering, gated on environment type the same way. The
 scoped pass costs nothing there — the user list is already in memory — and in practice the
 exact pass is what matches, because `/fleet/users` reports unscoped addresses.
 

--- a/docs/superpowers/specs/2026-09-07-instance-create-customer-email-design.md
+++ b/docs/superpowers/specs/2026-09-07-instance-create-customer-email-design.md
@@ -1,0 +1,178 @@
+# `instance create --customer-email` design
+
+Let a service provider create an instance on behalf of an end customer by naming the
+customer's email instead of hunting down their subscription ID.
+
+## Problem
+
+`omnistrate-ctl instance create` accepts `--subscription-id`. Operators know customers by
+email, not by `sub-XXXXXXXX`, so using it means a manual `subscription list` and a
+copy-paste. `omnistrate-ctl account customer create` already solved this with a
+`--customer-email` flag; `instance create` should behave the same way.
+
+The lookup that flag relies on, `dataaccess.GetSubscriptionByCustomerEmailInEnvironment`,
+has three defects that must be fixed for the feature to be correct:
+
+1. **It misses org-scoped customers.** In production environments the platform stores an
+   end customer's subscription under an *org-scoped* identity: the service provider's org
+   ID is appended to the local part of the email, as `<local>+<orgID>@<domain>`. So
+   `customer@example.com` owns a subscription whose `rootUserEmail` reads
+   `customer+org-abc123@example.com`. The fleet users API (`/fleet/users`) reports the
+   plain, unscoped email, but the fleet subscription API reports the scoped one. Matching
+   `rootUserEmail` against the raw input therefore finds nothing, and the helper's
+   not-found branch **creates a second subscription** for a customer who already has one.
+2. **It reads only the first page.** It calls `InventoryApiListSubscription` once and
+   ignores `nextPageToken`, so customers past the first page look like they have no
+   subscription — again ending in a duplicate.
+3. **It ignores subscription status.** A SUSPENDED subscription is returned as if usable,
+   and the create then fails downstream with an opaque error.
+
+## Format rules
+
+The canonical implementation lives server-side in `commons/pkg/utils/scopedorgutils.go`.
+This design mirrors it so the CLI and server agree:
+
+- Scoped form is `<local>+<orgID>@<domain>`; the org ID is appended as the **last** `+`
+  segment of the local part.
+- An org ID matches `^org-[a-zA-Z0-9][a-zA-Z0-9._-]*$`.
+- An address is already scoped when its last `+` segment matches that pattern.
+- Pre-existing plus tags are preserved: `customer+tag@example.com` scoped with
+  `org-abc123` becomes `customer+tag+org-abc123@example.com`.
+- **Org scoping only exists in production environments.** The fallback must not be
+  attempted outside PROD.
+
+## Subscription statuses
+
+The server's vocabulary is `ACTIVE`, `SUSPENDED`, `CANCELLED`, `TERMINATED`.
+
+`TerminateSubscription` soft-deletes the row, and the default listing path excludes
+soft-deleted rows — `includeInactive` is what switches the query to unscoped. TERMINATED
+and CANCELLED subscriptions are therefore invisible to the default listing, which is the
+behaviour we want: a terminated subscription should not block a customer from being
+re-subscribed. `SuspendSubscription` only sets the status, leaving the row live, so
+SUSPENDED is the non-ACTIVE status a lookup can realistically encounter.
+
+Consequently the listing keeps `IncludeInactive` off. Enabling it would resurrect
+terminated rows and turn legitimate re-subscription into an error.
+
+## Design
+
+### 1. `internal/utils/scopedemail.go` (new)
+
+```go
+// FormatEmailWithScopedOrg returns the org-scoped form of an address:
+//   ("customer@example.com", "org-abc123") -> "customer+org-abc123@example.com"
+func FormatEmailWithScopedOrg(email, orgID string) (string, error)
+
+// EmailHasScopedOrg reports whether the local part already ends in an org ID segment.
+func EmailHasScopedOrg(email string) bool
+```
+
+`FormatEmailWithScopedOrg` errors on a malformed address, a malformed org ID, or an
+address that is already scoped. `EmailHasScopedOrg` lets the lookup skip the scoped pass
+when the operator already passed a scoped address, which would otherwise scope it twice.
+Both functions are pure and make no API calls.
+
+### 2. `internal/dataaccess/subscription.go`
+
+The lookup takes an options struct rather than growing to six positional strings, and
+gains the environment type it needs to decide whether org scoping applies:
+
+```go
+type CustomerSubscriptionLookup struct {
+	ServiceID       string
+	EnvironmentID   string
+	EnvironmentType string // org-scoped fallback applies to PROD only
+	PlanID          string
+	CustomerEmail   string
+}
+
+func GetSubscriptionByCustomerEmailInEnvironment(
+	ctx context.Context,
+	token string,
+	lookup CustomerSubscriptionLookup,
+) (*openapiclientfleet.FleetDescribeSubscriptionResult, error)
+```
+
+Resolution order:
+
+1. `ListAllSubscriptions` filtered by `ProductTierId` — the paginating variant, replacing
+   the current single-page call.
+2. Collect candidates whose `rootUserEmail` equals the requested email, case-insensitively.
+3. If there are none, the environment type is production, and the requested address is not
+   already scoped, call `DescribeUser` for the caller's org ID, build the scoped address,
+   and collect candidates again. The `DescribeUser` call is lazy: an exact match never
+   pays for it.
+4. Apply the status gate below. It resolves to a subscription, an error, or "no candidates".
+5. On "no candidates", `CreateSubscriptionOnBehalf`, then `DescribeSubscription`, then run
+   the result through the same status gate.
+
+The status gate is a pure function over the candidate slice, which is what makes it
+testable without a network:
+
+| Candidates | Result |
+| --- | --- |
+| none | fall through to create |
+| exactly one ACTIVE | use it |
+| more than one ACTIVE | error listing the IDs, directing the user to `--subscription-id` |
+| one or more, none ACTIVE | status-specific error |
+
+Exact-email candidates take precedence over scoped-email candidates; the scoped pass only
+runs when the exact pass found nothing, so the two sets never compete.
+
+The SUSPENDED error names its remedy:
+
+> subscription sub-XXXX for customer@example.com on plan `<plan>` is SUSPENDED and cannot
+> be used to create an instance. Resume it with
+> `omnistrate-ctl subscription resume sub-XXXX`, or pass `--subscription-id` to use a
+> different subscription.
+
+Any other non-ACTIVE status produces the generic form (`is in status <STATUS>, expected
+ACTIVE`), so a status added later cannot be silently treated as usable.
+
+`CreateSubscriptionOnBehalf`'s inline email-to-user-ID search moves into
+`resolveCustomerUserIDByEmail`, which applies the same exact-then-scoped ordering. The
+scoped pass costs nothing there — the user list is already in memory — and in practice the
+exact pass is what matches, because `/fleet/users` reports unscoped addresses.
+
+`GetSubscriptionByCustomerEmail`, the plan-level wrapper, passes the offering's
+`ServiceEnvironmentType` through to the lookup.
+
+### 3. `cmd/instance/create.go`
+
+Add `--customer-email`, mirroring `account customer create`:
+
+- Rejected together with `--subscription-id`.
+- Validated with `utils.ValidateEmail` before any API call.
+- Resolved after `selectOfferingForEnvironment`, so target errors surface first and
+  `offering.ServiceEnvironmentType` is available. The resolved ID flows into the existing
+  `request.SubscriptionId` assignment; request construction is otherwise untouched.
+- Accepted in any environment. Only the org-scoped fallback is gated on PROD.
+- Creates the subscription when the customer has none, and says so in the flag help. The
+  command already prints `SubscriptionID`, so the operator sees which subscription was used.
+
+Explicitly **not** copied from `account customer create`: its behaviour of defaulting to
+the calling user's own email in PROD when neither flag is given. `instance create` with no
+flags keeps omitting `subscriptionId` and letting the server resolve it, exactly as today.
+
+`createExample` gains an entry for the new flag.
+
+### 4. Inherited fixes
+
+Because the lookup is shared, `instance adopt` and `account customer create` also stop
+creating duplicate subscriptions for org-scoped customers, start paginating, and start
+reporting suspended subscriptions instead of failing downstream.
+
+## Testing
+
+- `internal/utils/scopedemail_test.go` — scoping, rejection of an already-scoped address,
+  preservation of an existing plus tag, malformed org ID, malformed address.
+- `internal/dataaccess/subscription_test.go` — the status gate and candidate selection:
+  exact beats scoped, single ACTIVE, multiple ACTIVE, suspended-only, plan filtering.
+- `cmd/instance/create_test.go` — flag validation (both flags together, malformed email)
+  and resolution wiring through an injectable package-level func var.
+- Update the `account customer create` test stubs for the new signature.
+- `make docs` to regenerate the generated CLI reference under `mkdocs/docs/`.
+
+All fixtures use placeholder identities (`customer@example.com`, `org-abc123`). No real
+customer, organization, or address appears in code, tests, or documentation.

--- a/docs/superpowers/specs/2026-09-07-instance-create-customer-email-design.md
+++ b/docs/superpowers/specs/2026-09-07-instance-create-customer-email-design.md
@@ -176,7 +176,7 @@ reporting suspended subscriptions instead of failing downstream.
 - `cmd/instance/create_test.go` — flag validation (both flags together, malformed email)
   and resolution wiring through an injectable package-level func var.
 - Update the `account customer create` test stubs for the new signature.
-- `make docs` to regenerate the generated CLI reference under `mkdocs/docs/`.
+- `make gen-doc` to regenerate the generated CLI reference under `mkdocs/docs/`.
 
 All fixtures use placeholder identities (`customer@example.com`, `org-abc123`). No real
 customer, organization, or address appears in code, tests, or documentation.

--- a/docs/superpowers/specs/2026-09-07-instance-create-customer-email-design.md
+++ b/docs/superpowers/specs/2026-09-07-instance-create-customer-email-design.md
@@ -134,10 +134,10 @@ The SUSPENDED error names its remedy:
 Any other non-ACTIVE status produces the generic form (`is in status <STATUS>, expected
 ACTIVE`), so a status added later cannot be silently treated as usable.
 
-`CreateSubscriptionOnBehalf`'s inline email-to-user-ID search moves into a helper and gains
-the same exact-then-scoped ordering, gated on environment type the same way. The
-scoped pass costs nothing there — the user list is already in memory — and in practice the
-exact pass is what matches, because `/fleet/users` reports unscoped addresses.
+`CreateSubscriptionOnBehalf`'s inline email-to-user-ID search moves into a named helper so
+it can be tested directly. It deliberately does **not** get the scoped fallback: the fleet
+users API un-scopes an address before returning it, so a scoped pass there would be
+unreachable code. The subscription listing is the only place the scoped form is observable.
 
 `GetSubscriptionByCustomerEmail`, the plan-level wrapper, passes the offering's
 `ServiceEnvironmentType` through to the lookup.

--- a/internal/dataaccess/subscription.go
+++ b/internal/dataaccess/subscription.go
@@ -134,6 +134,9 @@ func GetSubscriptionByCustomerEmailInEnvironment(
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to describe newly created subscription for user %s", customerEmail)
 	}
+	if resp == nil {
+		return nil, errors.Errorf("describing newly created subscription for user %s returned an empty response", customerEmail)
+	}
 
 	// A newly created subscription goes through the same status gate, so every "unusable
 	// subscription" message in this command comes from one place.
@@ -222,6 +225,7 @@ func ListSubscriptionsWithOptions(ctx context.Context, token string, serviceID, 
 
 func ListAllSubscriptions(ctx context.Context, token string, serviceID, environmentID string, opts *ListSubscriptionsOptions) (subscriptions []openapiclientfleet.FleetDescribeSubscriptionResult, err error) {
 	var nextPageToken string
+	seen := map[string]struct{}{}
 
 	for {
 		pageOptions := ListSubscriptionsOptions{}
@@ -240,6 +244,12 @@ func ListAllSubscriptions(ctx context.Context, token string, serviceID, environm
 		if nextPageToken == "" {
 			return subscriptions, nil
 		}
+		// A server that echoes back a page token it already handed out would otherwise send
+		// this into an infinite loop, re-accumulating the same page forever.
+		if _, alreadySeen := seen[nextPageToken]; alreadySeen {
+			return subscriptions, nil
+		}
+		seen[nextPageToken] = struct{}{}
 	}
 }
 

--- a/internal/dataaccess/subscription.go
+++ b/internal/dataaccess/subscription.go
@@ -537,6 +537,8 @@ func TerminateSubscription(ctx context.Context, token string, serviceID, environ
 // The platform's full vocabulary is ACTIVE, SUSPENDED, CANCELLED and TERMINATED.
 const subscriptionStatusActive = "ACTIVE"
 
+const subscriptionStatusSuspended = "SUSPENDED"
+
 // matchSubscriptionsByEmail returns the subscriptions on a plan whose root user is the
 // given address. The plan filter is redundant with the server-side query parameter and is
 // kept so the matching is correct on its own terms.
@@ -605,7 +607,7 @@ func unusableSubscriptionError(
 ) error {
 	if len(candidates) == 1 {
 		candidate := candidates[0]
-		if strings.EqualFold(candidate.Status, "SUSPENDED") {
+		if strings.EqualFold(candidate.Status, subscriptionStatusSuspended) {
 			return errors.Errorf(
 				"subscription %s for customer %s on plan %s is SUSPENDED and cannot be used to create an instance. "+
 					"Resume it with 'omnistrate-ctl subscription resume %s', or pass --subscription-id to use a different subscription",
@@ -629,11 +631,27 @@ func unusableSubscriptionError(
 	for _, candidate := range candidates {
 		described = append(described, fmt.Sprintf("%s (%s)", candidate.Id, candidate.Status))
 	}
-	return errors.Errorf(
-		"customer %s has no active subscription on plan %s; found %s. "+
-			"Resume a suspended subscription with 'omnistrate-ctl subscription resume', or pass --subscription-id",
+
+	hasSuspended := false
+	for _, candidate := range candidates {
+		if strings.EqualFold(candidate.Status, subscriptionStatusSuspended) {
+			hasSuspended = true
+			break
+		}
+	}
+
+	msg := fmt.Sprintf(
+		"customer %s has no active subscription on plan %s; found %s",
 		customerEmail,
 		candidates[0].ProductTierName,
 		strings.Join(described, ", "),
 	)
+
+	if hasSuspended {
+		msg += ". Resume a suspended subscription with 'omnistrate-ctl subscription resume', or pass --subscription-id"
+	} else {
+		msg += ". Pass --subscription-id"
+	}
+
+	return errors.New(msg)
 }

--- a/internal/dataaccess/subscription.go
+++ b/internal/dataaccess/subscription.go
@@ -431,24 +431,15 @@ func CreateSubscriptionOnBehalf(ctx context.Context, token string, serviceID, en
 	// If email is provided instead of user ID, resolve it to user ID
 	customerUserID := opts.OnBehalfOfCustomerUserID
 	if customerUserID == "" && opts.OnBehalfOfCustomerEmail != "" {
-		listUsersRes, r, err := apiClient.InventoryApiAPI.InventoryApiListAllUsers(ctxWithToken).Execute()
-		if err != nil {
-			if r != nil {
-				_ = r.Body.Close()
-			}
-			return nil, handleFleetError(errors.Wrap(err, "failed to list users"))
-		}
+		listUsersRes, r, listErr := apiClient.InventoryApiAPI.InventoryApiListAllUsers(ctxWithToken).Execute()
 		if r != nil {
 			_ = r.Body.Close()
 		}
-
-		for _, user := range listUsersRes.Users {
-			if user.Email != nil && strings.EqualFold(*user.Email, opts.OnBehalfOfCustomerEmail) {
-				customerUserID = *user.UserId
-				break
-			}
+		if listErr != nil {
+			return nil, handleFleetError(errors.Wrap(listErr, "failed to list users"))
 		}
 
+		customerUserID = matchUserIDByEmail(listUsersRes.Users, opts.OnBehalfOfCustomerEmail)
 		if customerUserID == "" {
 			return nil, errors.Errorf("no user found with email %s", opts.OnBehalfOfCustomerEmail)
 		}
@@ -581,6 +572,21 @@ func TerminateSubscription(ctx context.Context, token string, serviceID, environ
 const subscriptionStatusActive = "ACTIVE"
 
 const subscriptionStatusSuspended = "SUSPENDED"
+
+// matchUserIDByEmail returns the ID of the user with the given address, or "" when there
+// is none. The fleet users API reports unscoped addresses, so a plain case-insensitive
+// comparison is the correct match.
+func matchUserIDByEmail(users []openapiclientfleet.AccessSideUser, email string) string {
+	for _, user := range users {
+		if user.Email == nil || user.UserId == nil {
+			continue
+		}
+		if strings.EqualFold(*user.Email, email) {
+			return *user.UserId
+		}
+	}
+	return ""
+}
 
 // matchSubscriptionsByEmail returns the subscriptions on a plan whose root user is the
 // given address. The plan filter is redundant with the server-side query parameter and is

--- a/internal/dataaccess/subscription.go
+++ b/internal/dataaccess/subscription.go
@@ -245,9 +245,17 @@ func ListAllSubscriptions(ctx context.Context, token string, serviceID, environm
 			return subscriptions, nil
 		}
 		// A server that echoes back a page token it already handed out would otherwise send
-		// this into an infinite loop, re-accumulating the same page forever.
+		// this into an infinite loop, re-accumulating the same page forever. Returning what
+		// was collected so far would be worse than failing: a caller resolving a customer
+		// email would read the truncated list as "no subscription" and create a duplicate,
+		// which is the very bug this lookup exists to prevent.
 		if _, alreadySeen := seen[nextPageToken]; alreadySeen {
-			return subscriptions, nil
+			return nil, errors.Errorf(
+				"subscription listing for service %s environment %s repeated page token %q; refusing to return a partial list",
+				serviceID,
+				environmentID,
+				nextPageToken,
+			)
 		}
 		seen[nextPageToken] = struct{}{}
 	}

--- a/internal/dataaccess/subscription.go
+++ b/internal/dataaccess/subscription.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
 	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
 	"github.com/pkg/errors"
 )
@@ -35,6 +36,17 @@ func DescribeSubscription(ctx context.Context, token string, serviceID, environm
 	return
 }
 
+// CustomerSubscriptionLookup identifies the customer and the plan a subscription is being
+// resolved for. EnvironmentType decides whether the org-scoped email fallback applies,
+// because org-scoped customer identities only exist in production environments.
+type CustomerSubscriptionLookup struct {
+	ServiceID       string
+	EnvironmentID   string
+	EnvironmentType string
+	PlanID          string
+	CustomerEmail   string
+}
+
 func GetSubscriptionByCustomerEmail(ctx context.Context, token string, serviceID string, planID string, customerEmail string) (resp *openapiclientfleet.FleetDescribeSubscriptionResult, err error) {
 	// Describe the service offering for this service and plan (product tier) ID to get the environment ID
 	serviceOfferingResult, err := DescribeServiceOffering(ctx, token, serviceID, planID, "")
@@ -44,14 +56,13 @@ func GetSubscriptionByCustomerEmail(ctx context.Context, token string, serviceID
 
 	for _, offering := range serviceOfferingResult.ConsumptionDescribeServiceOfferingResult.Offerings {
 		if offering.ProductTierID == planID {
-			return GetSubscriptionByCustomerEmailInEnvironment(
-				ctx,
-				token,
-				serviceID,
-				offering.ServiceEnvironmentID,
-				planID,
-				customerEmail,
-			)
+			return GetSubscriptionByCustomerEmailInEnvironment(ctx, token, CustomerSubscriptionLookup{
+				ServiceID:       serviceID,
+				EnvironmentID:   offering.ServiceEnvironmentID,
+				EnvironmentType: offering.ServiceEnvironmentType,
+				PlanID:          planID,
+				CustomerEmail:   customerEmail,
+			})
 		}
 	}
 
@@ -59,47 +70,55 @@ func GetSubscriptionByCustomerEmail(ctx context.Context, token string, serviceID
 	return
 }
 
+// GetSubscriptionByCustomerEmailInEnvironment resolves the subscription a customer owns for
+// a plan, creating one when the customer has none.
+//
+// The listing deliberately leaves IncludeInactive off. Terminating a subscription
+// soft-deletes its row, and only the inactive listing returns soft-deleted rows, so a
+// terminated subscription is correctly invisible here and the customer can be resubscribed.
+// A suspended subscription stays live and is reported rather than silently duplicated.
 func GetSubscriptionByCustomerEmailInEnvironment(
 	ctx context.Context,
 	token string,
-	serviceID string,
-	environmentID string,
-	planID string,
-	customerEmail string,
+	lookup CustomerSubscriptionLookup,
 ) (resp *openapiclientfleet.FleetDescribeSubscriptionResult, err error) {
-	ctxWithToken := context.WithValue(ctx, openapiclientfleet.ContextAccessToken, token)
-	apiClient := getFleetClient()
+	customerEmail := strings.TrimSpace(lookup.CustomerEmail)
+	if customerEmail == "" {
+		return nil, errors.New("customer email is required to look up a subscription")
+	}
 
-	req := apiClient.InventoryApiAPI.InventoryApiListSubscription(
-		ctxWithToken,
-		serviceID,
-		environmentID,
-	).ProductTierId(planID)
-
-	var r *http.Response
-	defer func() {
-		if r != nil {
-			_ = r.Body.Close()
-		}
-	}()
-
-	listSubscriptionResult, r, err := req.Execute()
+	subscriptions, err := ListAllSubscriptions(ctx, token, lookup.ServiceID, lookup.EnvironmentID, &ListSubscriptionsOptions{
+		ProductTierId: &lookup.PlanID,
+	})
 	if err != nil {
-		return nil, handleFleetError(err)
-	}
-	if r != nil {
-		_ = r.Body.Close()
-		r = nil
+		return nil, err
 	}
 
-	for _, subscription := range listSubscriptionResult.Subscriptions {
-		if strings.EqualFold(subscription.RootUserEmail, customerEmail) {
-			return &subscription, nil
+	candidates := matchSubscriptionsByEmail(subscriptions, lookup.PlanID, customerEmail)
+
+	// In production the platform stores an end customer's identity scoped to the service
+	// provider's organization, so a customer with no match under the plain address may still
+	// own a subscription under <local>+<orgID>@<domain>.
+	if len(candidates) == 0 &&
+		utils.IsProductionEnvironmentType(lookup.EnvironmentType) &&
+		!utils.EmailHasScopedOrg(customerEmail) {
+		var scopedEmail string
+		if scopedEmail, err = scopedCustomerEmail(ctx, token, customerEmail); err != nil {
+			return nil, err
 		}
+		candidates = matchSubscriptionsByEmail(subscriptions, lookup.PlanID, scopedEmail)
 	}
 
-	createResp, err := CreateSubscriptionOnBehalf(ctx, token, serviceID, environmentID, &CreateSubscriptionOnBehalfOptions{
-		ProductTierID:           planID,
+	selected, err := selectCustomerSubscription(candidates, customerEmail)
+	if err != nil {
+		return nil, err
+	}
+	if selected != nil {
+		return selected, nil
+	}
+
+	createResp, err := CreateSubscriptionOnBehalf(ctx, token, lookup.ServiceID, lookup.EnvironmentID, &CreateSubscriptionOnBehalfOptions{
+		ProductTierID:           lookup.PlanID,
 		OnBehalfOfCustomerEmail: customerEmail,
 	})
 	if err != nil {
@@ -111,12 +130,36 @@ func GetSubscriptionByCustomerEmailInEnvironment(
 		return nil, errors.Errorf("subscription creation for user %s returned an empty subscription ID", customerEmail)
 	}
 
-	resp, err = DescribeSubscription(ctx, token, serviceID, environmentID, subscriptionID)
+	resp, err = DescribeSubscription(ctx, token, lookup.ServiceID, lookup.EnvironmentID, subscriptionID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to describe newly created subscription for user %s", customerEmail)
 	}
 
+	// A newly created subscription goes through the same status gate, so every "unusable
+	// subscription" message in this command comes from one place.
+	if _, err = selectCustomerSubscription([]openapiclientfleet.FleetDescribeSubscriptionResult{*resp}, customerEmail); err != nil {
+		return nil, err
+	}
+
 	return resp, nil
+}
+
+// scopedCustomerEmail builds the org-scoped form of a customer address using the calling
+// service provider's organization ID.
+func scopedCustomerEmail(ctx context.Context, token, customerEmail string) (string, error) {
+	user, err := DescribeUser(ctx, token)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to describe the current user to resolve the provider organization ID")
+	}
+	if user == nil || user.OrgId == nil || strings.TrimSpace(*user.OrgId) == "" {
+		return "", errors.New("describe user returned an empty organization ID; cannot check for an org-scoped customer subscription")
+	}
+
+	scopedEmail, err := utils.FormatEmailWithScopedOrg(customerEmail, strings.TrimSpace(*user.OrgId))
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to build the org-scoped form of %s", customerEmail)
+	}
+	return scopedEmail, nil
 }
 
 type ListSubscriptionsOptions struct {

--- a/internal/dataaccess/subscription.go
+++ b/internal/dataaccess/subscription.go
@@ -2,6 +2,7 @@ package dataaccess
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -530,4 +531,109 @@ func TerminateSubscription(ctx context.Context, token string, serviceID, environ
 		return handleFleetError(err)
 	}
 	return
+}
+
+// subscriptionStatusActive is the only subscription status that may back a new instance.
+// The platform's full vocabulary is ACTIVE, SUSPENDED, CANCELLED and TERMINATED.
+const subscriptionStatusActive = "ACTIVE"
+
+// matchSubscriptionsByEmail returns the subscriptions on a plan whose root user is the
+// given address. The plan filter is redundant with the server-side query parameter and is
+// kept so the matching is correct on its own terms.
+func matchSubscriptionsByEmail(
+	subscriptions []openapiclientfleet.FleetDescribeSubscriptionResult,
+	planID string,
+	email string,
+) []openapiclientfleet.FleetDescribeSubscriptionResult {
+	matches := make([]openapiclientfleet.FleetDescribeSubscriptionResult, 0, 1)
+	for _, subscription := range subscriptions {
+		if planID != "" && !strings.EqualFold(subscription.ProductTierId, planID) {
+			continue
+		}
+		if !strings.EqualFold(subscription.RootUserEmail, email) {
+			continue
+		}
+		matches = append(matches, subscription)
+	}
+	return matches
+}
+
+// selectCustomerSubscription picks the one subscription that may back a new instance.
+// It returns (nil, nil) when there is nothing to choose from, which tells the caller to
+// create a subscription instead.
+func selectCustomerSubscription(
+	candidates []openapiclientfleet.FleetDescribeSubscriptionResult,
+	customerEmail string,
+) (*openapiclientfleet.FleetDescribeSubscriptionResult, error) {
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	active := make([]openapiclientfleet.FleetDescribeSubscriptionResult, 0, len(candidates))
+	for _, candidate := range candidates {
+		if strings.EqualFold(candidate.Status, subscriptionStatusActive) {
+			active = append(active, candidate)
+		}
+	}
+
+	switch len(active) {
+	case 1:
+		selected := active[0]
+		return &selected, nil
+	case 0:
+		return nil, unusableSubscriptionError(candidates, customerEmail)
+	default:
+		ids := make([]string, 0, len(active))
+		for _, candidate := range active {
+			ids = append(ids, candidate.Id)
+		}
+		return nil, errors.Errorf(
+			"found %d active subscriptions for customer %s on plan %s (%s). Pass --subscription-id to choose one",
+			len(active),
+			customerEmail,
+			active[0].ProductTierName,
+			strings.Join(ids, ", "),
+		)
+	}
+}
+
+// unusableSubscriptionError explains why the subscriptions a customer does own cannot back
+// a new instance, and names the remedy when there is one.
+func unusableSubscriptionError(
+	candidates []openapiclientfleet.FleetDescribeSubscriptionResult,
+	customerEmail string,
+) error {
+	if len(candidates) == 1 {
+		candidate := candidates[0]
+		if strings.EqualFold(candidate.Status, "SUSPENDED") {
+			return errors.Errorf(
+				"subscription %s for customer %s on plan %s is SUSPENDED and cannot be used to create an instance. "+
+					"Resume it with 'omnistrate-ctl subscription resume %s', or pass --subscription-id to use a different subscription",
+				candidate.Id,
+				customerEmail,
+				candidate.ProductTierName,
+				candidate.Id,
+			)
+		}
+		return errors.Errorf(
+			"subscription %s for customer %s on plan %s is in status %s, expected ACTIVE, so it cannot be used to create an instance. "+
+				"Pass --subscription-id to use a different subscription",
+			candidate.Id,
+			customerEmail,
+			candidate.ProductTierName,
+			candidate.Status,
+		)
+	}
+
+	described := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		described = append(described, fmt.Sprintf("%s (%s)", candidate.Id, candidate.Status))
+	}
+	return errors.Errorf(
+		"customer %s has no active subscription on plan %s; found %s. "+
+			"Resume a suspended subscription with 'omnistrate-ctl subscription resume', or pass --subscription-id",
+		customerEmail,
+		candidates[0].ProductTierName,
+		strings.Join(described, ", "),
+	)
 }

--- a/internal/dataaccess/subscription_test.go
+++ b/internal/dataaccess/subscription_test.go
@@ -3,6 +3,7 @@ package dataaccess
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -209,6 +210,34 @@ func startSubscriptionTestServer(t *testing.T, handler http.HandlerFunc) {
 	t.Setenv("OMNISTRATE_RETRY_MAX", "0")
 }
 
+// TestListAllSubscriptionsStopsOnRepeatedNextPageToken reproduces a server that always hands
+// back the same nextPageToken value, regardless of which page was requested. Each page
+// returns its own distinct subscription, so a correctly bounded call collects exactly one
+// page beyond the first before the repeated token is caught; without the seen-token guard,
+// this would loop forever, calling the server and accumulating a fresh "duplicate token"
+// page indefinitely.
+func TestListAllSubscriptionsStopsOnRepeatedNextPageToken(t *testing.T) {
+	var listCalls int
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		listCalls++
+		w.Header().Set("Content-Type", "application/json")
+		id := fmt.Sprintf("sub-%d", listCalls)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ids":           []string{id},
+			"subscriptions": []map[string]any{subscriptionJSON(id, "customer@example.com", "ACTIVE")},
+			"nextPageToken": "page-repeats",
+		})
+	})
+
+	subscriptions, err := ListAllSubscriptions(context.Background(), "test-token", "s-test", "se-test", nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 2, listCalls, "the call must stop the first time the token repeats, not loop forever")
+	require.Len(t, subscriptions, 2)
+	assert.Equal(t, "sub-1", subscriptions[0].Id)
+	assert.Equal(t, "sub-2", subscriptions[1].Id, "the page fetched with the not-yet-seen token must still be collected")
+}
+
 func TestGetSubscriptionByCustomerEmailInEnvironmentPaginates(t *testing.T) {
 	var listCalls int
 	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -279,6 +308,42 @@ func TestGetSubscriptionByCustomerEmailInEnvironmentFallsBackToScopedEmailInProd
 	assert.Equal(t, 1, describeUserCalls)
 }
 
+// TestGetSubscriptionByCustomerEmailInEnvironmentPrefersExactMatchOverScoped proves the exact
+// address wins when both an exact-match and an org-scoped-match subscription exist for the
+// same customer and plan simultaneously. The scoped fallback must never even be consulted in
+// that case: describe-user is never called, and the org-scoped subscription is never chosen.
+func TestGetSubscriptionByCustomerEmailInEnvironmentPrefersExactMatchOverScoped(t *testing.T) {
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/2022-09-01-00/user":
+			t.Fatal("the scoped fallback must not be consulted when an exact match already exists")
+		case "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ids": []string{"sub-exact", "sub-scoped"},
+				"subscriptions": []map[string]any{
+					subscriptionJSON("sub-exact", "customer@example.com", "ACTIVE"),
+					subscriptionJSON("sub-scoped", "customer+org-abc123@example.com", "ACTIVE"),
+				},
+			})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	subscription, err := GetSubscriptionByCustomerEmailInEnvironment(context.Background(), "test-token", CustomerSubscriptionLookup{
+		ServiceID:       "s-test",
+		EnvironmentID:   "se-test",
+		EnvironmentType: "PROD",
+		PlanID:          "pt-test",
+		CustomerEmail:   "customer@example.com",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+	assert.Equal(t, "sub-exact", subscription.Id, "the exact-address match must win over the org-scoped match")
+}
+
 func TestGetSubscriptionByCustomerEmailInEnvironmentSkipsScopedFallbackOutsideProd(t *testing.T) {
 	var createCalls int
 	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -317,6 +382,45 @@ func TestGetSubscriptionByCustomerEmailInEnvironmentSkipsScopedFallbackOutsidePr
 	require.NotNil(t, subscription)
 	assert.Equal(t, "sub-new", subscription.Id)
 	assert.Equal(t, 1, createCalls)
+}
+
+// TestGetSubscriptionByCustomerEmailInEnvironmentHandlesNullDescribeAfterCreate reproduces a
+// server that answers the post-create describe call with HTTP 200 and a literal `null` body.
+// The generated SDK client decodes that into a nil result with no error, so the lookup must
+// treat it as an error rather than dereferencing the nil pointer.
+func TestGetSubscriptionByCustomerEmailInEnvironmentHandlesNullDescribeAfterCreate(t *testing.T) {
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/2022-09-01-00/fleet/users":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"users": []map[string]any{{"userId": "user-test", "email": "customer@example.com"}},
+			})
+		case r.URL.Path == "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription" && r.Method == http.MethodPost:
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "sub-new"})
+		case r.URL.Path == "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ids":           []string{},
+				"subscriptions": []map[string]any{},
+			})
+		case r.URL.Path == "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription/sub-new":
+			_, _ = w.Write([]byte("null"))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	subscription, err := GetSubscriptionByCustomerEmailInEnvironment(context.Background(), "test-token", CustomerSubscriptionLookup{
+		ServiceID:       "s-test",
+		EnvironmentID:   "se-test",
+		EnvironmentType: "DEV",
+		PlanID:          "pt-test",
+		CustomerEmail:   "customer@example.com",
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, subscription)
+	assert.Contains(t, err.Error(), "customer@example.com")
 }
 
 func TestGetSubscriptionByCustomerEmailInEnvironmentReportsSuspended(t *testing.T) {

--- a/internal/dataaccess/subscription_test.go
+++ b/internal/dataaccess/subscription_test.go
@@ -1,0 +1,135 @@
+package dataaccess
+
+import (
+	"testing"
+
+	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testSubscription(id, email, status string) openapiclientfleet.FleetDescribeSubscriptionResult {
+	return openapiclientfleet.FleetDescribeSubscriptionResult{
+		Id:              id,
+		ProductTierId:   "pt-test",
+		ProductTierName: "test-plan",
+		RootUserEmail:   email,
+		Status:          status,
+	}
+}
+
+func TestMatchSubscriptionsByEmailIsCaseInsensitive(t *testing.T) {
+	subscriptions := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "Customer@Example.com", "ACTIVE"),
+	}
+
+	matches := matchSubscriptionsByEmail(subscriptions, "pt-test", "customer@example.com")
+
+	require.Len(t, matches, 1)
+	assert.Equal(t, "sub-1", matches[0].Id)
+}
+
+func TestMatchSubscriptionsByEmailFiltersOtherPlans(t *testing.T) {
+	other := testSubscription("sub-2", "customer@example.com", "ACTIVE")
+	other.ProductTierId = "pt-other"
+	subscriptions := []openapiclientfleet.FleetDescribeSubscriptionResult{other}
+
+	matches := matchSubscriptionsByEmail(subscriptions, "pt-test", "customer@example.com")
+
+	assert.Empty(t, matches)
+}
+
+func TestMatchSubscriptionsByEmailDoesNotMatchScopedFormImplicitly(t *testing.T) {
+	subscriptions := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "customer+org-abc123@example.com", "ACTIVE"),
+	}
+
+	matches := matchSubscriptionsByEmail(subscriptions, "pt-test", "customer@example.com")
+
+	assert.Empty(t, matches, "the scoped form must only match when the caller asks for it explicitly")
+}
+
+func TestSelectCustomerSubscriptionNoCandidatesSignalsCreate(t *testing.T) {
+	subscription, err := selectCustomerSubscription(nil, "customer@example.com")
+
+	require.NoError(t, err)
+	assert.Nil(t, subscription)
+}
+
+func TestSelectCustomerSubscriptionReturnsSingleActive(t *testing.T) {
+	candidates := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "customer@example.com", "ACTIVE"),
+	}
+
+	subscription, err := selectCustomerSubscription(candidates, "customer@example.com")
+
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+	assert.Equal(t, "sub-1", subscription.Id)
+}
+
+func TestSelectCustomerSubscriptionIgnoresNonActiveWhenAnActiveExists(t *testing.T) {
+	candidates := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "customer@example.com", "SUSPENDED"),
+		testSubscription("sub-2", "customer@example.com", "ACTIVE"),
+	}
+
+	subscription, err := selectCustomerSubscription(candidates, "customer@example.com")
+
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+	assert.Equal(t, "sub-2", subscription.Id)
+}
+
+func TestSelectCustomerSubscriptionRejectsMultipleActive(t *testing.T) {
+	candidates := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "customer@example.com", "ACTIVE"),
+		testSubscription("sub-2", "customer@example.com", "ACTIVE"),
+	}
+
+	_, err := selectCustomerSubscription(candidates, "customer@example.com")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sub-1")
+	assert.Contains(t, err.Error(), "sub-2")
+	assert.Contains(t, err.Error(), "--subscription-id")
+}
+
+func TestSelectCustomerSubscriptionReportsSuspended(t *testing.T) {
+	candidates := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "customer@example.com", "SUSPENDED"),
+	}
+
+	_, err := selectCustomerSubscription(candidates, "customer@example.com")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sub-1")
+	assert.Contains(t, err.Error(), "SUSPENDED")
+	assert.Contains(t, err.Error(), "omnistrate-ctl subscription resume sub-1")
+}
+
+func TestSelectCustomerSubscriptionReportsOtherNonActiveStatus(t *testing.T) {
+	candidates := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "customer@example.com", "CANCELLED"),
+	}
+
+	_, err := selectCustomerSubscription(candidates, "customer@example.com")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CANCELLED")
+	assert.Contains(t, err.Error(), "expected ACTIVE")
+	assert.NotContains(t, err.Error(), "subscription resume")
+}
+
+func TestSelectCustomerSubscriptionReportsEveryNonActiveCandidate(t *testing.T) {
+	candidates := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "customer@example.com", "SUSPENDED"),
+		testSubscription("sub-2", "customer@example.com", "CANCELLED"),
+	}
+
+	_, err := selectCustomerSubscription(candidates, "customer@example.com")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sub-1 (SUSPENDED)")
+	assert.Contains(t, err.Error(), "sub-2 (CANCELLED)")
+}

--- a/internal/dataaccess/subscription_test.go
+++ b/internal/dataaccess/subscription_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/omnistrate-oss/omnistrate-ctl/internal/utils"
 	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -433,4 +434,68 @@ func TestGetSubscriptionByCustomerEmailPlumbsEnvironmentTypeToScopedFallback(t *
 	require.NotNil(t, subscription)
 	assert.Equal(t, "sub-1", subscription.Id)
 	assert.Equal(t, 1, describeUserCalls, "the offering's ServiceEnvironmentType must reach the lookup and trigger the scoped fallback")
+}
+
+func TestMatchUserIDByEmail(t *testing.T) {
+	users := []openapiclientfleet.AccessSideUser{
+		{UserId: utils.ToPtr("user-1"), Email: utils.ToPtr("other@example.com")},
+		{UserId: utils.ToPtr("user-2"), Email: utils.ToPtr("Customer@Example.com")},
+		{UserId: utils.ToPtr("user-3")},
+		{Email: utils.ToPtr("no-id@example.com")},
+	}
+
+	assert.Equal(t, "user-2", matchUserIDByEmail(users, "customer@example.com"))
+	assert.Equal(t, "", matchUserIDByEmail(users, "absent@example.com"))
+	assert.Equal(t, "", matchUserIDByEmail(users, "no-id@example.com"))
+	assert.Equal(t, "", matchUserIDByEmail(nil, "customer@example.com"))
+}
+
+func TestCreateSubscriptionOnBehalfResolvesUserByEmail(t *testing.T) {
+	var capturedUserID string
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/2022-09-01-00/fleet/users":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"users": []map[string]any{
+					{"userId": "user-other", "email": "other@example.com"},
+					{"userId": "user-test", "email": "customer@example.com"},
+				},
+			})
+		case "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription":
+			var body map[string]any
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+			capturedUserID, _ = body["onBehalfOfCustomerUserId"].(string)
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "sub-new"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	result, err := CreateSubscriptionOnBehalf(context.Background(), "test-token", "s-test", "se-test", &CreateSubscriptionOnBehalfOptions{
+		ProductTierID:           "pt-test",
+		OnBehalfOfCustomerEmail: "customer@example.com",
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "sub-new", result.GetId())
+	assert.Equal(t, "user-test", capturedUserID)
+}
+
+func TestCreateSubscriptionOnBehalfReportsUnknownEmail(t *testing.T) {
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/2022-09-01-00/fleet/users" {
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"users": []map[string]any{}})
+	})
+
+	_, err := CreateSubscriptionOnBehalf(context.Background(), "test-token", "s-test", "se-test", &CreateSubscriptionOnBehalfOptions{
+		ProductTierID:           "pt-test",
+		OnBehalfOfCustomerEmail: "customer@example.com",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "customer@example.com")
 }

--- a/internal/dataaccess/subscription_test.go
+++ b/internal/dataaccess/subscription_test.go
@@ -193,8 +193,8 @@ func subscriptionJSON(id, email, status string) map[string]any {
 }
 
 // startSubscriptionTestServer points the SDK clients at a stub server for the duration of
-// the test and returns it.
-func startSubscriptionTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+// the test.
+func startSubscriptionTestServer(t *testing.T, handler http.HandlerFunc) {
 	t.Helper()
 
 	server := httptest.NewServer(handler)
@@ -206,8 +206,6 @@ func startSubscriptionTestServer(t *testing.T, handler http.HandlerFunc) *httpte
 	t.Setenv("OMNISTRATE_HOST_SCHEME", serverURL.Scheme)
 	t.Setenv("CLIENT_TIMEOUT_IN_SECONDS", "5")
 	t.Setenv("OMNISTRATE_RETRY_MAX", "0")
-
-	return server
 }
 
 func TestGetSubscriptionByCustomerEmailInEnvironmentPaginates(t *testing.T) {
@@ -355,4 +353,84 @@ func TestGetSubscriptionByCustomerEmailInEnvironmentRequiresEmail(t *testing.T) 
 
 	require.Error(t, err)
 	assert.Contains(t, strings.ToLower(err.Error()), "customer email is required")
+}
+
+// serviceOfferingJSON builds a fleet service-offering payload with every field the SDK's
+// generated ServiceOffering.UnmarshalJSON requires present, for one offering on one plan.
+func serviceOfferingJSON(planID, environmentID, environmentType string) map[string]any {
+	return map[string]any{
+		"ConsumptionDescribeServiceOfferingResult": map[string]any{
+			"createdAt":           "2026-09-07T00:00:00Z",
+			"isDeprecated":        false,
+			"serviceDescription":  "test-service",
+			"serviceId":           "s-test",
+			"serviceName":         "test-service",
+			"serviceOrgId":        "org-abc123",
+			"serviceProviderId":   "sp-test",
+			"serviceProviderName": "test-provider",
+			"serviceURLKey":       "test-service",
+			"offerings": []map[string]any{
+				{
+					"AutoApproveSubscription":      false,
+					"productTierDocumentation":     "",
+					"productTierID":                planID,
+					"productTierName":              "test-plan",
+					"productTierPricing":           nil,
+					"productTierSupport":           "",
+					"productTierType":              "",
+					"productTierURLKey":            "",
+					"productTierVersion":           "",
+					"resourceParameters":           []any{},
+					"serviceAPIID":                 "",
+					"serviceAPIVersion":            "",
+					"serviceEnvironmentID":         environmentID,
+					"serviceEnvironmentName":       "",
+					"serviceEnvironmentType":       environmentType,
+					"serviceEnvironmentURLKey":     "",
+					"serviceEnvironmentVisibility": "",
+					"serviceLogoURL":               "",
+					"serviceModelID":               "",
+					"serviceModelName":             "",
+					"serviceModelStatus":           "",
+					"serviceModelType":             "",
+					"serviceModelURLKey":           "",
+				},
+			},
+		},
+	}
+}
+
+// TestGetSubscriptionByCustomerEmailPlumbsEnvironmentTypeToScopedFallback proves that the
+// plan-level wrapper GetSubscriptionByCustomerEmail actually threads the offering's
+// ServiceEnvironmentType into the lookup: only a customer whose subscription exists under
+// the org-scoped address is present, so the scoped fallback must fire, which only happens
+// when EnvironmentType reaches the lookup as "PROD".
+func TestGetSubscriptionByCustomerEmailPlumbsEnvironmentTypeToScopedFallback(t *testing.T) {
+	var describeUserCalls int
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/2022-09-01-00/fleet/service-offering/s-test":
+			_ = json.NewEncoder(w).Encode(serviceOfferingJSON("pt-test", "se-test", "PROD"))
+		case "/2022-09-01-00/user":
+			describeUserCalls++
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "user-provider", "orgId": "org-abc123"})
+		case "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ids": []string{"sub-1"},
+				"subscriptions": []map[string]any{
+					subscriptionJSON("sub-1", "customer+org-abc123@example.com", "ACTIVE"),
+				},
+			})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	subscription, err := GetSubscriptionByCustomerEmail(context.Background(), "test-token", "s-test", "pt-test", "customer@example.com")
+
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+	assert.Equal(t, "sub-1", subscription.Id)
+	assert.Equal(t, 1, describeUserCalls, "the offering's ServiceEnvironmentType must reach the lookup and trigger the scoped fallback")
 }

--- a/internal/dataaccess/subscription_test.go
+++ b/internal/dataaccess/subscription_test.go
@@ -210,13 +210,13 @@ func startSubscriptionTestServer(t *testing.T, handler http.HandlerFunc) {
 	t.Setenv("OMNISTRATE_RETRY_MAX", "0")
 }
 
-// TestListAllSubscriptionsStopsOnRepeatedNextPageToken reproduces a server that always hands
-// back the same nextPageToken value, regardless of which page was requested. Each page
-// returns its own distinct subscription, so a correctly bounded call collects exactly one
-// page beyond the first before the repeated token is caught; without the seen-token guard,
-// this would loop forever, calling the server and accumulating a fresh "duplicate token"
-// page indefinitely.
-func TestListAllSubscriptionsStopsOnRepeatedNextPageToken(t *testing.T) {
+// TestListAllSubscriptionsErrorsOnRepeatedNextPageToken reproduces a server that always hands
+// back the same nextPageToken value, regardless of which page was requested. Without the
+// seen-token guard this loops forever. With it, the call must FAIL rather than return the
+// pages it managed to collect: a truncated list is indistinguishable from a complete one, so
+// a caller resolving a customer email would read it as "no subscription" and create a
+// duplicate — the exact bug this lookup exists to prevent.
+func TestListAllSubscriptionsErrorsOnRepeatedNextPageToken(t *testing.T) {
 	var listCalls int
 	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
 		listCalls++
@@ -231,11 +231,38 @@ func TestListAllSubscriptionsStopsOnRepeatedNextPageToken(t *testing.T) {
 
 	subscriptions, err := ListAllSubscriptions(context.Background(), "test-token", "s-test", "se-test", nil)
 
-	require.NoError(t, err)
+	require.Error(t, err, "a repeated page token must fail rather than silently truncate")
+	assert.Contains(t, err.Error(), "repeated page token")
+	assert.Nil(t, subscriptions, "no partial list may be handed back to the caller")
 	assert.Equal(t, 2, listCalls, "the call must stop the first time the token repeats, not loop forever")
-	require.Len(t, subscriptions, 2)
-	assert.Equal(t, "sub-1", subscriptions[0].Id)
-	assert.Equal(t, "sub-2", subscriptions[1].Id, "the page fetched with the not-yet-seen token must still be collected")
+}
+
+// TestGetSubscriptionByCustomerEmailInEnvironmentDoesNotCreateOnTruncatedListing pins the
+// consequence of the guard above: when the listing cannot be completed, the lookup must
+// surface that error and must NOT fall through to creating a subscription.
+func TestGetSubscriptionByCustomerEmailInEnvironmentDoesNotCreateOnTruncatedListing(t *testing.T) {
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			t.Fatal("a listing that could not be completed must never lead to creating a subscription")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ids":           []string{"sub-1"},
+			"subscriptions": []map[string]any{subscriptionJSON("sub-1", "other@example.com", "ACTIVE")},
+			"nextPageToken": "page-repeats",
+		})
+	})
+
+	_, err := GetSubscriptionByCustomerEmailInEnvironment(context.Background(), "test-token", CustomerSubscriptionLookup{
+		ServiceID:       "s-test",
+		EnvironmentID:   "se-test",
+		EnvironmentType: "PROD",
+		PlanID:          "pt-test",
+		CustomerEmail:   "customer@example.com",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "repeated page token")
 }
 
 func TestGetSubscriptionByCustomerEmailInEnvironmentPaginates(t *testing.T) {

--- a/internal/dataaccess/subscription_test.go
+++ b/internal/dataaccess/subscription_test.go
@@ -1,6 +1,12 @@
 package dataaccess
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 
 	openapiclientfleet "github.com/omnistrate-oss/omnistrate-sdk-go/fleet"
@@ -164,4 +170,189 @@ func TestSelectCustomerSubscriptionReportsNonSuspendedMultipleCandidates(t *test
 	assert.Contains(t, err.Error(), "sub-2 (TERMINATED)")
 	assert.Contains(t, err.Error(), "--subscription-id")
 	assert.NotContains(t, err.Error(), "resume")
+}
+
+// subscriptionJSON builds a fleet subscription payload with every field the SDK requires.
+func subscriptionJSON(id, email, status string) map[string]any {
+	return map[string]any{
+		"createdAt":         "2026-09-07T00:00:00Z",
+		"id":                id,
+		"instanceCount":     0,
+		"productTierId":     "pt-test",
+		"productTierName":   "test-plan",
+		"rootUserEmail":     email,
+		"rootUserId":        "user-test",
+		"rootUserName":      "test-customer",
+		"serviceId":         "s-test",
+		"serviceName":       "test-service",
+		"status":            status,
+		"updatedAt":         "2026-09-07T00:00:00Z",
+		"updatedByUserId":   "user-test",
+		"updatedByUserName": "test-customer",
+	}
+}
+
+// startSubscriptionTestServer points the SDK clients at a stub server for the duration of
+// the test and returns it.
+func startSubscriptionTestServer(t *testing.T, handler http.HandlerFunc) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	t.Setenv("OMNISTRATE_HOST", serverURL.Host)
+	t.Setenv("OMNISTRATE_HOST_SCHEME", serverURL.Scheme)
+	t.Setenv("CLIENT_TIMEOUT_IN_SECONDS", "5")
+	t.Setenv("OMNISTRATE_RETRY_MAX", "0")
+
+	return server
+}
+
+func TestGetSubscriptionByCustomerEmailInEnvironmentPaginates(t *testing.T) {
+	var listCalls int
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription", r.URL.Path)
+		require.Equal(t, "pt-test", r.URL.Query().Get("productTierId"))
+		listCalls++
+
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("nextPageToken") == "" {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ids":           []string{"sub-1"},
+				"subscriptions": []map[string]any{subscriptionJSON("sub-1", "other@example.com", "ACTIVE")},
+				"nextPageToken": "page-2",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ids":           []string{"sub-2"},
+			"subscriptions": []map[string]any{subscriptionJSON("sub-2", "customer@example.com", "ACTIVE")},
+		})
+	})
+
+	subscription, err := GetSubscriptionByCustomerEmailInEnvironment(context.Background(), "test-token", CustomerSubscriptionLookup{
+		ServiceID:       "s-test",
+		EnvironmentID:   "se-test",
+		EnvironmentType: "DEV",
+		PlanID:          "pt-test",
+		CustomerEmail:   "customer@example.com",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+	assert.Equal(t, "sub-2", subscription.Id)
+	assert.Equal(t, 2, listCalls, "the lookup must follow nextPageToken")
+}
+
+func TestGetSubscriptionByCustomerEmailInEnvironmentFallsBackToScopedEmailInProd(t *testing.T) {
+	var describeUserCalls int
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/2022-09-01-00/user":
+			describeUserCalls++
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "user-provider", "orgId": "org-abc123"})
+		case "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ids": []string{"sub-1"},
+				"subscriptions": []map[string]any{
+					subscriptionJSON("sub-1", "customer+org-abc123@example.com", "ACTIVE"),
+				},
+			})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	subscription, err := GetSubscriptionByCustomerEmailInEnvironment(context.Background(), "test-token", CustomerSubscriptionLookup{
+		ServiceID:       "s-test",
+		EnvironmentID:   "se-test",
+		EnvironmentType: "PROD",
+		PlanID:          "pt-test",
+		CustomerEmail:   "customer@example.com",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+	assert.Equal(t, "sub-1", subscription.Id)
+	assert.Equal(t, 1, describeUserCalls)
+}
+
+func TestGetSubscriptionByCustomerEmailInEnvironmentSkipsScopedFallbackOutsideProd(t *testing.T) {
+	var createCalls int
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.URL.Path == "/2022-09-01-00/user":
+			t.Fatal("describe user must not be called outside production")
+		case r.URL.Path == "/2022-09-01-00/fleet/users":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"users": []map[string]any{{"userId": "user-test", "email": "customer@example.com"}},
+			})
+		case r.URL.Path == "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription" && r.Method == http.MethodPost:
+			createCalls++
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "sub-new"})
+		case r.URL.Path == "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"ids":           []string{"sub-1"},
+				"subscriptions": []map[string]any{subscriptionJSON("sub-1", "customer+org-abc123@example.com", "ACTIVE")},
+			})
+		case r.URL.Path == "/2022-09-01-00/fleet/service/s-test/environment/se-test/subscription/sub-new":
+			_ = json.NewEncoder(w).Encode(subscriptionJSON("sub-new", "customer@example.com", "ACTIVE"))
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	})
+
+	subscription, err := GetSubscriptionByCustomerEmailInEnvironment(context.Background(), "test-token", CustomerSubscriptionLookup{
+		ServiceID:       "s-test",
+		EnvironmentID:   "se-test",
+		EnvironmentType: "DEV",
+		PlanID:          "pt-test",
+		CustomerEmail:   "customer@example.com",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, subscription)
+	assert.Equal(t, "sub-new", subscription.Id)
+	assert.Equal(t, 1, createCalls)
+}
+
+func TestGetSubscriptionByCustomerEmailInEnvironmentReportsSuspended(t *testing.T) {
+	startSubscriptionTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			t.Fatal("a suspended subscription must not trigger a create")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"ids":           []string{"sub-1"},
+			"subscriptions": []map[string]any{subscriptionJSON("sub-1", "customer@example.com", "SUSPENDED")},
+		})
+	})
+
+	_, err := GetSubscriptionByCustomerEmailInEnvironment(context.Background(), "test-token", CustomerSubscriptionLookup{
+		ServiceID:       "s-test",
+		EnvironmentID:   "se-test",
+		EnvironmentType: "DEV",
+		PlanID:          "pt-test",
+		CustomerEmail:   "customer@example.com",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "SUSPENDED")
+	assert.Contains(t, err.Error(), "omnistrate-ctl subscription resume sub-1")
+}
+
+func TestGetSubscriptionByCustomerEmailInEnvironmentRequiresEmail(t *testing.T) {
+	_, err := GetSubscriptionByCustomerEmailInEnvironment(context.Background(), "test-token", CustomerSubscriptionLookup{
+		ServiceID:     "s-test",
+		EnvironmentID: "se-test",
+		PlanID:        "pt-test",
+		CustomerEmail: "   ",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "customer email is required")
 }

--- a/internal/dataaccess/subscription_test.go
+++ b/internal/dataaccess/subscription_test.go
@@ -49,6 +49,22 @@ func TestMatchSubscriptionsByEmailDoesNotMatchScopedFormImplicitly(t *testing.T)
 	assert.Empty(t, matches, "the scoped form must only match when the caller asks for it explicitly")
 }
 
+func TestMatchSubscriptionsByEmailWithoutPlanFilter(t *testing.T) {
+	onOtherPlan := testSubscription("sub-2", "customer@example.com", "ACTIVE")
+	onOtherPlan.ProductTierId = "pt-other"
+	subscriptions := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "customer@example.com", "ACTIVE"),
+		onOtherPlan,
+		testSubscription("sub-3", "other@example.com", "ACTIVE"),
+	}
+
+	matches := matchSubscriptionsByEmail(subscriptions, "", "customer@example.com")
+
+	require.Len(t, matches, 2)
+	assert.Equal(t, "sub-1", matches[0].Id)
+	assert.Equal(t, "sub-2", matches[1].Id)
+}
+
 func TestSelectCustomerSubscriptionNoCandidatesSignalsCreate(t *testing.T) {
 	subscription, err := selectCustomerSubscription(nil, "customer@example.com")
 
@@ -132,4 +148,20 @@ func TestSelectCustomerSubscriptionReportsEveryNonActiveCandidate(t *testing.T) 
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "sub-1 (SUSPENDED)")
 	assert.Contains(t, err.Error(), "sub-2 (CANCELLED)")
+	assert.Contains(t, err.Error(), "resume")
+}
+
+func TestSelectCustomerSubscriptionReportsNonSuspendedMultipleCandidates(t *testing.T) {
+	candidates := []openapiclientfleet.FleetDescribeSubscriptionResult{
+		testSubscription("sub-1", "customer@example.com", "CANCELLED"),
+		testSubscription("sub-2", "customer@example.com", "TERMINATED"),
+	}
+
+	_, err := selectCustomerSubscription(candidates, "customer@example.com")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "sub-1 (CANCELLED)")
+	assert.Contains(t, err.Error(), "sub-2 (TERMINATED)")
+	assert.Contains(t, err.Error(), "--subscription-id")
+	assert.NotContains(t, err.Error(), "resume")
 }

--- a/internal/dataaccess/user.go
+++ b/internal/dataaccess/user.go
@@ -2,6 +2,7 @@ package dataaccess
 
 import (
 	"context"
+	"net/http"
 
 	openapiclient "github.com/omnistrate-oss/omnistrate-sdk-go/v1"
 )
@@ -10,13 +11,19 @@ func DescribeUser(ctx context.Context, token string) (*openapiclient.DescribeUse
 	ctxWithToken := context.WithValue(ctx, openapiclient.ContextAccessToken, token)
 
 	apiClient := getV1Client()
-	resp, r, err := apiClient.UsersApiAPI.UsersApiDescribeUser(ctxWithToken).Execute()
 
+	var r *http.Response
+	defer func() {
+		if r != nil {
+			_ = r.Body.Close()
+		}
+	}()
+
+	resp, r, err := apiClient.UsersApiAPI.UsersApiDescribeUser(ctxWithToken).Execute()
 	err = handleV1Error(err)
 	if err != nil {
 		return nil, err
 	}
 
-	r.Body.Close()
 	return resp, nil
 }

--- a/internal/utils/print.go
+++ b/internal/utils/print.go
@@ -231,8 +231,8 @@ func PromptPassword(title, placeholder string) (string, error) {
 	return value, nil
 }
 
-// ValidateEmail returns a validation function that checks for a valid email address.
-// The match is case-insensitive and the TLD has no upper bound on length, so it accepts
+// ValidateEmail reports whether input is a valid email address, returning an error when it
+// is not. The match is case-insensitive and the TLD has no upper bound on length, so it accepts
 // capitalized addresses and modern long TLDs (for example ".cloud" or ".online") the same
 // way subscription matching elsewhere in the CLI does (matchSubscriptionsByEmail and
 // matchUserIDByEmail in internal/dataaccess both compare addresses with strings.EqualFold).

--- a/internal/utils/print.go
+++ b/internal/utils/print.go
@@ -232,8 +232,12 @@ func PromptPassword(title, placeholder string) (string, error) {
 }
 
 // ValidateEmail returns a validation function that checks for a valid email address.
+// The match is case-insensitive and the TLD has no upper bound on length, so it accepts
+// capitalized addresses and modern long TLDs (for example ".cloud" or ".online") the same
+// way subscription matching elsewhere in the CLI does (matchSubscriptionsByEmail and
+// matchUserIDByEmail in internal/dataaccess both compare addresses with strings.EqualFold).
 func ValidateEmail(input string) error {
-	emailRegex := regexp.MustCompile(`^[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,4}$`)
+	emailRegex := regexp.MustCompile(`(?i)^[a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,}$`)
 	if emailRegex.MatchString(input) {
 		return nil
 	}

--- a/internal/utils/scopedemail.go
+++ b/internal/utils/scopedemail.go
@@ -1,0 +1,69 @@
+package utils
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// scopedOrgIDRegex matches an organization ID. It mirrors the server-side definition so the
+// CLI and the platform agree on what the trailing segment of a scoped address looks like.
+var scopedOrgIDRegex = regexp.MustCompile(`^org-[a-zA-Z0-9][a-zA-Z0-9._\-]*$`)
+
+// FormatEmailWithScopedOrg returns the org-scoped form of an address, which is how the
+// platform stores an end customer's identity inside a service provider's organization:
+//
+//	("customer@example.com", "org-abc123") -> "customer+org-abc123@example.com"
+//
+// Any plus tag already present is preserved, with the organization ID appended after it.
+func FormatEmailWithScopedOrg(email, orgID string) (string, error) {
+	localPart, domain, err := splitEmail(email)
+	if err != nil {
+		return "", err
+	}
+	if !scopedOrgIDRegex.MatchString(orgID) {
+		return "", fmt.Errorf("invalid organization ID %q", orgID)
+	}
+	if localPartHasScopedOrg(localPart) {
+		return "", fmt.Errorf("email %q is already scoped to an organization", email)
+	}
+
+	return fmt.Sprintf("%s+%s@%s", localPart, orgID, domain), nil
+}
+
+// EmailHasScopedOrg reports whether an address already carries an organization ID as the
+// last segment of its local part.
+func EmailHasScopedOrg(email string) bool {
+	localPart, _, err := splitEmail(email)
+	if err != nil {
+		return false
+	}
+	return localPartHasScopedOrg(localPart)
+}
+
+// IsProductionEnvironmentType reports whether an environment type is a production one.
+// Org-scoped customer identities only exist in production environments.
+func IsProductionEnvironmentType(environmentType string) bool {
+	switch strings.ToUpper(strings.TrimSpace(environmentType)) {
+	case "PROD", "PRODUCTION":
+		return true
+	default:
+		return false
+	}
+}
+
+func splitEmail(email string) (localPart, domain string, err error) {
+	parts := strings.Split(strings.TrimSpace(email), "@")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid email address %q", email)
+	}
+	return parts[0], parts[1], nil
+}
+
+func localPartHasScopedOrg(localPart string) bool {
+	segments := strings.Split(localPart, "+")
+	if len(segments) < 2 {
+		return false
+	}
+	return scopedOrgIDRegex.MatchString(segments[len(segments)-1])
+}

--- a/internal/utils/scopedemail_test.go
+++ b/internal/utils/scopedemail_test.go
@@ -1,0 +1,56 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormatEmailWithScopedOrg(t *testing.T) {
+	scoped, err := FormatEmailWithScopedOrg("customer@example.com", "org-abc123")
+	require.NoError(t, err)
+	assert.Equal(t, "customer+org-abc123@example.com", scoped)
+}
+
+func TestFormatEmailWithScopedOrgPreservesExistingPlusTag(t *testing.T) {
+	scoped, err := FormatEmailWithScopedOrg("customer+team@example.com", "org-abc123")
+	require.NoError(t, err)
+	assert.Equal(t, "customer+team+org-abc123@example.com", scoped)
+}
+
+func TestFormatEmailWithScopedOrgRejectsAlreadyScopedEmail(t *testing.T) {
+	_, err := FormatEmailWithScopedOrg("customer+org-abc123@example.com", "org-abc123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already scoped")
+}
+
+func TestFormatEmailWithScopedOrgRejectsBadInput(t *testing.T) {
+	for name, tc := range map[string]struct{ email, orgID string }{
+		"no at sign":    {"customer.example.com", "org-abc123"},
+		"two at signs":  {"customer@example@com", "org-abc123"},
+		"empty org":     {"customer@example.com", ""},
+		"org bad shape": {"customer@example.com", "abc123"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, err := FormatEmailWithScopedOrg(tc.email, tc.orgID)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestEmailHasScopedOrg(t *testing.T) {
+	assert.True(t, EmailHasScopedOrg("customer+org-abc123@example.com"))
+	assert.True(t, EmailHasScopedOrg("customer+team+org-abc123@example.com"))
+	assert.False(t, EmailHasScopedOrg("customer@example.com"))
+	assert.False(t, EmailHasScopedOrg("customer+team@example.com"))
+	assert.False(t, EmailHasScopedOrg("not-an-email"))
+}
+
+func TestIsProductionEnvironmentType(t *testing.T) {
+	assert.True(t, IsProductionEnvironmentType("PROD"))
+	assert.True(t, IsProductionEnvironmentType("production"))
+	assert.True(t, IsProductionEnvironmentType("  Prod  "))
+	assert.False(t, IsProductionEnvironmentType("DEV"))
+	assert.False(t, IsProductionEnvironmentType(""))
+}

--- a/internal/utils/scopedemail_test.go
+++ b/internal/utils/scopedemail_test.go
@@ -45,6 +45,15 @@ func TestEmailHasScopedOrg(t *testing.T) {
 	assert.False(t, EmailHasScopedOrg("customer@example.com"))
 	assert.False(t, EmailHasScopedOrg("customer+team@example.com"))
 	assert.False(t, EmailHasScopedOrg("not-an-email"))
+
+	// The local part is only the org segment: splitting on "+" yields a single, empty
+	// segment ("") before the org ID, which is still >= 2 segments, so this is currently
+	// reported as scoped even though there is no real local part in front of it.
+	assert.True(t, EmailHasScopedOrg("+org-abc123@example.com"))
+
+	// A trailing "+" with nothing after it: the last segment is empty and does not match
+	// the org ID shape, so this is correctly reported as not scoped.
+	assert.False(t, EmailHasScopedOrg("customer+@example.com"))
 }
 
 func TestIsProductionEnvironmentType(t *testing.T) {

--- a/internal/utils/validate_email_test.go
+++ b/internal/utils/validate_email_test.go
@@ -1,0 +1,59 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateEmail(t *testing.T) {
+	for name, tc := range map[string]struct {
+		email   string
+		wantErr bool
+	}{
+		"capitalized address is accepted": {
+			email: "Customer@Example.com",
+		},
+		"dot-cloud TLD is accepted": {
+			email: "customer@acme.cloud",
+		},
+		"dot-online TLD is accepted": {
+			email: "customer@acme.online",
+		},
+		"plus tag is accepted": {
+			email: "customer+tag@example.com",
+		},
+		"org-scoped address is accepted": {
+			email: "customer+org-abc123@example.com",
+		},
+		"missing at sign is rejected": {
+			email:   "customer.example.com",
+			wantErr: true,
+		},
+		"two at signs are rejected": {
+			email:   "customer@example@com",
+			wantErr: true,
+		},
+		"empty local part is rejected": {
+			email:   "@example.com",
+			wantErr: true,
+		},
+		"empty domain is rejected": {
+			email:   "customer@",
+			wantErr: true,
+		},
+		"domain without a dot is rejected": {
+			email:   "customer@example",
+			wantErr: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			err := ValidateEmail(tc.email)
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/mkdocs/docs/omnistrate-ctl_instance_create.md
+++ b/mkdocs/docs/omnistrate-ctl_instance_create.md
@@ -7,7 +7,7 @@ Create an instance deployment
 This command helps you create an instance deployment for your service.
 
 ```
-omnistrate-ctl instance create --service=[service] --environment=[environment] --plan=[plan] --version=[version] --resource=[resource] [--cloud-provider=aws|gcp|azure|nebius] [--region=region] [--param=param] [--param-file=file-path] [--instance-id=id] [--customer-account-id=account-instance-id] [--cloud-provider-native-network-id=network-id] [--network-type=PUBLIC|INTERNAL] [--onprem-platform=platform] [--tags key=value,key2=value2] [--breakpoints id-or-key[:event[|event...]],...] [flags]
+omnistrate-ctl instance create --service=[service] --environment=[environment] --plan=[plan] --version=[version] --resource=[resource] [--cloud-provider=aws|gcp|azure|nebius] [--region=region] [--param=param] [--param-file=file-path] [--instance-id=id] [--customer-email=email] [--customer-account-id=account-instance-id] [--cloud-provider-native-network-id=network-id] [--network-type=PUBLIC|INTERNAL] [--onprem-platform=platform] [--tags key=value,key2=value2] [--breakpoints id-or-key[:event[|event...]],...] [flags]
 ```
 
 ### Examples
@@ -42,6 +42,9 @@ omnistrate-ctl instance create --service=MyService --environment=dev --plan='AWS
 
 # Create an air-gapped/on-prem installer-backed instance. Do not pass --cloud-provider or --region with --onprem-platform.
 omnistrate-ctl instance create --service=MyService --environment=dev --plan='Airgap' --resource=myResource --onprem-platform=Generic --param-file /path/to/params.json
+
+# Create an instance deployment on behalf of an end customer, resolved from their email
+omnistrate-ctl instance create --service=mysql --environment=prod --plan=mysql --resource=mySQL --cloud-provider=aws --region=us-east-2 --param-file /path/to/params.json --customer-email customer@example.com
 ```
 
 ### Options
@@ -51,6 +54,7 @@ omnistrate-ctl instance create --service=MyService --environment=dev --plan='Air
       --cloud-provider string                     Cloud provider (aws|gcp|azure|nebius). Required unless --onprem-platform is provided; do not use with --onprem-platform.
       --cloud-provider-native-network-id string   Cloud provider native network ID to inject as cloud_provider_native_network_id in instance deployment parameters
       --customer-account-id string                Customer BYOA account onboarding instance ID to inject as the cloud account. Use 'omnistrate-ctl account customer list' or 'omnistrate-ctl account customer describe <instance-id>' to find it.
+      --customer-email string                     Customer email to create the instance deployment on behalf of. Resolves the customer's subscription for this service plan, creating one if they have none. Cannot be combined with --subscription-id.
       --environment string                        Environment name
   -h, --help                                      help for create
       --instance-id string                        ID of a previously deleted instance to restore


### PR DESCRIPTION
## What

Adds `--customer-email` to `omnistrate-ctl instance create`, so an operator can name an end customer by email instead of looking up and pasting a subscription ID:

```bash
omnistrate-ctl instance create --service=MyService --environment=prod --plan=MyPlan \
  --resource=myResource --cloud-provider=aws --region=us-east-2 \
  --customer-email customer@example.com
```

It resolves the customer's subscription for that service plan, creates one if they have none, and is rejected in combination with `--subscription-id`.

## Why this is more than a flag

The resolution reuses the shared `internal/dataaccess` lookup that `instance adopt` and `account customer create` already call. That lookup had three defects that had to be fixed for the feature to be correct:

1. **It missed org-scoped customers.** In production the platform stores an end customer's subscription under an org-scoped identity — the provider's org ID appended to the local part, as `<local>+<orgID>@<domain>`. The fleet users API reports the plain address; the subscription API reports the scoped one. Matching only the plain form found nothing, so the not-found branch **created a second subscription for a customer who already had one**.
2. **It read only the first page** of subscriptions, ignoring `nextPageToken` — a second path to the same duplicate.
3. **It ignored subscription status**, returning a SUSPENDED subscription as if usable and failing downstream with an opaque error.

All three are fixed, so `instance adopt` and `account customer create` inherit the fixes.

## Behaviour

Resolution order, in the shared lookup:

1. List all subscriptions for the plan, following `nextPageToken` to exhaustion.
2. Match `rootUserEmail` case-insensitively against the address given.
3. If nothing matched **and** the environment is production **and** the address is not already scoped: resolve the provider org ID and match again against the scoped form. This step is lazy — an exact match never pays for the extra call, and it never runs outside production.
4. Status gate: exactly one ACTIVE wins; more than one ACTIVE errors and asks for `--subscription-id`; one or more candidates with none ACTIVE produces a status-specific error.
5. Only if there are still no candidates: create the subscription, then run the created subscription through the same status gate.

A suspended subscription now names its remedy rather than failing downstream:

> subscription sub-XXXX for customer@example.com on plan `<plan>` is SUSPENDED and cannot be used to create an instance. Resume it with `omnistrate-ctl subscription resume sub-XXXX`, or pass `--subscription-id` to use a different subscription.

`IncludeInactive` is deliberately left off. Terminating a subscription soft-deletes the row, so terminated subscriptions stay invisible to the listing and a customer can be re-subscribed; enabling it would resurrect those rows and turn legitimate re-subscription into an error.

## Behaviour change to call out

**`instance adopt --customer-email` now hard-errors when the customer's only subscription is SUSPENDED or CANCELLED**, where it previously adopted into it. This follows from the status gate living in the shared lookup. The failure is loud and actionable, and both escape hatches exist (`omnistrate-ctl subscription resume <id>`, or `adopt --subscription-id`). `account customer create` inherits the same gate on its production path.

`instance create` with no `--customer-email` is unchanged: the request still omits `subscriptionId` and lets the platform resolve it.

## Also fixed

`utils.ValidateEmail` rejected capitalized addresses and any TLD longer than four characters, so `Customer@Example.com` and `customer@acme.cloud` failed validation — while the matching layer beneath is deliberately case-insensitive. Broadened to be case-insensitive with no TLD length cap; it only accepts more input, so no existing caller changes.

Also: a nil-dereference panic on a null describe response, an unbounded pagination loop when a server echoes a page token, and a response-body leak in `DescribeUser` on the error path.

## Testing

- Unit tests for the scoped-email helpers, candidate matching, and the status gate.
- `httptest`-backed tests for the lookup: pagination, the production-only scoped fallback (asserting the extra call fires exactly once in production and never outside it), exact-beats-scoped precedence, suspended reporting, and the repeated-page-token guard.
- An end-to-end test of `runCreate` asserting the resolved subscription ID reaches the create-instance request body — verified by mutation to fail when the wiring is broken.
- Manual verification against a test service in a production environment: creating for a customer with no subscription created one and used it; re-running reused the same subscription and created **no duplicate**. Test instances were deleted afterwards.
- `make unit-test`, `golangci-lint run ./...` and `gofmt` all clean.

Design and implementation notes are in `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
