### PR TITLE
fix: clear docs image CVEs and add it to the security scan

### DIFF
--- a/.github/workflows/grype-scan.yml
+++ b/.github/workflows/grype-scan.yml
@@ -8,7 +8,6 @@ on:
   workflow_dispatch:
 
 env:
-  SCAN_IMAGE_NAME: localbuild/omnistrate-ctl
   SCAN_PLATFORM: linux/amd64
 
 concurrency:
@@ -17,10 +16,37 @@ concurrency:
 
 jobs:
   grype-scan:
-    name: Scan Docker image
+    name: Scan ${{ matrix.image.label }} image
     runs-on: ubuntu-latest
     permissions:
       contents: read
+
+    strategy:
+      # Scan every image even when one of them fails, so a single regression does not hide
+      # the state of the others.
+      fail-fast: false
+      matrix:
+        image:
+          - label: CLI
+            slug: cli
+            dockerfile: ./build/Dockerfile
+            # Empty means "use the repository default .dockerignore".
+            dockerignore: ""
+            build-args: |
+              GIT_COMMIT=${{ github.sha }}
+              GIT_VERSION=${{ github.ref_name }}
+              GOPROXY=https://proxy.golang.org,direct
+              GOSUMDB=sum.golang.org
+          - label: docs
+            slug: docs
+            dockerfile: ./build/Dockerfile.docs
+            # Mirrors docs-deploy.yml, which swaps in a docs-specific ignore file so the
+            # mkdocs/ directory reaches the build context.
+            dockerignore: build/Dockerfile.docs.dockerignore
+            build-args: ""
+
+    env:
+      SCAN_IMAGE_NAME: localbuild/omnistrate-ctl-${{ matrix.image.slug }}
 
     steps:
       - name: Checkout repository
@@ -29,23 +55,23 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
+      - name: Use image-specific dockerignore
+        if: matrix.image.dockerignore != ''
+        run: cp "${{ matrix.image.dockerignore }}" .dockerignore
+
       - name: Build image for scan
         timeout-minutes: 30
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          file: ./build/Dockerfile
+          file: ${{ matrix.image.dockerfile }}
           platforms: ${{ env.SCAN_PLATFORM }}
           push: false
           load: true
           tags: ${{ env.SCAN_IMAGE_NAME }}:${{ github.sha }}
-          cache-from: type=gha,scope=grype-scan-amd64
-          cache-to: type=gha,mode=max,scope=grype-scan-amd64
-          build-args: |
-            GIT_COMMIT=${{ github.sha }}
-            GIT_VERSION=${{ github.ref_name }}
-            GOPROXY=https://proxy.golang.org,direct
-            GOSUMDB=sum.golang.org
+          cache-from: type=gha,scope=grype-scan-${{ matrix.image.slug }}-amd64
+          cache-to: type=gha,mode=max,scope=grype-scan-${{ matrix.image.slug }}-amd64
+          build-args: ${{ matrix.image.build-args }}
 
       - name: Scan image for vulnerabilities
         id: grype
@@ -190,16 +216,19 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: grype-vulnerability-report
+          name: grype-vulnerability-report-${{ matrix.image.slug }}
           path: |
             grype-results.html
             grype-results.json
           if-no-files-found: ignore
 
       - name: Enforce vulnerability threshold
+        env:
+          IMAGE_LABEL: ${{ matrix.image.label }}
         run: |
           node <<'NODE'
           const fs = require("fs");
+          const label = process.env.IMAGE_LABEL || "image";
           const report = JSON.parse(fs.readFileSync("grype-results.json", "utf8"));
           const matches = Array.isArray(report.matches) ? report.matches : [];
           const failingMatches = matches.filter((match) => {
@@ -208,7 +237,18 @@ jobs:
           });
 
           if (failingMatches.length > 0) {
-            console.error(`Found ${failingMatches.length} vulnerabilities with severity high or critical.`);
+            console.error(`${label} image: found ${failingMatches.length} vulnerabilities with severity high or critical.`);
+            // Summarise inline so the offending packages and whether a fix exists are visible
+            // in the log, rather than only in the uploaded report.
+            for (const match of failingMatches) {
+              const vulnerability = match?.vulnerability ?? {};
+              const artifact = match?.artifact ?? {};
+              const fixVersions = vulnerability.fix?.versions ?? [];
+              const fix = fixVersions.length > 0 ? `fixed in ${fixVersions.join(", ")}` : "no fix available";
+              console.error(`  ${vulnerability.severity} ${artifact.name}@${artifact.version} ${vulnerability.id} (${fix})`);
+            }
             process.exit(1);
           }
