### PR TITLE
fix: clear OpenSSL CVEs failing the image scan gate

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -45,7 +45,12 @@ RUN --mount=type=bind,source=.,target=/go/src/ctl,rw \
 ## Deploy
 FROM alpine:latest AS app
 
-RUN apk add --no-cache ca-certificates curl jq
+# The published alpine:latest image is rebuilt less often than the Alpine package
+# repository is updated, so its preinstalled packages can carry already-fixed CVEs — the
+# OpenSSL libraries that apk-tools links against are the usual offenders. Upgrading before
+# installing pulls those forward to whatever the repository currently ships, which keeps
+# the image clean as new advisories land rather than only at the next base-image rebuild.
+RUN apk --no-cache upgrade && apk add --no-cache ca-certificates curl jq
 
 COPY --from=builder /out/omnistrate-ctl /usr/local/bin/omnistrate-ctl
 WORKDIR /omnistrate


### PR DESCRIPTION
## What

Adds `apk --no-cache upgrade` to the runtime stage of `build/Dockerfile`, clearing the 18 high/critical findings that were failing the Grype gate.

## Why

The gate fails the build on any finding at high or critical severity. All 18 came from a single root cause — the runtime image was shipping OpenSSL `3.5.7-r0`:

| Severity | Package | Installed | Fixed in | Count |
|---|---|---|---|---|
| Critical | `libcrypto3` / `libssl3` | 3.5.7-r0 | 3.5.8-r0 | 4 |
| High | `libcrypto3` / `libssl3` | 3.5.7-r0 | 3.5.8-r0 | 14 |

Every one is an `apk` package with an available fix. **Nothing in the Go dependency tree was implicated** — the scan's Go findings were clean. The cause is that the published `alpine:latest` image is rebuilt less often than the Alpine package repository is updated, so its preinstalled packages (including the OpenSSL libraries `apk-tools` links against) can carry advisories Alpine has already fixed. `apk add` alone doesn't touch packages that are already present, so those stale versions survived into the final image.

Upgrading before installing pulls them forward to whatever the repository currently ships, which also keeps the image clean as new advisories land rather than only at the next base-image rebuild.

## Verification

Reproduced and verified locally by building the exact image the workflow scans (`build/Dockerfile`, `linux/amd64`) and running Grype v0.118.0 against it:

| | high/critical | total findings | `libcrypto3` / `libssl3` | image size |
|---|---|---|---|---|
| before | **18** | 24 | 3.5.7-r0 | 28.1 MiB |
| after | **0** | 4 | 3.5.8-r0 | 30.6 MiB |

The 4 remaining findings are all Medium, below the gate's `high` cutoff: `CVE-2025-60876` in busybox and `CVE-2026-58055` in `nghttp2-libs`.

Also confirmed the image still works: `omnistrate-ctl --version` runs, and `curl`, `jq` and the CA bundle are all still present.

## On the size increase

The image grows 28.1 MiB → 30.6 MiB, because the upgraded package files land in a new layer while the originals remain in the base layer. I measured the narrower alternative — upgrading only `libcrypto3` and `libssl3` — and it came out at 30.5 MiB, also with 0 high/critical. Since the broad upgrade costs 0.1 MiB more and additionally covers whichever package falls behind next, it seemed the better trade. Happy to switch to the targeted form if you'd rather keep the change minimal.

## Out of scope, but worth knowing

The docs image (`build/Dockerfile.docs`, `nginx:alpine`) is **not** covered by this scan workflow, and it currently carries 6 high/critical findings of its own — in `tiff` and `libuuid`, unrelated to this OpenSSL issue. Left alone here since it's a different image and pipeline, but happy to follow up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