+
+          console.log(`${label} image: no vulnerabilities at or above the high severity threshold.`);
           NODE

--- a/build/Dockerfile.docs
+++ b/build/Dockerfile.docs
@@ -24,7 +24,18 @@ COPY ./mkdocs .
 RUN mkdocs build --strict 
 
 # Production stage - Serve the built site
-FROM nginx:alpine
+#
+# alpine-slim rather than alpine: the full nginx:alpine image ships the optional dynamic
+# modules, which pull in libgd and therefore tiff. This site serves static files with gzip
+# and loads no dynamic modules, so none of that is reachable — but tiff was contributing two
+# high-severity advisories with no fixed version available upstream, so they could not be
+# patched away. Dropping to the slim variant removes the dependency instead.
+FROM nginx:alpine-slim
+
+# The published base image is rebuilt less often than the Alpine package repository is
+# updated, so preinstalled packages can carry already-fixed CVEs. Upgrade so the served
+# image picks up current patches as advisories land.
+RUN apk --no-cache upgrade
 
 # Copy the built site from the builder stage
 COPY --from=builder /app/site /usr/share/nginx/html


### PR DESCRIPTION
## What

Two changes:

1. Clears the six high-severity findings in the docs image.
2. Brings the docs image under the Grype scan gate, which previously only covered the CLI image.

## Why an `apk upgrade` was not enough

The docs image (`build/Dockerfile.docs`, served publicly) was never scanned. It carried six high findings, and they are not the same kind of problem:

| Package | Installed | CVEs | Fix available |
|---|---|---|---|
| `libuuid` | 2.42.1-r0 | 4 | yes — 2.42.3-r0 / -r1 |
| `tiff` | 4.7.1-r0 | 2 | **no fixed version upstream** |

An `apk upgrade` — the fix used for the CLI image in #719 — would have cleared `libuuid` and left both `tiff` advisories in place, so the gate would still have failed.

`tiff` is not something the docs site uses. It arrives via `libgd`, which the full `nginx:alpine` image pulls in for the optional dynamic modules:

```
tiff-4.7.1-r0 is required by:
libgd-2.3.3-r10
```

This site serves static files with gzip and loads no dynamic modules — `nginx.conf` has no `load_module`, `image_filter`, `perl`, `xslt`, `geoip` or `njs` directives. So the fix is to stop shipping the dependency rather than to patch it: `nginx:alpine-slim` has neither `libgd`/`tiff` nor `libuuid`. The `apk upgrade` is still there to keep the remainder current as new advisories land.

## Bringing the docs image under the gate

The scan job becomes a matrix over both images, so this cannot drift unnoticed again:

- `fail-fast: false`, so one image failing does not hide the state of the other.
- Artifacts (`grype-vulnerability-report-<slug>`) and build caches are namespaced per image.
- The docs entry copies `build/Dockerfile.docs.dockerignore` into place first, mirroring what `docs-deploy.yml` does so `mkdocs/` reaches the build context.
- The threshold step now names the image and lists each offending package with its fix status. Diagnosing #719 meant downloading the JSON artifact to find out which packages were at fault; that now shows up directly in the log.

Job names change from `Scan Docker image` to `Scan CLI image` / `Scan docs image`. `main` has no branch protection, so no required-check configuration depends on the old name.

## Verification

Built both images exactly as the workflow does (`linux/amd64`, docs build with its dockerignore in place) and scanned with Grype v0.118.0:

| image | high/critical before | after | remaining |
|---|---|---|---|
| docs | **6** | **0** | 3 Medium (busybox `CVE-2025-60876`) |

The served site was checked end to end, not just scanned: container starts, `GET /` returns HTTP 200 with 34 KB of HTML, gzip is negotiated (`Content-Encoding: gzip`, which this `nginx.conf` configures), and the nginx error log is clean.

The rewritten threshold script was exercised against real scan output — the fixed docs report (exits 0) and the recorded failing CLI report from #718 (exits 1 and prints the 18 packages with `fixed in 3.5.8-r0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
